### PR TITLE
Fix metadata loss, Rename shortcuts, and multi-photo selection

### DIFF
--- a/tests/test_photo_tool_flow.py
+++ b/tests/test_photo_tool_flow.py
@@ -139,7 +139,7 @@ class PhotoToolFlowTests(unittest.TestCase):
         cls.script += '\n' + section("for (const id of ['healRadius', 'healFeather', 'healOpacity'])", "for (const id of ['lensProfileEnabled'")
         cls.script += '\n' + section("$('lensReset').onclick", 'function overlayPoint(')
         cls.script += '\n' + section("$('editOverlay').addEventListener('pointerdown'", "$('editOverlay').addEventListener('pointermove'")
-        cls.script += '\n' + section("document.addEventListener('keydown', (e) => {\n  const tag = e.target.tagName;", "document.addEventListener('keyup', (e) => {")
+        cls.script += '\n' + section("document.addEventListener('keydown', (e) => {", "document.addEventListener('keyup', (e) => {")
 
     def run_js(self, body):
         result = subprocess.run(['node', '--input-type=module', '-e', self.script + '\n' + body],

--- a/tests/test_ui_audit_regressions.py
+++ b/tests/test_ui_audit_regressions.py
@@ -1,0 +1,16 @@
+"""Run behavioral JavaScript regressions through the standard test entrypoint."""
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(shutil.which('node'), 'Node.js is unavailable')
+class UIAuditRegressions(unittest.TestCase):
+    def test_ui_behaviors(self):
+        result = subprocess.run(
+            ['node', '--test', str(ROOT / 'tests/ui-audit-regressions.test.mjs')],
+            cwd=ROOT, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/ui-audit-regressions.test.mjs
+++ b/tests/ui-audit-regressions.test.mjs
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import vm from 'node:vm';
+
+const source = (name) => readFileSync(new URL(`../web/${name}`, import.meta.url), 'utf8');
+const tick = async () => { for (let i = 0; i < 12; i++) await Promise.resolve(); };
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+function metadataHarness({ get, post } = {}) {
+  const elements = new Map();
+  const timers = new Map();
+  const writes = [];
+  let timerId = 0;
+  for (const id of ['iptcTitle', 'iptcCaption']) {
+    elements.set(id, { value: '', disabled: false,
+      addEventListener(type, fn) { this[type] = fn; } });
+  }
+  elements.set('infoPane', { classList: { contains: () => true } });
+  const context = vm.createContext({
+    setTimeout(fn) { const id = ++timerId; timers.set(id, fn); return id; },
+    clearTimeout(id) { timers.delete(id); },
+  });
+  vm.runInContext(source('metadata-panel.js').replace('export function', 'function'), context);
+  const panel = context.createMetadataPanel({
+    el: (id) => elements.get(id), toast() {},
+    get: get || (async () => ({ iptc: {} })),
+    post: async (path, body) => {
+      writes.push(JSON.parse(JSON.stringify(body)));
+      return post ? post(path, body) : { ok: true };
+    },
+  });
+  return { panel, elements, writes,
+    input(value) { elements.get('iptcTitle').value = value; elements.get('iptcTitle').input(); },
+    async fireTimers() {
+      const callbacks = [...timers.values()]; timers.clear();
+      callbacks.forEach((fn) => fn()); await tick();
+    },
+  };
+}
+
+test('metadata typed just before navigation is saved to its original photo', async () => {
+  const h = metadataHarness();
+  await h.panel.refresh('A');
+  h.input('Title for A');
+  await h.panel.refresh('B');
+  h.input('Title for B');
+  await h.fireTimers();
+  assert.deepEqual(h.writes, [
+    { name: 'A', fields: { title: 'Title for A', caption: null } },
+    { name: 'B', fields: { title: 'Title for B', caption: null } },
+  ]);
+});
+
+test('metadata writes stay ordered and returning waits for the pending save', async () => {
+  const first = deferred();
+  let title = '';
+  const h = metadataHarness({
+    get: async () => ({ iptc: { title } }),
+    post: async (_path, body) => {
+      if (body.fields.title === 'first') await first.promise;
+      title = body.fields.title; return { ok: true };
+    },
+  });
+  await h.panel.refresh('A');
+  h.input('first'); await h.fireTimers();
+  h.input('latest'); await h.fireTimers();
+  assert.equal(h.writes.length, 1, 'a newer write must not overtake a slow save');
+  const returning = h.panel.refresh('A', true);
+  first.resolve(); await returning;
+  assert.equal(title, 'latest');
+  assert.equal(h.elements.get('iptcTitle').value, 'latest');
+});
+
+test('late metadata from the previous photo cannot overwrite the current fields', async () => {
+  const a = deferred(), b = deferred();
+  const h = metadataHarness({ get: (path) => path.endsWith('A') ? a.promise : b.promise });
+  const loadingA = h.panel.refresh('A'); await tick();
+  const loadingB = h.panel.refresh('B'); await tick();
+  assert.equal(h.elements.get('iptcTitle').disabled, true);
+  b.resolve({ iptc: { title: 'B title' } }); await loadingB;
+  a.resolve({ iptc: { title: 'A title' } }); await loadingA;
+  assert.equal(h.elements.get('iptcTitle').value, 'B title');
+  assert.equal(h.elements.get('iptcTitle').disabled, false);
+});
+
+function selectionHarness() {
+  const images = ['A', 'B', 'C'].map((name) => ({ name }));
+  const state = { images, idx: 0, msel: new Set() };
+  const start = source('app.js').indexOf('async function selectPhotoFromPointer(');
+  const implementation = source('app.js').slice(start).split('\n/* -------------------------------------------------------------- prefs */')[0];
+  const context = vm.createContext({
+    S: state, selectionAnchorName: null, cur: () => images[state.idx],
+    visible: () => images, paintSelectionState() {},
+    go: async (index) => { state.idx = index; },
+  });
+  vm.runInContext(implementation, context);
+  return { state, click: (index, modifiers = {}) => context.selectPhotoFromPointer(images[index], modifiers) };
+}
+
+for (const modifier of ['metaKey', 'ctrlKey']) {
+  test(`${modifier} click expands a plain-click selection`, async () => {
+    const h = selectionHarness();
+    await h.click(0); await h.click(1, { [modifier]: true });
+    assert.deepEqual([...h.state.msel], ['A', 'B']);
+    await h.click(2, { [modifier]: true });
+    assert.deepEqual([...h.state.msel], ['A', 'B', 'C']);
+    await h.click(1, { [modifier]: true });
+    assert.deepEqual([...h.state.msel], ['A', 'C']);
+  });
+}
+
+test('plain clicks reset and Shift-click still selects the visible range', async () => {
+  const h = selectionHarness();
+  await h.click(0); await h.click(2, { shiftKey: true });
+  assert.deepEqual([...h.state.msel], ['A', 'B', 'C']);
+  await h.click(1);
+  assert.equal(h.state.msel.size, 0);
+  assert.equal(h.state.idx, 1);
+});
+
+function renameHarness() {
+  const elements = new Map();
+  const document = { activeElement: { focus() {} } };
+  const writes = [];
+  let selection = ['A'];
+  for (const id of ['renameDialog', 'renameTemplate', 'renameCustom', 'renameStart',
+    'renamePreview', 'renameCancel', 'renameApply']) {
+    elements.set(id, { value: id === 'renameTemplate' ? '{filename}' : '', disabled: false,
+      offsetParent: {}, classList: { toggle() {} }, setAttribute() {},
+      focus() { document.activeElement = this; }, select() {},
+      querySelectorAll() { return ['renameTemplate', 'renameCustom', 'renameStart', 'renameCancel', 'renameApply'].map((key) => elements.get(key)).filter((e) => !e.disabled); },
+      addEventListener(type, fn) { this[type] = fn; } });
+  }
+  const s = source('catalog-ui.js');
+  const implementation = s.slice(s.indexOf('  function bindRename() {'), s.indexOf('\n  bindSources();'));
+  const context = vm.createContext({ document, el: (id) => elements.get(id),
+    ctx: { selection: () => selection }, toast() {},
+    post: async (_path, body) => { writes.push(JSON.parse(JSON.stringify(body))); return { ok: true, preview: [], renamed: 1 }; },
+  });
+  vm.runInContext(implementation, context);
+  return { rename: context.bindRename(), elements, document, writes,
+    selection(names) { selection = names; },
+    key(key, shiftKey = false) {
+      const event = { key, shiftKey, stopped: false, prevented: false,
+        stopPropagation() { this.stopped = true; }, preventDefault() { this.prevented = true; } };
+      elements.get('renameDialog').keydown?.(event);
+      return event;
+    },
+  };
+}
+
+test('Rename keeps its opening selection even if library selection changes', async () => {
+  const h = renameHarness(); h.rename.open(); await tick();
+  h.selection(['B']); await h.elements.get('renameApply').click();
+  assert.deepEqual(h.writes.map((body) => body.names), [['A'], ['A']]);
+});
+
+test('Rename captures shortcuts and wraps focus inside the dialog', async () => {
+  const h = renameHarness(); h.rename.open(); await tick();
+  assert.equal(h.document.activeElement, h.elements.get('renameTemplate'));
+  h.elements.get('renameCancel').focus();
+  assert.equal(h.key('5').stopped, true);
+  h.elements.get('renameApply').focus();
+  assert.equal(h.key('Tab').prevented, true);
+  assert.equal(h.document.activeElement, h.elements.get('renameTemplate'));
+  h.key('Tab', true);
+  assert.equal(h.document.activeElement, h.elements.get('renameApply'));
+  assert.equal(h.key('Escape').prevented, true);
+});
+
+test('editor shortcuts ignore an open modal even if focus is outside it', () => {
+  const s = source('app.js');
+  const start = s.indexOf("document.addEventListener('keydown', (e) => {");
+  const registration = s.slice(start, s.indexOf("document.addEventListener('keyup'", start));
+  let handler, ratings = 0;
+  const context = vm.createContext({
+    document: { querySelector: () => ({}), addEventListener(_type, fn) { handler = fn; } },
+    cur: () => null, S: {}, KEYS: { pick: [], reject: [], unflag: [] },
+    setRating() { ratings++; }, LABEL_KEYS: {}, SURVEY: null,
+  });
+  vm.runInContext(registration, context);
+  handler({ key: '5', target: { tagName: 'BUTTON' }, preventDefault() {} });
+  assert.equal(ratings, 0);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7912,6 +7912,7 @@ function finishSpeedKey(key) {
 }());
 
 document.addEventListener('keydown', (e) => {
+  if (e.defaultPrevented || document.querySelector('.modal-backdrop.on')) return;
   const tag = e.target.tagName;
   if (tag === 'INPUT' && ['range', 'number'].includes(e.target.type) &&
       PHOTO_TOOL_PANES.includes(S.activePane) && e.target.closest('.panel-pane.on') &&
@@ -9071,6 +9072,9 @@ async function selectPhotoFromPointer(image, event) {
       for (const item of list.slice(first, last + 1)) S.msel.add(item.name);
     }
   } else if (additive) {
+    // A plain click represents one selection through cur(), until a modifier
+    // click expands it into the explicit selection set.
+    if (!S.msel.size && visible().includes(cur())) S.msel.add(cur().name);
     S.msel.has(image.name) ? S.msel.delete(image.name) : S.msel.add(image.name);
     selectionAnchorName = image.name;
   } else {

--- a/web/catalog-ui.js
+++ b/web/catalog-ui.js
@@ -567,50 +567,94 @@ export function createCatalogUI(ctx) {
   function bindRename() {
     const dialog = el('renameDialog');
     if (!dialog) return null;
+    let names = [];
+    let returnFocus = null;
+    let previewSequence = 0;
+    const apply = el('renameApply');
     const show = (visible) => {
       dialog.setAttribute('aria-hidden', visible ? 'false' : 'true');
       dialog.classList.toggle('on', visible);
+      if (visible) {
+        returnFocus = document.activeElement;
+        el('renameTemplate').focus();
+        el('renameTemplate').select();
+      } else {
+        previewSequence++;
+        returnFocus?.focus?.({ preventScroll: true });
+        returnFocus = null;
+      }
     };
 
     async function preview() {
-      const names = ctx.selection();
-      if (!names.length) return;
-      const result = await post('/api/photos/rename', {
-        names,
-        template: el('renameTemplate').value,
-        custom: el('renameCustom').value,
-        start: Number(el('renameStart').value) || 1,
-        preview: true,
-      });
-      el('renamePreview').innerHTML = (result.preview || [])
-        .map((row) => `<span>${row.from} → <strong>${row.to}</strong></span>`)
-        .join('') + (result.total > 3
-          ? `<span class="muted">…and ${result.total - 3} more</span>` : '');
+      const request = ++previewSequence;
+      apply.disabled = true;
+      try {
+        const result = await post('/api/photos/rename', {
+          names,
+          template: el('renameTemplate').value,
+          custom: el('renameCustom').value,
+          start: Number(el('renameStart').value) || 1,
+          preview: true,
+        });
+        if (request !== previewSequence) return;
+        el('renamePreview').innerHTML = (result.preview || [])
+          .map((row) => `<span>${row.from} → <strong>${row.to}</strong></span>`)
+          .join('') + (result.total > 3
+            ? `<span class="muted">…and ${result.total - 3} more</span>` : '');
+        apply.disabled = Boolean(result.error);
+      } catch (error) {
+        if (request === previewSequence) toast('Could not preview the rename');
+      }
     }
 
+    dialog.addEventListener('keydown', (event) => {
+      event.stopPropagation();
+      if (event.key === 'Escape') {
+        event.preventDefault(); show(false); return;
+      }
+      if (event.key !== 'Tab') return;
+      const controls = [...dialog.querySelectorAll(
+        'button:not([disabled]), input:not([disabled])'
+      )].filter((element) => !element.hidden && element.offsetParent !== null);
+      if (!controls.length) return;
+      const first = controls[0], last = controls.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault(); last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault(); first.focus();
+      }
+    });
     ['renameTemplate', 'renameCustom', 'renameStart'].forEach((id) => {
       const input = el(id);
       if (input) input.addEventListener('input', preview);
     });
     const cancel = el('renameCancel');
     if (cancel) cancel.addEventListener('click', () => show(false));
-    const apply = el('renameApply');
     if (apply) {
       apply.addEventListener('click', async () => {
-        const names = ctx.selection();
-        const result = await post('/api/photos/rename', {
-          names,
-          template: el('renameTemplate').value,
-          custom: el('renameCustom').value,
-          start: Number(el('renameStart').value) || 1,
-        });
-        show(false);
-        toast(result.ok ? `Renamed ${result.renamed} photos`
-          : `Rename stopped: ${result.error}`);
-        if (ctx.onLibraryChanged) ctx.onLibraryChanged();
+        apply.disabled = true;
+        try {
+          const result = await post('/api/photos/rename', {
+            names,
+            template: el('renameTemplate').value,
+            custom: el('renameCustom').value,
+            start: Number(el('renameStart').value) || 1,
+          });
+          show(false);
+          toast(result.ok ? `Renamed ${result.renamed} photos`
+            : `Rename stopped: ${result.error}`);
+          if (ctx.onLibraryChanged) ctx.onLibraryChanged();
+        } catch (error) {
+          toast('Could not rename photos');
+          apply.disabled = false;
+        }
       });
     }
-    return { open() { show(true); preview(); } };
+    return { open() {
+      names = [...ctx.selection()];
+      if (!names.length) { toast('Select photos first'); return; }
+      show(true); preview();
+    } };
   }
 
   bindSources();

--- a/web/metadata-panel.js
+++ b/web/metadata-panel.js
@@ -28,6 +28,31 @@ export function createMetadataPanel(ctx) {
   let currentName = null;
   let saveTimer = null;
   let loading = false;
+  let pendingSave = null;
+  let saveChain = Promise.resolve();
+  let refreshSequence = 0;
+
+  function setLoading(value) {
+    loading = value;
+    for (const id of [...Object.keys(FIELDS), ...Object.keys(GPS_FIELDS)]) {
+      if (el(id)) el(id).disabled = value || !currentName;
+    }
+  }
+
+  function flushSave() {
+    clearTimeout(saveTimer);
+    const snapshot = pendingSave;
+    pendingSave = null;
+    if (snapshot) {
+      // Preserve request order even when an earlier metadata write is slow.
+      saveChain = saveChain.then(() => post('/api/metadata', snapshot))
+        .then((result) => {
+          if (result?.error) throw new Error(result.error);
+        })
+        .catch(() => toast('Could not save photo metadata'));
+    }
+    return saveChain;
+  }
 
   function collect() {
     const fields = {};
@@ -46,25 +71,29 @@ export function createMetadataPanel(ctx) {
 
   function queueSave() {
     if (loading || !currentName) return;
+    // A later navigation must not change either the destination or the values.
+    pendingSave = { name: currentName, fields: collect() };
     clearTimeout(saveTimer);
-    saveTimer = setTimeout(() => {
-      post('/api/metadata', { name: currentName, fields: collect() })
-        .catch(() => {});
-    }, 500);
+    saveTimer = setTimeout(flushSave, 500);
   }
 
   let loadedName = null;
 
   async function refresh(name, force = false) {
-    currentName = name || null;
+    const saving = flushSave();
+    const request = ++refreshSequence;
+    const targetName = name || null;
+    currentName = targetName;
     const isVisible = Boolean(el('infoPane')?.classList.contains('on'));
-    if (!isVisible && !force) {
+    if ((!isVisible || currentName === loadedName) && !force) {
+      setLoading(false);
       return;
     }
-    if (currentName === loadedName && !force) return;
-    loading = true;
+    setLoading(true);
     try {
-      if (!currentName) {
+      await saving;
+      if (request !== refreshSequence) return;
+      if (!targetName) {
         loadedName = null;
         Object.keys(FIELDS).forEach((id) => { if (el(id)) el(id).value = ''; });
         Object.keys(GPS_FIELDS).forEach((id) => {
@@ -73,8 +102,9 @@ export function createMetadataPanel(ctx) {
         return;
       }
       const response = await get(
-        `/api/metadata?name=${encodeURIComponent(currentName)}`);
-      loadedName = currentName;
+        `/api/metadata?name=${encodeURIComponent(targetName)}`);
+      if (request !== refreshSequence) return;
+      loadedName = targetName;
       const iptc = (response && response.iptc) || {};
       Object.entries(FIELDS).forEach(([id, key]) => {
         if (el(id)) el(id).value = iptc[key] || '';
@@ -85,7 +115,7 @@ export function createMetadataPanel(ctx) {
     } catch (error) {
       /* A photo outside the catalog simply has no metadata row yet. */
     } finally {
-      loading = false;
+      if (request === refreshSequence) setLoading(false);
     }
   }
 


### PR DESCRIPTION
Typing metadata and immediately switching photos could lose the edit or write it to the next photo. Rename allowed editor shortcuts to alter the selection behind the dialog, and Cmd/Ctrl-click dropped the first plain-click selection.

- Capture metadata values and their photo before debouncing, preserve write order, and ignore stale loads.
- Keep Rename tied to its opening selection, contain keyboard focus, and suspend editor shortcuts while a modal is open.
- Seed additive selection with the current plain-click photo so batch actions include both photos.

Validation: nine behavioral JavaScript regressions pass; the full Python suite passed with 899 tests and 3 skips. Replayed all three bugs in the running browser UI against this combined baseline, verified both saved titles through the CLI, and confirmed two selected photos in Export. Browser console errors were empty. Updated the existing photo-tool test extraction marker to accommodate the keyboard guard.
