### PR TITLE
Require verified Windows signatures for public releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,7 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.version }}
       source_ref: ${{ needs.prepare.outputs.source_ref }}
+      require_signing: true
     secrets: inherit
 
   publish:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,6 +10,11 @@ on:
         description: Package version (leave blank for a CI build)
         required: false
         type: string
+      require_signing:
+        description: Require valid Authenticode signatures for release artifacts
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       version:
@@ -19,6 +24,16 @@ on:
         description: Exact source commit selected by the release workflow
         required: false
         type: string
+      require_signing:
+        description: Require valid Authenticode signatures for release artifacts
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      WINDOWS_CERTIFICATE_BASE64:
+        required: false
+      WINDOWS_CERTIFICATE_PASSWORD:
+        required: false
 
 permissions:
   contents: read
@@ -93,6 +108,15 @@ jobs:
         with:
           ref: ${{ inputs.source_ref || github.sha }}
 
+      - name: Validate Windows signing configuration
+        shell: pwsh
+        env:
+          REQUIRE_SIGNING: ${{ inputs.require_signing && 'true' || 'false' }}
+          WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          ./scripts/windows/sign-release.ps1 -CheckOnly -RequireSigning:($env:REQUIRE_SIGNING -eq 'true') | Out-Null
+
       - name: Restore build caches
         uses: actions/cache@v4
         with:
@@ -120,10 +144,13 @@ jobs:
         shell: pwsh
         env:
           PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
+          REQUIRE_SIGNING: ${{ inputs.require_signing && 'true' || 'false' }}
+          WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
           python -m unittest discover -s tests -p test_windows_packaging.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          ./scripts/windows/build-release.ps1 -Version $env:PACKAGE_VERSION
+          ./scripts/windows/build-release.ps1 -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
 
       - name: Upload portable build and installer
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ seconds, use `scripts/update-personal-app.sh`. It reuses the verified packaged
 runtime and preserves the previous app as a rollback copy.
 
 To make a reproducible Windows package on a Windows x64 build host with Rust,
-Git, `uv`, and optionally `makensis` installed:
+Git, `uv`, and NSIS (`makensis`) installed:
 
 ```powershell
 .\scripts\windows\build-release.ps1 -Version 0.1.0
 ```
 
 The script verifies pinned downloads, compiles both GPU renderers and the
-desktop shell, runs a packaged-runtime smoke test, and writes a portable ZIP
-plus an installer (when `makensis` is available) under `dist/`.
+desktop shell, tests the packaged runtime and install/uninstall cycle, and writes
+a portable ZIP plus an installer under `dist/`. Pass `-PortableOnly` explicitly
+to build only the ZIP without NSIS.
 See [WINDOWS.md](WINDOWS.md) for the platform boundary, future native-viewport
 path, and release proof gates.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -53,9 +53,32 @@ build a ZIP without NSIS or installer testing.
 `.github/workflows/windows-build.yml` checks pull requests and produces packages
 on `main`, manual dispatch, or reusable-workflow calls. The reusable workflow
 accepts a required `version` string and uploads both files in the
-`LightTable-windows-x64` artifact for the unified release workflow. Code signing
-is not currently configured for Windows artifacts; runtime and installer smoke
-tests do not establish Windows GUI or RAW-rendering proof.
+`LightTable-windows-x64` artifact for the unified release workflow. `source_ref`
+selects the exact release commit. `require_signing` defaults to `false` for CI;
+the public release workflow sets it to `true` and passes signing secrets to the
+reusable workflow. Runtime and installer smoke tests do not establish Windows
+GUI or RAW-rendering proof.
+
+For Authenticode signing, configure repository secrets
+`WINDOWS_CERTIFICATE_BASE64` (a base64-encoded PFX containing a valid code-signing
+certificate and private key) and `WINDOWS_CERTIFICATE_PASSWORD`. The installed
+Windows SDK must provide `signtool.exe`. A reusable-workflow caller must pass
+these secrets explicitly or use `secrets: inherit`.
+
+`build-release.ps1 -RequireSigning` checks the signing configuration before any
+downloads or compilation and refuses missing or partial credentials. Without
+credentials, ordinary CI builds remain unsigned. With credentials, the build
+signs the desktop executable, both render-engine executables, and the final
+NSIS installer; verification precedes smoke testing and final archiving. The
+temporary PFX is deleted in a `finally` block and no certificate is installed
+in the Windows certificate store. `build-manifest.json` records whether the
+package was signed.
+
+The signing helper uses SHA-256 file and RFC 3161 timestamp digests with the
+DigiCert timestamp service, then requires `signtool verify /pa /all /tw` to
+pass. The flags follow [Microsoft's SignTool documentation](https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool).
+Configuring this workflow does not itself obtain a certificate or prove a
+successful signed release.
 
 Windows support is an additional host around the shared render core, not a
 replacement for the macOS implementation.

--- a/release/README.md
+++ b/release/README.md
@@ -75,6 +75,16 @@ The canonical updater URL is
 It becomes live after the first Mac release. The private signing key must match
 the public key embedded in `app/Info.plist`.
 
+## Windows release signing
+
+Ordinary CI builds remain unsigned so runtime and installation checks can run
+without release credentials. Public release builds set `require_signing: true`
+and fail before building if signing is not configured. Set repository secrets
+`WINDOWS_CERTIFICATE_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD` for the authorized
+Authenticode certificate export. The Windows SDK SignTool signs and timestamps
+the app and engine executables before packaging, then signs the final installer.
+The npm installer independently rejects an invalid or unsigned Windows installer.
+
 ## CLI and package definitions
 
 A Mac release contains `Contents/MacOS/lighttable-cli`. Its launcher resolves

--- a/scripts/windows/build-release.ps1
+++ b/scripts/windows/build-release.ps1
@@ -2,11 +2,16 @@ param(
     [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$')]
     [string]$Version = "0.1.0",
     [string]$OutputDirectory = "dist",
-    [switch]$PortableOnly
+    [switch]$PortableOnly,
+    [switch]$RequireSigning
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# Public releases must fail before downloads or compilation when signing is
+# unavailable. CI builds can run without a certificate unless explicitly gated.
+$SigningEnabled = & (Join-Path $PSScriptRoot "sign-release.ps1") -CheckOnly -RequireSigning:$RequireSigning
 
 $PythonVersion = "3.13.12"
 $PythonArchiveSha256 = "76f238f606250c87c6beac75dccd35ee99070a13490555936abb6cb64ecce3d0"
@@ -187,6 +192,14 @@ try {
         (Join-Path $Project "windows-shell\target\$Target\release\lighttable-desktop-shell.exe") `
         (Join-Path $Payload "LightTable.exe")
 
+    if ($SigningEnabled) {
+        & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files @(
+            (Join-Path $Payload "LightTable.exe"),
+            (Join-Path $Engine "lighttable-engine.exe"),
+            (Join-Path $Engine "spektrafilm-rs.exe")
+        )
+    }
+
     & $PythonExe -B `
         (Join-Path $Project "scripts\windows\runtime-smoke.py") `
         $Resources `
@@ -200,11 +213,8 @@ try {
         source_revision = $SourceRevision.Trim()
         architecture = "x64"
         python_version = $PythonVersion
+        authenticode_signed = [bool]$SigningEnabled
     } | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $Payload "build-manifest.json")
-
-    $Zip = Join-Path $Output "LightTable-$Version-windows-x64.zip"
-    if (Test-Path $Zip) { Remove-Item -Force $Zip }
-    Compress-Archive -Path $Payload -DestinationPath $Zip -CompressionLevel Optimal
 
     if (-not $PortableOnly) {
         $Installer = Join-Path $Output "LightTable-$Version-windows-x64-setup.exe"
@@ -219,8 +229,16 @@ try {
             "/DUNINSTALL_MANIFEST=$UninstallManifest" `
             (Join-Path $Project "scripts\windows\installer.nsi")
         if ($LASTEXITCODE -ne 0) { throw "The Windows installer failed to build" }
+        if ($SigningEnabled) {
+            & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files $Installer
+        }
         & (Join-Path $Project "scripts\windows\installer-smoke.ps1") -Installer $Installer -Version $Version
     }
+
+    # Archive only after every required signature and installer check passes.
+    $Zip = Join-Path $Output "LightTable-$Version-windows-x64.zip"
+    if (Test-Path $Zip) { Remove-Item -Force $Zip }
+    Compress-Archive -Path $Payload -DestinationPath $Zip -CompressionLevel Optimal
 
     Write-Host "Built Windows artifacts in $Output"
 } finally {

--- a/scripts/windows/sign-release.ps1
+++ b/scripts/windows/sign-release.ps1
@@ -1,0 +1,75 @@
+param(
+    [string[]]$Files = @(),
+    [switch]$RequireSigning,
+    [switch]$CheckOnly
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$HasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_BASE64)
+$HasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+if (-not $HasCertificate -and -not $HasPassword -and -not $RequireSigning) {
+    if ($CheckOnly) { return $false }
+    Write-Host "Authenticode is not configured; this is an unsigned CI build."
+    return
+}
+if (-not $HasCertificate -or -not $HasPassword) {
+    throw "Windows signing requires both WINDOWS_CERTIFICATE_BASE64 and WINDOWS_CERTIFICATE_PASSWORD."
+}
+if ($env:OS -ne "Windows_NT") { throw "Authenticode signing requires Windows and the Windows SDK." }
+
+$SignTool = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+if (-not $SignTool) {
+    $SdkBin = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+    $Candidate = Get-ChildItem -Path (Join-Path $SdkBin "*\x64\signtool.exe") -File -ErrorAction SilentlyContinue |
+        Sort-Object { [version]$_.Directory.Parent.Name } -Descending |
+        Select-Object -First 1
+    if ($Candidate) { $SignTool = Get-Command $Candidate.FullName }
+}
+if (-not $SignTool) { throw "Windows signing requires signtool.exe from the installed Windows SDK." }
+
+$SigningDirectory = Join-Path ([IO.Path]::GetTempPath()) ("lighttable-signing-" + [Guid]::NewGuid())
+$CertificatePath = Join-Path $SigningDirectory "certificate.pfx"
+$Certificate = $null
+try {
+    New-Item -ItemType Directory -Path $SigningDirectory | Out-Null
+    # Keep the decoded key in the runner's user-private temporary directory;
+    # neither its contents nor the password are written to build logs.
+    try {
+        [IO.File]::WriteAllBytes($CertificatePath, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_BASE64))
+        $Certificate = [Security.Cryptography.X509Certificates.X509Certificate2]::new(
+            $CertificatePath, $env:WINDOWS_CERTIFICATE_PASSWORD,
+            [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet
+        )
+    } catch {
+        throw "The Windows signing certificate could not be decoded or opened."
+    }
+    if (-not $Certificate.HasPrivateKey) { throw "The Windows signing certificate has no private key." }
+    if ($Certificate.NotBefore -gt (Get-Date) -or $Certificate.NotAfter -le (Get-Date)) {
+        throw "The Windows signing certificate is not currently valid."
+    }
+    if ($CheckOnly) { return $true }
+    if ($Files.Count -eq 0) { throw "At least one executable is required for Authenticode signing." }
+
+    foreach ($File in $Files) {
+        $Executable = (Resolve-Path -LiteralPath $File).Path
+        if ([IO.Path]::GetExtension($Executable) -ine ".exe") {
+            throw "The Windows release signing list must contain only executables."
+        }
+        # Microsoft's SignTool syntax uses /fd for the file digest and /td with
+        # /tr for an RFC 3161 timestamp. Pass arguments directly; never echo them.
+        # https://learn.microsoft.com/windows/win32/seccrypto/signtool
+        & $SignTool.Source sign /q /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 `
+            /f $CertificatePath /p $env:WINDOWS_CERTIFICATE_PASSWORD $Executable
+        if ($LASTEXITCODE -ne 0) { throw "Windows executable signing or timestamping failed." }
+        & $SignTool.Source verify /q /pa /all /tw $Executable
+        if ($LASTEXITCODE -ne 0) { throw "Windows executable Authenticode verification failed." }
+        Write-Host "Verified Authenticode signature: $([IO.Path]::GetFileName($Executable))"
+    }
+} finally {
+    if ($Certificate) { $Certificate.Dispose() }
+    if (Test-Path -LiteralPath $SigningDirectory) {
+        Remove-Item -LiteralPath $SigningDirectory -Recurse -Force
+    }
+}

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 import re
+import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -70,6 +73,71 @@ class WindowsUninstallManifestTests(unittest.TestCase):
                 self.skipTest("Creating symlinks requires Windows developer mode")
             with self.assertRaises(ValueError):
                 manifest.make_manifest(payload)
+
+
+class WindowsSigningContractTests(unittest.TestCase):
+    def test_reusable_workflow_preserves_source_identity_and_passes_signing_requirement(self):
+        workflow = (ROOT / ".github/workflows/windows-build.yml").read_text()
+        reusable = workflow.split("  workflow_call:\n", 1)[1].split("\npermissions:", 1)[0]
+        self.assertIn("      source_ref:", reusable)
+        self.assertIn("      require_signing:", reusable)
+        self.assertIn("        default: false\n        type: boolean", reusable)
+        self.assertEqual(workflow.count("ref: ${{ inputs.source_ref || github.sha }}"), 2)
+        self.assertIn("WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}", workflow)
+        self.assertIn("WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}", workflow)
+        self.assertIn("-RequireSigning:($env:REQUIRE_SIGNING -eq 'true')", workflow)
+        self.assertLess(workflow.index("name: Validate Windows signing configuration"),
+                        workflow.index("name: Install pinned build tools"))
+
+    def test_payload_and_installer_are_signed_before_archiving(self):
+        build = (ROOT / "scripts/windows/build-release.ps1").read_text()
+        self.assertLess(build.index("-CheckOnly -RequireSigning:$RequireSigning"),
+                        build.index("foreach ($Tool"))
+        payload_signing = build.index('-RequireSigning -Files @(')
+        installer_signing = build.index('-RequireSigning -Files $Installer')
+        self.assertLess(payload_signing, build.index('& $MakeNsis.Source'))
+        self.assertLess(installer_signing, build.index('"scripts\\windows\\installer-smoke.ps1"'))
+        self.assertLess(installer_signing, build.index("Compress-Archive"))
+        self.assertIn('authenticode_signed = [bool]$SigningEnabled', build)
+
+
+@unittest.skipUnless(shutil.which("pwsh") or shutil.which("powershell"), "PowerShell is required")
+class WindowsSigningGateTests(unittest.TestCase):
+    def invoke(self, script, *arguments, certificate=None, password=None):
+        environment = {key: value for key, value in os.environ.items()
+                       if key not in ("WINDOWS_CERTIFICATE_BASE64", "WINDOWS_CERTIFICATE_PASSWORD")}
+        if certificate is not None:
+            environment["WINDOWS_CERTIFICATE_BASE64"] = certificate
+        if password is not None:
+            environment["WINDOWS_CERTIFICATE_PASSWORD"] = password
+        return subprocess.run(
+            [shutil.which("pwsh") or shutil.which("powershell"), "-NoLogo", "-NoProfile",
+             "-NonInteractive", "-File", str(ROOT / "scripts/windows" / script), *arguments],
+            capture_output=True, text=True, env=environment, timeout=30,
+        )
+
+    def test_optional_signing_without_credentials_needs_no_windows_sdk(self):
+        result = self.invoke("sign-release.ps1", "-CheckOnly")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("False", result.stdout)
+
+    def test_required_signing_without_credentials_fails_before_a_build_starts(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "not-created"
+            result = self.invoke("build-release.ps1", "-RequireSigning", "-OutputDirectory", str(output))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Windows signing requires both", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_partial_configuration_never_silently_produces_an_unsigned_build(self):
+        for configuration in ({"certificate": "synthetic-test-certificate"},
+                              {"password": "synthetic-test-password"}):
+            with self.subTest(configuration=next(iter(configuration))):
+                result = self.invoke("sign-release.ps1", "-CheckOnly", **configuration)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Windows signing requires both", result.stderr)
+                for value in configuration.values():
+                    self.assertNotIn(value, result.stdout + result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Public Windows releases now require a valid Authenticode signing configuration before compilation. The build signs and verifies the app, render engines, and installer before smoke tests and final archiving; ordinary CI can still produce unsigned test artifacts.

Validation: eight focused Windows packaging tests passed, including executing missing/partial credential failures in PowerShell; actionlint passed, and the commit secret scan found no leaks. Actual signing awaits the release certificate.
