### PR TITLE
Keep saves ordered and finish catalog UI fixes

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import shutil
 import sqlite3
 import threading
@@ -1824,8 +1825,16 @@ class Catalog:
             where.append("COALESCE(f.capture_time, f.mtime_iso) >= ?")
             params.append(str(date_from))
         if date_to:
-            where.append("COALESCE(f.capture_time, f.mtime_iso) <= ?")
-            params.append(str(date_to))
+            bound = str(date_to)
+            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", bound):
+                # A bare date bound is inclusive: capture times carry a time
+                # of day, so comparing the full text excluded everything shot
+                # after midnight on the last day.
+                where.append(
+                    "substr(COALESCE(f.capture_time, f.mtime_iso), 1, 10) <= ?")
+            else:
+                where.append("COALESCE(f.capture_time, f.mtime_iso) <= ?")
+            params.append(bound)
         query_text = " ".join(str(flt.get("query", "")).split())
         if query_text:
             where.append(

--- a/ingest_workflow.py
+++ b/ingest_workflow.py
@@ -278,7 +278,8 @@ def render_path(template: str, context: dict) -> str:
     return "/".join(segments)
 
 
-def _template_context(item: dict, sequence: int, custom: str) -> dict:
+def template_context(item: dict, sequence: int, custom: str) -> dict:
+    """Token values for one described photo: name, camera, sequence, dates."""
     moment = _parse_moment(item.get("captureTime"))
     if moment is None:
         try:
@@ -368,7 +369,7 @@ def build_plan(items, request, *, existing_hashes=None) -> dict:
                                 "name": str(item.get("name", "")),
                                 "hash": digest, "reason": "duplicate"})
                 continue
-        context = _template_context(item, sequence, request["custom"])
+        context = template_context(item, sequence, request["custom"])
         folder = render_path(request["folderTemplate"], context)
         name = str(item.get("name", ""))
         stem = render_path(request["filenameTemplate"], context) \

--- a/scripts/sign-app.sh
+++ b/scripts/sign-app.sh
@@ -39,6 +39,11 @@ sign_path() {
 # Wheels and the film engines contain nested Mach-O code. Sign every leaf
 # before sealing the framework and application bundles around them.
 while IFS= read -r -d '' CANDIDATE; do
+  # Signing the main executable seals its containing app as well. Defer it
+  # until the CLI and the rest of the nested code have their own signatures.
+  if [[ "$CANDIDATE" == "$APP/Contents/MacOS/LightTable" ]]; then
+    continue
+  fi
   if /usr/bin/file -b "$CANDIDATE" | /usr/bin/grep -q 'Mach-O'; then
     sign_path "$CANDIDATE"
   fi

--- a/server.py
+++ b/server.py
@@ -5309,6 +5309,9 @@ class Handler(BaseHTTPRequestHandler):
                             catalog_entry_for(b["name"]), origin=origin)
                 EVENTS.publish("state", {
                     "names": [b["name"]], "fields": sorted(entry),
+                    # Carry the accepted update: a queued window save can
+                    # land before another client reacts to this event.
+                    "patch": copy.deepcopy(entry),
                     "origin": origin or "window",
                     "client": str(self.headers.get(
                         "X-LightTable-Client", ""))[:80],
@@ -5343,6 +5346,7 @@ class Handler(BaseHTTPRequestHandler):
                                     catalog_entry_for(name), origin=origin)
                 EVENTS.publish("state", {
                     "names": list(updates), "fields": sorted(cleaned),
+                    "patch": copy.deepcopy(cleaned),
                     "origin": origin or "window",
                     "client": str(self.headers.get(
                         "X-LightTable-Client", ""))[:80],
@@ -6507,25 +6511,31 @@ def rename_photos(body: dict) -> dict:
     except (TypeError, ValueError):
         start = 1
     batch = hashlib.sha256(str(time.time_ns()).encode()).hexdigest()[:16]
+    custom = str(body.get("custom", ""))
     planned: list[tuple[Path, Path, int, str]] = []
     taken: set[Path] = set()
-    for offset, name in enumerate(names):
+    described: set[Path] = set()
+    for name in names:
         path, source_id, relpath, _ = resolve_name(name)
-        context = {
-            "filename": path.stem,
-            # Zero-padded so a renamed set sorts the way an ingested one does.
-            "sequence": f"{start + offset:0{ingest_workflow.SEQUENCE_DIGITS}d}",
-            "custom": str(body.get("custom", "")),
-            "camera": "", "captureTime": "",
-        }
-        item = next((i for i in ingest_workflow.scan_source(path.parent,
-                                                            limit=1)
-                     if i["path"] == str(path)), None)
-        if item:
-            context["camera"] = item.get("camera", "")
-            context["captureTime"] = item.get("captureTime", "")
+        if path in described:
+            continue  # a virtual copy shares its original's file
+        described.add(path)
+        # Describe this photo itself. Scanning its folder with a limit of one
+        # described only the first photo there, so {camera} and the date
+        # tokens were empty for every other frame in the selection.
+        try:
+            item = ingest_workflow.describe_file(path)
+        except (OSError, ValueError):
+            item = {"name": path.name}
+        # Zero-padded so a renamed set sorts the way an ingested one does.
+        context = ingest_workflow.template_context(
+            item, start + len(planned), custom)
         stem = ingest_workflow.render_path(template, context)
-        target = path.with_name(f"{stem}{path.suffix}")
+        if "/" in stem:
+            raise ValueError("a rename template cannot create folders")
+        # A template whose tokens are all empty must keep the current name:
+        # ".jpg" would be a hidden file the library never shows again.
+        target = path.with_name(f"{stem or path.stem}{path.suffix}")
         suffix = 2
         while (target in taken or target.exists()) and target != path:
             target = path.with_name(f"{stem}-{suffix}{path.suffix}")

--- a/tests/edit-save-integration.test.mjs
+++ b/tests/edit-save-integration.test.mjs
@@ -45,7 +45,10 @@ function harness({manual = false} = {}) {
   const context = {
     console, structuredClone, Promise, AggregateError, S,
     $: node, cur: () => S.images[S.idx],
-    window: {addEventListener: noop},
+    window: {addEventListener: noop, confirm: () => true},
+    CLIENT_ID: 'test-window',
+    SURVEY: {active: 'B.raw', names: ['A.raw', 'B.raw']},
+    cullResults: () => S.images, chosenCull: () => ['sharp'], CULL_LABELS: {sharp: 'Sharp'},
     NATIVE_PREVIEW: false, GRADE_DEFAULTS: {},
     PRESET_BROWSER: null, METADATA: null,
     HISTORY: {
@@ -87,7 +90,7 @@ function harness({manual = false} = {}) {
     'setRenderPresentation', 'scheduleNativeViewportLayout', 'applyView', 'setCropMode',
     'setCompareActive', 'updateLoupeInfoOverlay', 'syncAIPhoto', 'loadLensProfile',
     'loadRawCameraDefault', 'showExif', 'presentVideo', 'broadcastToLoupe', 'prefetch',
-    'setEditorLoading',
+    'setEditorLoading', 'invalidateVisibleCache', 'syncCullPanel', 'confirmTransfer',
   ]) context[name] = noop;
   const stateStart = appSource.indexOf("let _lastHistorySnapshot = '';");
   const stateEnd = appSource.indexOf('function photoMatchesQuery(', stateStart);
@@ -98,13 +101,15 @@ function harness({manual = false} = {}) {
     'const photoUndo = createPhotoUndoHistory();',
     'const _pendingStateFetches = new Map();',
     'let navigationGeneration = 0, lastNavigationDirection = 1;',
+    "let _stripKey = '', _gridKey = '';",
     'let renderTimer, refineTimer, settleRenderTimer, browserOriginal, browserOriginalTextureURL;',
     ...['snapshot', 'filmRenderFingerprint', 'baseEditsFingerprint', 'updateUndoRedoButtons',
       'pushUndoState', 'pushUndo', 'restore', 'undo', 'redo', 'isStateLoaded',
       'normalizeLibraryImage', 'prefetchState',
-      'showCurrentImage', 'go', 'persistMark', 'saveStateFor'].map(appFunction),
+      'showCurrentImage', 'go', 'persistMark', 'saveStateFor', 'enqueuePhotoPatch',
+      'pasteSettingsTo', 'applyCullFlags', 'keepSurveySelection', 'applyServerStateEvent'].map(appFunction),
     appSource.slice(stateStart, stateEnd),
-    'globalThis.app = {saveState, saveStateFor, persistMark, go, showCurrentImage, pushUndo, undo, redo, flushEditSaves, queue: editSaveQueue, photoUndo};',
+    'globalThis.app = {saveState, saveStateFor, persistMark, go, showCurrentImage, pushUndo, undo, redo, flushEditSaves, pasteSettingsTo, applyCullFlags, keepSurveySelection, applyServerStateEvent, queue: editSaveQueue, photoUndo};',
   ].join('\n');
   vm.runInNewContext(code, context, {filename: 'actual-app-save-functions.js'});
   context.app.showCurrentImage(S.images[0]);
@@ -270,4 +275,181 @@ test('marks on the already displayed photo survive a concurrent state reload aft
   assert.equal(current.rating, 4);
   assert.equal(current.status, 'approved');
   assert.equal(app.S.grade.exposure, 0);
+});
+
+
+function clipboard(exposure) {
+  return {params: {profile_enabled: false}, grade: {exposure}, masks: [], heals: [], optics: {}};
+}
+
+test('paste joins a pending full save and later slider input cannot be reverted by its completion', async () => {
+  const app = harness({manual: true});
+  app.S.grade.exposure = 1;
+  app.S.crop = {x: .1, y: .2, w: .7, h: .6};
+  app.saveState();
+  app.S.clipboard = clipboard(4);
+  const paste = app.pasteSettingsTo([app.S.images[0]]);
+  assert.equal(app.S.grade.exposure, 4, 'paste is visible before its transport settles');
+  await settle();
+  assert.equal(app.requests.length, 1);
+  assert.equal(app.requests[0].path, '/api/state');
+  assert.equal(app.requests[0].state.grade.exposure, 4);
+  assert.deepEqual(app.requests[0].state.crop, {x: .1, y: .2, w: .7, h: .6});
+  app.S.grade.exposure = 5;
+  app.saveState();
+  app.requests[0].resolve({ok: true});
+  await paste;
+  assert.equal(app.S.grade.exposure, 5, 'paste completion must not reapply stale controls');
+  const saved = app.flushEditSaves();
+  await settle();
+  assert.equal(app.requests[1].state.grade.exposure, 5);
+  app.requests[1].resolve({ok: true});
+  assert.equal(await saved, true);
+});
+
+test('paste supersedes a failed noncurrent recipe and retry keeps its crop and new adjustments', async () => {
+  const app = harness({manual: true});
+  app.S.grade.exposure = 1;
+  app.S.crop = {x: .1};
+  const failed = app.saveState(true);
+  await settle();
+  app.requests[0].resolve({error: 'Disk full'});
+  assert.equal(await failed, false);
+  await app.go(1);
+  app.S.clipboard = clipboard(4);
+  await app.pasteSettingsTo([app.S.images[0]]);
+  assert.equal(app.requests.length, 1, 'failed state waits for explicit retry');
+  assert.equal(app.queue.getPending('A.raw').state.grade.exposure, 4);
+  assert.deepEqual(plain(app.queue.getPending('A.raw').state.crop), {x: .1});
+  assert.ok(!app.toasts.includes('Settings pasted'));
+  const retry = app.nodes.get('retryEditSave').onclick();
+  await settle();
+  assert.equal(app.requests[1].state.grade.exposure, 4);
+  app.requests[1].resolve({ok: true});
+  await retry;
+});
+
+test('assisted culling serializes new flags with pending full recipes', async () => {
+  const app = harness();
+  app.S.grade.exposure = 2;
+  app.saveState();
+  await app.applyCullFlags([], 'approved');
+  assert.ok(app.requests.every(request => request.path === '/api/state'));
+  assert.deepEqual(app.requests.map(request => [request.state.name, request.state.status]), [
+    ['A.raw', 'approved'], ['B.raw', 'approved'],
+  ]);
+  assert.equal(app.requests[0].state.grade.exposure, 2);
+  assert.equal(app.queue.getStatus().state, 'saved');
+});
+
+test('survey keep waits behind an outgoing full save and preserves its reject flag', async () => {
+  const app = harness({manual: true});
+  app.S.grade.exposure = 2;
+  app.saveState();
+  await app.go(1);
+  await settle();
+  const keep = app.keepSurveySelection();
+  await settle();
+  assert.deepEqual(app.requests.map(request => request.state.name), ['A.raw', 'B.raw']);
+  assert.equal(app.requests[1].state.status, 'approved');
+  app.requests[1].resolve({ok: true});
+  app.requests[0].resolve({ok: true});
+  await settle();
+  assert.equal(app.requests[2].state.name, 'A.raw');
+  assert.equal(app.requests[2].state.status, 'skipped');
+  assert.equal(app.requests[2].state.grade.exposure, 2);
+  app.requests[2].resolve({ok: true});
+  await keep;
+});
+
+test('accepted external patch repairs an older in-flight save without replacing unrelated edits', async () => {
+  const app = harness({manual: true});
+  app.S.grade.exposure = 2;
+  app.S.crop = {x: .15};
+  const oldSave = app.saveState(true);
+  await settle();
+  await app.applyServerStateEvent({client: 'cli', names: ['A.raw'], origin: 'cli', patch: {grade: {exposure: 8}}});
+  assert.equal(app.S.grade.exposure, 8);
+  assert.equal(app.stateReads.length, 0, 'accepted fields must not depend on a stale GET');
+  assert.equal(app.requests.length, 1, 'repair is serialized behind the older request');
+  app.requests[0].resolve({ok: true});
+  await settle();
+  assert.equal(app.requests[1].state.grade.exposure, 8);
+  assert.deepEqual(app.requests[1].state.crop, {x: .15});
+  app.requests[1].resolve({ok: true});
+  await oldSave;
+  assert.equal(await app.flushEditSaves(), true);
+  app.undo();
+  assert.equal(app.S.grade.exposure, 2, 'the external patch remains undoable');
+  const undoSave = app.flushEditSaves();
+  await settle();
+  app.requests[2].resolve({ok: true});
+  await undoSave;
+});
+
+test('accepted external patch updates a failed outgoing recipe before explicit retry', async () => {
+  const app = harness({manual: true});
+  app.S.grade.exposure = 2;
+  const oldSave = app.saveState(true);
+  await settle();
+  app.requests[0].resolve({error: 'Offline'});
+  await oldSave;
+  await app.go(1);
+  await app.applyServerStateEvent({client: 'cli', names: ['A.raw'], patch: {grade: {exposure: 9}, rating: 5}});
+  assert.equal(app.requests.length, 1);
+  assert.equal(app.queue.getPending('A.raw').state.grade.exposure, 9);
+  await app.go(0);
+  assert.equal(app.S.grade.exposure, 9);
+  assert.equal(app.S.images[0].rating, 5);
+  const retry = app.nodes.get('retryEditSave').onclick();
+  await settle();
+  assert.equal(app.requests[1].state.grade.exposure, 9);
+  app.requests[1].resolve({ok: true});
+  await retry;
+});
+
+test('metadata-only external events leave edit controls and queued recipes intact', async () => {
+  const app = harness();
+  app.S.grade.exposure = 2;
+  app.saveState();
+  await app.applyServerStateEvent({names: ['A.raw'], fields: ['metadata'], origin: 'metadata'});
+  assert.equal(app.S.grade.exposure, 2);
+  assert.equal(app.queue.getPending('A.raw').state.grade.exposure, 2);
+  assert.equal(app.stateReads.length, 0);
+  await app.flushEditSaves();
+});
+
+test('paste during a photo load survives a stale state response after its write completes', async () => {
+  const app = harness();
+  app.S.images[1].stateLoaded = false;
+  const navigation = app.go(1);
+  app.S.clipboard = clipboard(4);
+  await app.pasteSettingsTo([app.S.images[1]]);
+  assert.equal(app.requests[0].state.grade.exposure, 4);
+  assert.equal(app.queue.getStatus().state, 'saved');
+  app.stateReads[0].resolve({grade: {exposure: -3}});
+  await navigation;
+  assert.equal(app.S.grade.exposure, 4);
+});
+
+test('a failed history flush prevents save success and Retry waits for history', async () => {
+  const app = harness();
+  app.context.HISTORY.flush = async () => false;
+  assert.equal(await app.saveState(true), false);
+  let retried = false;
+  app.context.HISTORY.retry = async () => { retried = true; return false; };
+  await app.nodes.get('retryEditSave').onclick();
+  assert.equal(retried, true);
+  assert.ok(!app.toasts.includes('Edits saved'));
+  assert.match(app.toasts.at(-1), /Still unable to save/);
+});
+
+
+test('an external patch on an idle photo is displayed without echoing another state write', async () => {
+  const app = harness();
+  await app.applyServerStateEvent({client: 'other-window', names: ['A.raw'], patch: {grade: {exposure: 6}}});
+  assert.equal(app.S.grade.exposure, 6);
+  assert.equal(app.S.images[0].grade.exposure, 6);
+  assert.equal(app.requests.length, 0);
+  assert.equal(app.queue.getStatus().state, 'saved');
 });

--- a/tests/edit-save-queue.test.mjs
+++ b/tests/edit-save-queue.test.mjs
@@ -12,10 +12,11 @@ const deferred = () => {
   return {promise, resolve, reject};
 };
 
-function harness() {
+function harness(options = {}) {
   let clock = 0, nextId = 0;
   const timers = new Map(), requests = [], statuses = [];
   const queue = createEditSaveQueue({
+    ...options,
     send(name, payload) {
       const result = deferred();
       requests.push({name, payload, ...result});
@@ -210,4 +211,93 @@ test('synchronous send failures are retained and unrelated photos still save', a
   await queue.retry();
   assert.deepEqual(writes.map(write => write.name), ['B', 'A']);
   assert.equal(queue.getStatus().state, 'saved');
+});
+
+
+test('bulk writes use at most four shared transport slots and every photo makes progress', async () => {
+  const {queue, requests} = harness();
+  for (let i = 0; i < 17; i++) queue.enqueue(`photo-${i}`, {exposure: i}, {immediate: true});
+  const done = queue.flush();
+  await settle();
+  assert.equal(requests.length, 4);
+  let peak = queue.getStatus().savingNames.length;
+  for (let i = 0; i < 17; i++) {
+    assert.ok(requests[i], `photo ${i} must acquire a released slot`);
+    requests[i].resolve();
+    await settle();
+    peak = Math.max(peak, queue.getStatus().savingNames.length);
+    assert.ok(queue.getStatus().savingNames.length <= 4);
+  }
+  await done;
+  assert.equal(peak, 4);
+  assert.deepEqual(requests.map(request => request.name), Array.from({length: 17}, (_, i) => `photo-${i}`));
+  assert.equal(queue.getStatus().state, 'saved');
+});
+
+test('a failed transport frees its slot and retry joins the pool without overtaking waiting photos', async () => {
+  const {queue, requests} = harness({maxConcurrent: 2});
+  for (const name of ['A', 'B', 'C', 'D']) queue.enqueue(name, {exposure: 1}, {immediate: true});
+  const failed = assert.rejects(queue.flush(), /Could not save edits for A/);
+  await settle();
+  requests[0].reject(new Error('Offline'));
+  await settle();
+  assert.deepEqual(requests.map(request => request.name), ['A', 'B', 'C']);
+  queue.enqueue('A', {exposure: 2});
+  const retry = queue.retry('A');
+  await settle();
+  assert.equal(requests.length, 3, 'retry must respect the occupied transport slots');
+  requests[1].resolve();
+  await settle();
+  assert.equal(requests[3].name, 'D', 'previously waiting photo is not starved by retry');
+  requests[2].resolve();
+  await settle();
+  assert.equal(requests[4].name, 'A');
+  assert.equal(requests[4].payload.exposure, 2);
+  assert.equal(queue.getStatus().savingNames.length, 2);
+  requests[3].resolve();
+  requests[4].resolve();
+  await Promise.all([failed, retry]);
+  assert.equal(queue.getStatus().state, 'saved');
+});
+
+test('new debounced input removes an unflushed photo from the waiting transport pool', async () => {
+  const {queue, requests, advance} = harness({maxConcurrent: 1});
+  queue.enqueue('A', {exposure: 1}, {immediate: true});
+  queue.enqueue('B', {exposure: 2}, {immediate: true});
+  queue.enqueue('B', {exposure: 3});
+  await settle();
+  requests[0].resolve();
+  await settle();
+  assert.equal(requests.length, 1, 'B retains its new debounce after A releases a slot');
+  await advance(400);
+  assert.equal(requests[1].payload.exposure, 3);
+  requests[1].resolve();
+  await queue.flush();
+});
+
+test('later input cannot delay a flush already waiting for a transport slot', async () => {
+  const {queue, requests, timers} = harness({maxConcurrent: 1});
+  queue.enqueue('A', {exposure: 1}, {immediate: true});
+  queue.enqueue('B', {exposure: 2});
+  const flush = queue.flush('B');
+  queue.enqueue('C', {exposure: 4}, {immediate: true});
+  queue.enqueue('B', {exposure: 3});
+  await settle();
+  assert.equal(timers.size, 0);
+  requests[0].resolve();
+  await settle();
+  assert.equal(requests[1].name, 'B');
+  assert.equal(requests[1].payload.exposure, 3);
+  requests[1].resolve();
+  await flush;
+  await settle();
+  assert.equal(requests[2].name, 'C');
+  requests[2].resolve();
+  await queue.flush();
+});
+
+test('transport concurrency must be a positive integer', () => {
+  for (const maxConcurrent of [0, -1, 1.5, Infinity, NaN]) {
+    assert.throws(() => createEditSaveQueue({send() {}, maxConcurrent}), RangeError);
+  }
 });

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -417,6 +417,21 @@ class QueryTests(unittest.TestCase):
         self.assertEqual(
             self.cat.query({"filter": {"status": "approved"}})["total"], 1)
 
+    def test_a_bare_end_date_includes_that_whole_day(self):
+        with self.cat.write() as conn:
+            conn.execute("UPDATE files SET capture_time=? WHERE relpath=?",
+                         ("2024-03-09T18:30:00", "f0.jpg"))
+            conn.execute("UPDATE files SET capture_time=? WHERE relpath=?",
+                         ("2024-03-10T00:00:01", "f1.jpg"))
+        result = self.cat.query({"filter": {"dateFrom": "2024-03-09",
+                                            "dateTo": "2024-03-09"}})
+        self.assertEqual([item["relpath"] for item in result["items"]],
+                         ["f0.jpg"])
+        # A bound with a time of day still compares exactly.
+        precise = self.cat.query({"filter": {"dateFrom": "2024-03-09",
+                                             "dateTo": "2024-03-09T12:00:00"}})
+        self.assertEqual(precise["total"], 0)
+
     def test_paging_reports_total_beyond_the_page(self):
         page = self.cat.query({"limit": 3})
         self.assertEqual(page["total"], 7)

--- a/tests/test_history_panel.py
+++ b/tests/test_history_panel.py
@@ -33,7 +33,7 @@ const nodes = Object.fromEntries(['historyList', 'historyClear', 'historyPane'].
   classList: {contains: () => false},
   addEventListener(type, callback) { this.handlers[type] = callback; },
 }]));
-const posts = [], notices = [], restored = [];
+const posts = [], notices = [], restored = [], statuses = [];
 let get = async () => ({steps: []});
 let post = async (path, body) => { posts.push({path, body}); return {ok: true}; };
 let enabled = true;
@@ -41,6 +41,7 @@ const h = createHistoryPanel({
   el: id => nodes[id], post: (...args) => post(...args), get: (...args) => get(...args),
   toast: message => notices.push(message), enabled: () => enabled,
   onRestore: state => restored.push(state),
+  onStatus: status => statuses.push(status),
 });
 """
 
@@ -49,7 +50,7 @@ const h = createHistoryPanel({
 class HistoryPanelTests(unittest.TestCase):
     def run_js(self, body):
         result = subprocess.run(['node', '--input-type=module', '-e', HARNESS + body],
-                                cwd=ROOT, text=True, capture_output=True, check=True)
+                                cwd=ROOT, text=True, capture_output=True, check=True, timeout=30)
         return json.loads(result.stdout)
 
     def test_final_slider_snapshot_flushes_without_another_interaction(self):
@@ -109,22 +110,115 @@ console.log(JSON.stringify(posts.map(p => p.body.state.masks[0].points)));
 """)
         self.assertEqual(result, [[1], [3]])
 
-    def test_failed_write_is_visible_and_does_not_block_later_steps(self):
+    def test_failed_write_survives_its_window_and_retries_before_later_steps(self):
         result = self.run_js("""
+let online = false;
+const persisted = [];
 post = async (path, body) => {
   posts.push({path, body});
-  if (body.state.value === 1) throw new Error('offline');
-  if (body.state.value === 2) return {error: 'disk full'};
+  if (body.name === 'a' && !online) throw new Error('offline');
+  persisted.push(body.name + body.state.value);
   return {ok: true};
 };
 h.record('a', 'Light', {value: 1});
 h.record('a', 'Crop', {value: 2});
 h.record('a', 'Remove', {value: 3});
-await h.flush();
-console.log(JSON.stringify({sent: posts.map(p => p.body.state.value), notices}));
+h.record('b', 'Light', {value: 1});
+await settle(); await advance(2000);
+const first = {pending: h.hasPending, persisted: [...persisted], status: statuses.at(-1)};
+const failedFlush = await h.flush();
+const stillPending = h.hasPending;
+online = true;
+const retry = await h.retry();
+console.log(JSON.stringify({first, failedFlush, stillPending, retry, persisted,
+  sent: posts.map(p => p.body.name + p.body.state.value), notices,
+  finished: h.hasPending, status: statuses.at(-1)}));
 """)
-        self.assertEqual(result['sent'], [1, 2, 3])
+        self.assertEqual(result['first'], {
+            'pending': True, 'persisted': ['b1'],
+            'status': {'pendingNames': ['a'], 'failedNames': ['a'],
+                       'error': 'Could not save photo history'},
+        })
+        self.assertFalse(result['failedFlush'])
+        self.assertTrue(result['stillPending'])
+        self.assertTrue(result['retry'])
+        self.assertEqual(result['persisted'], ['b1', 'a1', 'a2', 'a3'])
+        self.assertEqual(result['sent'], ['a1', 'b1', 'a1', 'a1', 'a2', 'a3'])
         self.assertEqual(result['notices'], ['Could not save photo history'] * 2)
+        self.assertFalse(result['finished'])
+        self.assertEqual(result['status'], {'pendingNames': [], 'failedNames': [], 'error': None})
+
+    def test_flush_reports_a_failure_that_occurs_during_the_flush(self):
+        result = self.run_js("""
+const first = deferred();
+post = async (path, body) => { posts.push({path, body}); return first.promise; };
+h.record('a', 'Light', {value: 1});
+h.record('a', 'Light', {value: 2});
+const flushing = h.flush();
+first.resolve({ok: false, error: 'disk full'});
+const saved = await flushing;
+console.log(JSON.stringify({saved, pending: h.hasPending,
+  sent: posts.map(p => p.body.state.value), notices}));
+""")
+        self.assertEqual(result, {
+            'saved': False, 'pending': True, 'sent': [1],
+            'notices': ['Could not save photo history'],
+        })
+
+    def test_failed_clear_retries_before_subsequent_edits(self):
+        result = self.run_js("""
+let online = false;
+post = async (path, body) => {
+  posts.push({path, body});
+  if (path.endsWith('/clear') && !online) return {error: 'disk full'};
+  return {ok: true};
+};
+await h.refresh('a');
+h.record('a', 'Light', {value: 1});
+const clearing = nodes.historyClear.handlers.click();
+h.record('a', 'Light', {value: 2});
+await clearing; await settle();
+const before = {actions: posts.map(p => p.body.state?.value ?? 'clear'),
+  pending: h.hasPending, status: statuses.at(-1)};
+online = true;
+const saved = await h.retry();
+console.log(JSON.stringify({before, saved, pending: h.hasPending,
+  actions: posts.map(p => p.body.state?.value ?? 'clear'), notices}));
+""")
+        self.assertEqual(result['before'], {
+            'actions': [1, 'clear'], 'pending': True,
+            'status': {'pendingNames': ['a'], 'failedNames': ['a'],
+                       'error': 'Could not clear photo history'},
+        })
+        self.assertTrue(result['saved'])
+        self.assertFalse(result['pending'])
+        self.assertEqual(result['actions'], [1, 'clear', 'clear', 2])
+        self.assertEqual(result['notices'], ['Could not clear photo history'])
+
+    def test_scoped_retry_keeps_other_photos_pending(self):
+        result = self.run_js("""
+let online = false;
+post = async (path, body) => {
+  posts.push({path, body});
+  if (!online) return {error: 'offline'};
+  return {ok: true};
+};
+h.record('a', 'Light', {value: 1}); h.record('b', 'Light', {value: 1});
+await settle(); online = true;
+const savedA = await h.retry('a');
+const middle = {pending: h.hasPending, status: statuses.at(-1)};
+const savedB = await h.flush('b');
+console.log(JSON.stringify({savedA, middle, savedB, pending: h.hasPending,
+  names: posts.map(p => p.body.name)}));
+""")
+        self.assertTrue(result['savedA'])
+        self.assertEqual(result['middle'], {
+            'pending': True, 'status': {'pendingNames': ['b'], 'failedNames': ['b'],
+                                     'error': 'Could not save photo history'},
+        })
+        self.assertTrue(result['savedB'])
+        self.assertFalse(result['pending'])
+        self.assertEqual(result['names'], ['a', 'b', 'a', 'b'])
 
     def test_late_history_results_do_not_replace_selected_photo(self):
         result = self.run_js("""

--- a/tests/test_ingest_workflow.py
+++ b/tests/test_ingest_workflow.py
@@ -159,7 +159,7 @@ class TemplateTests(unittest.TestCase):
         item = {"name": "IMG_0007.CR2", "camera": "Canon EOS R5",
                 "captureTime": "2026-07-04T08:09:10"}
         item.update(overrides)
-        return ingest._template_context(item, 7, "beach")
+        return ingest.template_context(item, 7, "beach")
 
     def test_folder_and_filename_tokens_render(self):
         context = self._context()

--- a/tests/test_macos_signing.py
+++ b/tests/test_macos_signing.py
@@ -1,0 +1,42 @@
+"""Exercise nested signing with the packaged command wrapper present."""
+import platform
+import plistlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(platform.system() == 'Darwin' and shutil.which('cc'),
+                     'macOS compiler and signing tools required')
+class MacOSSigningTests(unittest.TestCase):
+    def test_main_app_is_sealed_after_the_command_wrapper(self):
+        with tempfile.TemporaryDirectory(prefix='lighttable-signing-test-') as raw:
+            app = Path(raw) / 'LightTable.app'
+            contents = app / 'Contents'
+            executable = contents / 'MacOS' / 'LightTable'
+            executable.parent.mkdir(parents=True)
+            (contents / 'Info.plist').write_bytes(plistlib.dumps({
+                'CFBundleIdentifier': 'org.lighttable.signing-test',
+                'CFBundleExecutable': 'LightTable',
+                'CFBundlePackageType': 'APPL',
+                'CFBundleVersion': '1',
+            }))
+            subprocess.run(['cc', '-x', 'c', '-', '-o', str(executable)],
+                           input='int main(void) { return 0; }\n', text=True,
+                           capture_output=True, check=True, timeout=60)
+            wrapper = executable.with_name('lighttable-cli')
+            wrapper.write_text('#!/bin/sh\nexit 0\n')
+            wrapper.chmod(0o755)
+            signed = subprocess.run([str(ROOT / 'scripts/sign-app.sh'), str(app)],
+                                    text=True, capture_output=True, timeout=60)
+            self.assertEqual(signed.returncode, 0, signed.stdout + signed.stderr)
+            subprocess.run(['codesign', '--verify', '--deep', '--strict', str(app)],
+                           capture_output=True, check=True, timeout=30)
+            # Both executables remain usable after sealing the enclosing app.
+            for path in (executable, wrapper):
+                subprocess.run([str(path)], check=True, timeout=10)

--- a/tests/test_photo_feature_contracts.py
+++ b/tests/test_photo_feature_contracts.py
@@ -59,7 +59,6 @@ class PhotoFeatureContractTests(unittest.TestCase):
         self.assertIn(".workspace-cullbar { grid-column:1; grid-row:2; }", css)
         self.assertIn("function markingTargets()", javascript)
         self.assertIn("function syncCullBars()", javascript)
-        self.assertIn("api('/api/state/bulk'", javascript)
 
     def test_professional_scopes_share_the_bounded_preview_sample(self):
         html = (ROOT / "web" / "index.html").read_text()

--- a/tests/test_server_catalog.py
+++ b/tests/test_server_catalog.py
@@ -335,6 +335,53 @@ class RenameTests(CatalogServerTestCase):
         self.assertEqual(moved["total"], 1)
         self.assertEqual(moved["items"][0]["rating"], 3)
 
+    def test_camera_and_date_tokens_describe_each_photo(self):
+        """Every photo is described itself, not the first one in its folder."""
+        import ingest_workflow
+
+        def describe(path):
+            path = Path(path)
+            return {"name": path.name, "camera": f"Cam {path.stem.upper()}",
+                    "captureTime": "2024-03-09T10:11:12", "mtime": 0.0}
+
+        names = [self.qualified("a.jpg"), self.qualified("sub/b.jpg")]
+        with mock.patch.object(ingest_workflow, "describe_file",
+                               side_effect=describe):
+            result = server.rename_photos({
+                "names": names,
+                "template": "{camera}_{yyyy}{mm}{dd}_{sequence}"})
+        self.assertEqual(result["renamed"], 2)
+        self.assertTrue((self.root / "Cam A_20240309_0001.jpg").is_file())
+        self.assertTrue(
+            (self.root / "sub" / "Cam B_20240309_0002.jpg").is_file())
+
+    def test_a_template_without_values_keeps_the_original_name(self):
+        """Empty tokens must never rename a photo to a hidden ".jpg"."""
+        result = server.rename_photos(
+            {"names": [self.qualified("a.jpg")], "template": "{camera}"})
+        self.assertEqual(result["renamed"], 0)
+        self.assertTrue((self.root / "a.jpg").is_file())
+        self.assertEqual([p.name for p in self.root.iterdir()
+                          if p.name.startswith(".")], [])
+
+    def test_a_folder_separator_in_the_template_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "cannot create folders"):
+            server.rename_photos({"names": [self.qualified("a.jpg")],
+                                  "template": "{yyyy}/{filename}"})
+        self.assertTrue((self.root / "a.jpg").is_file())
+
+    def test_a_virtual_copy_and_its_original_rename_the_file_once(self):
+        original = self.qualified("a.jpg")
+        created = server.update_library(
+            {"action": "create_virtual", "name": original})
+        result = server.rename_photos(
+            {"names": [original, created["copy"]["name"]],
+             "template": "Trip_{sequence}"})
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["renamed"], 1)
+        self.assertTrue((self.root / "Trip_0001.jpg").is_file())
+        self.assertFalse((self.root / "Trip_0002.jpg").exists())
+
     def test_rename_carries_the_sidecar(self):
         (self.root / "a.xmp").write_text("<x/>")
         server.rename_photos({"names": [self.qualified("a.jpg")],

--- a/tests/test_server_http.py
+++ b/tests/test_server_http.py
@@ -3,8 +3,53 @@ from __future__ import annotations
 import io
 import unittest
 from contextlib import redirect_stderr
+from unittest import mock
 
 import server
+from events import EventBroker
+
+
+class AcceptedStateEventTests(unittest.TestCase):
+    def test_state_events_keep_the_accepted_patch_after_later_writes(self):
+        for path in ("/api/state", "/api/state/bulk"):
+            with self.subTest(path=path):
+                broker = EventBroker()
+                subscriber = broker.subscribe("other-window")
+                handler = server.Handler.__new__(server.Handler)
+                handler.path = path
+                handler.headers = {"X-LightTable-Client": "cli-test"}
+                handler._enforce_security = mock.Mock()
+                handler._json = mock.Mock()
+                handler._log_request = mock.Mock()
+                patch = {"rating": 9, "status": "approved"}
+                body = ({"name": "a.jpg", **patch} if path == "/api/state"
+                        else {"names": ["a.jpg", "b.jpg"], "entry": patch})
+                handler._body = lambda: {**body, "origin": "cli"}
+                accepted = {}
+
+                def save_one(name, entry):
+                    accepted[name] = entry
+
+                def save_many(entries):
+                    accepted.update(entries)
+
+                with mock.patch.object(server, "EVENTS", broker), \
+                        mock.patch.object(server, "catalog_handle", return_value=None), \
+                        mock.patch.object(server, "catalog_image_id", return_value=None), \
+                        mock.patch.object(server, "save_image_state", side_effect=save_one), \
+                        mock.patch.object(server, "save_image_states", side_effect=save_many):
+                    handler.do_POST()
+                self.assertTrue(handler._json.call_args.args[0]["ok"])
+                event = broker.get(subscriber, timeout=0)
+                self.assertEqual(event["patch"], {"rating": 5, "status": "approved"})
+                self.assertEqual(event["names"], list(accepted))
+                self.assertEqual(event["client"], "cli-test")
+                self.assertEqual(event["fields"], ["rating", "status"])
+                # The event must not change if a following save modifies the
+                # stored state before the other window consumes its update.
+                for entry in accepted.values():
+                    entry["rating"] = 1
+                self.assertEqual(event["patch"]["rating"], 5)
 
 
 class QuietDisconnectTests(unittest.TestCase):

--- a/web/app.js
+++ b/web/app.js
@@ -3807,25 +3807,36 @@ const editSaveQueue = createEditSaveQueue({
     if (image) invalidateEditedThumbnail(image);
     if (payload.history) HISTORY?.record(name, payload.history.label, payload.history.state);
   },
-  onStatus(status) {
-    const label = $('editSaveStatus');
-    label.textContent = status.state === 'error' ? 'Edits not saved'
-      : status.state === 'saving' ? 'Saving…' : 'Saved';
-    label.dataset.state = status.state;
-    label.title = status.state === 'error'
-      ? 'Keep this window open and retry to save your changes.' : '';
-    $('retryEditSave').hidden = status.state !== 'error';
-  },
+  onStatus: () => updateEditSaveStatus(),
 });
+let historySaveStatus = { pendingNames: [], failedNames: [], error: null };
+function updateEditSaveStatus() {
+  const status = editSaveQueue.getStatus();
+  const state = status.state === 'error' || historySaveStatus.error ? 'error'
+    : status.state === 'saving' || historySaveStatus.pendingNames.length ? 'saving' : 'saved';
+  const label = $('editSaveStatus');
+  label.textContent = state === 'error' ? 'Edits not saved' : state === 'saving' ? 'Saving…' : 'Saved';
+  label.dataset.state = state;
+  label.title = state === 'error' ? 'Keep this window open and retry to save your changes.' : '';
+  $('retryEditSave').hidden = state !== 'error';
+}
 
 async function flushEditSaves() {
-  try { await editSaveQueue.flush(); await HISTORY?.flush(); return true; }
-  catch { toast('Edits could not be saved. Use Retry save before continuing.'); return false; }
+  try {
+    await editSaveQueue.flush();
+    if (await HISTORY?.flush() === false) throw new Error('Could not save photo history');
+    return true;
+  } catch { toast('Edits could not be saved. Use Retry save before continuing.'); return false; }
 }
 
 $('retryEditSave').onclick = async () => {
-  try { await editSaveQueue.retry(); toast('Edits saved'); }
-  catch { toast('Still unable to save. Your changes are kept in this window.'); }
+  try {
+    await editSaveQueue.retry();
+    if (await (HISTORY?.retry ? HISTORY.retry() : HISTORY?.flush()) === false) {
+      throw new Error('Could not save photo history');
+    }
+    toast('Edits saved');
+  } catch { toast('Still unable to save. Your changes are kept in this window.'); }
 };
 window.addEventListener('beforeunload', (event) => {
   if (!editSaveQueue.getStatus().pendingNames.length && !HISTORY?.hasPending) return;
@@ -4562,9 +4573,11 @@ function renderCollections() {
     const row = document.createElement('div');
     row.className = 'collection-row' +
       (collection.id === S.activeCollection ? ' on' : '');
-    row.innerHTML = `<button class="collection-main" type="button"><span></span><b>${collectionImages(collection).length}</b></button><button class="collection-delete" type="button" title="Delete collection" aria-label="Delete ${collection.name}">×</button>`;
+    row.innerHTML = `<button class="collection-main" type="button"><span></span><b>${collectionImages(collection).length}</b></button><button class="collection-delete" type="button" title="Delete collection">×</button>`;
     row.querySelector('span').textContent =
       `${collection.type === 'smart' ? '✦ ' : ''}${collection.name}`;
+    row.querySelector('.collection-delete').setAttribute(
+      'aria-label', `Delete ${collection.name}`);
     row.querySelector('.collection-main').onclick = () => {
       S.activeCollection = S.activeCollection === collection.id ? '' : collection.id;
       refreshFilteredView(); savePrefs();
@@ -5875,6 +5888,25 @@ function advanceAfterMark(im) {
   }
 }
 
+// Every local state mutation joins the same per-photo chain. A partial patch
+// must retain any full recipe still waiting to save, including after a failure.
+function enqueuePhotoPatch(im, patch, { historyLabel } = {}) {
+  const pending = editSaveQueue.getPending(im.name);
+  const state = { ...pending?.state, ...cloneValue(patch), name: im.name };
+  Object.assign(im, cloneValue(patch));
+  if (im.stateLoadEdits) Object.assign(im.stateLoadEdits, cloneValue(patch));
+  const history = pending?.history ? {
+    label: historyLabel || pending.history.label,
+    state: { ...pending.history.state },
+  } : null;
+  if (history) {
+    for (const key of ['params', 'grade', 'crop', 'masks', 'heals', 'optics']) {
+      if (Object.prototype.hasOwnProperty.call(patch, key)) history.state[key] = cloneValue(patch[key]);
+    }
+  }
+  editSaveQueue.enqueue(im.name, { state, history }, { immediate: true });
+}
+
 /* saveState() always writes the photo the editor has open; marking from the
  * survey needs to write a different one. */
 function saveStateFor(im, immediate = false) {
@@ -5992,12 +6024,8 @@ async function applyCullFlags(group, status) {
   if (!window.confirm(
     `${verb} ${targets.length} photo${targets.length === 1 ? '' : 's'} `
     + `matching ${criteria}? Existing flags on those photos are replaced.`)) return;
-  for (const image of targets) image.status = status;
-  await api('/api/state/bulk', {
-    names: targets.map((image) => image.name),
-    entry: { status },
-    historyLabel: `Assisted culling: ${criteria}`,
-  });
+  for (const image of targets) enqueuePhotoPatch(image, { status });
+  if (!await flushEditSaves()) return;
   invalidateVisibleCache();
   _stripKey = _gridKey = '';
   refreshLists();
@@ -6881,41 +6909,39 @@ $('copyBtn').onclick = () => {
   confirmTransfer('copyBtn');
   toast('Settings copied');
 };
-function pasteInto(im) {
-  im.params = cloneValue(S.clipboard.params);
-  im.grade = cloneValue(S.clipboard.grade);
-  im.masks = normalizeMasks(cloneValue(S.clipboard.masks));
-  im.heals = normalizeHeals(cloneValue(S.clipboard.heals));
-  im.optics = normalizeOptics(cloneValue(S.clipboard.optics));
-}
 async function pasteSettingsTo(targets) {
   if (!S.clipboard) return toast('Nothing copied');
   const items = [...new Set(targets)].filter(Boolean);
   if (!items.length) return;
-  const currentIncluded = items.includes(cur());
-  const names = items.map((im) => im.name);
-  const result = await api('/api/state/bulk', {
-    names, entry: {
-      params: S.clipboard.params, grade: S.clipboard.grade,
-      masks: S.clipboard.masks, heals: S.clipboard.heals, optics: S.clipboard.optics,
-    },
-  });
-  if (result.error) return toast(result.error);
+  const current = cur();
+  const currentIncluded = items.includes(current) && S.editingName === current.name;
+  const settings = {
+    params: cloneValue(S.clipboard.params), grade: cloneValue(S.clipboard.grade),
+    masks: normalizeMasks(cloneValue(S.clipboard.masks)),
+    heals: normalizeHeals(cloneValue(S.clipboard.heals)),
+    optics: normalizeOptics(cloneValue(S.clipboard.optics)),
+  };
+  // Apply before yielding so later input starts from the pasted state. Waiting
+  // for a bulk POST here used to let an older queued recipe overwrite the paste.
   if (currentIncluded) pushUndo();
-  items.forEach(pasteInto);
-  items.forEach(invalidateEditedThumbnail);
+  for (const image of items) {
+    enqueuePhotoPatch(image, settings, { historyLabel: 'Paste settings' });
+    if (image !== current) photoUndo.clear(image.name);
+    invalidateEditedThumbnail(image);
+  }
   if (currentIncluded) {
-    S.params = cloneValue(cur().params);
-    S.grade = cloneValue(cur().grade);
-    S.masks = normalizeMasks(cur().masks); S.heals = normalizeHeals(cur().heals);
-    S.optics = normalizeOptics(cur().optics); S.maskTextureDirty = true;
+    S.params = cloneValue(current.params);
+    S.grade = cloneValue(current.grade);
+    S.masks = normalizeMasks(current.masks); S.heals = normalizeHeals(current.heals);
+    S.optics = normalizeOptics(current.optics); S.maskTextureDirty = true;
     S.selectedMaskId = S.masks[0]?.id || null; S.selectedHealId = S.heals[0]?.id || null;
     syncControls(); syncGrade(); syncCurveFromGrade(); syncHsl();
     syncMaskPanel(); syncHealPanel(); syncOpticsPanel(); drawGrade(); renderFilm(0);
   }
   refreshLists();
+  if (!await flushEditSaves()) return;
   confirmTransfer('pasteBtn');
-  toast(names.length === 1 ? 'Settings pasted' : `Pasted to ${names.length} photos`);
+  toast(items.length === 1 ? 'Settings pasted' : `Pasted to ${items.length} photos`);
 }
 $('pasteBtn').onclick = () => pasteSettingsTo(transferTargets());
 $('pasteAllBtn').onclick = () => pasteSettingsTo(visible());
@@ -9283,6 +9309,7 @@ HISTORY = createHistoryPanel({
   post: api,
   get: getJSON,
   toast,
+  onStatus(status) { historySaveStatus = status; updateEditSaveStatus(); },
   enabled: () => S.catalogEnabled,
   onRestore: (state) => {
     pushUndo();
@@ -9410,24 +9437,19 @@ async function trashRejected() {
 /* ------------------------------------------------------- survey controls */
 if ($('surveyClose')) $('surveyClose').onclick = () => SURVEY.close();
 if ($('surveySwap')) $('surveySwap').onclick = () => SURVEY.swap();
-if ($('surveyKeep')) {
-  $('surveyKeep').onclick = async () => {
-    const keeper = SURVEY.active;
-    if (!keeper) return;
-    const others = SURVEY.names.filter((name) => name !== keeper);
-    S.images.forEach((image) => {
-      if (image.name === keeper) image.status = 'approved';
-      else if (others.includes(image.name)) image.status = 'skipped';
-    });
-    await api('/api/state', { name: keeper, status: 'approved' });
-    if (others.length) {
-      await api('/api/state/bulk',
-                { names: others, entry: { status: 'skipped' } });
-    }
-    refreshLists();
-    toast('Marked the select and rejected the rest');
-  };
+async function keepSurveySelection() {
+  const keeper = SURVEY.active;
+  if (!keeper) return;
+  const names = new Set(SURVEY.names);
+  for (const image of S.images) {
+    if (image.name === keeper) enqueuePhotoPatch(image, { status: 'approved' });
+    else if (names.has(image.name)) enqueuePhotoPatch(image, { status: 'skipped' });
+  }
+  refreshLists();
+  if (!await flushEditSaves()) return;
+  toast('Marked the select and rejected the rest');
 }
+if ($('surveyKeep')) $('surveyKeep').onclick = keepSurveySelection;
 
 /* --------------------------------------------------- lens: auto-straighten */
 if ($('autoLevel')) {
@@ -9680,30 +9702,40 @@ async function applyServerStateEvent(event) {
   if (event.client === CLIENT_ID) return;
   const names = Array.isArray(event.names) ? event.names : [];
   const current = cur();
-  for (const name of names) { if (name !== current?.name) photoUndo.clear(name); }
-  if (!current || !names.includes(current.name)) {
-    await reloadLibrary();
+  const patch = event.patch;
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    // IPTC updates do not change the edit recipe. A GET here can read an older
+    // window save and wrongly restore it over newer local editor controls.
+    if (current && names.includes(current.name)) METADATA?.refresh(current.name);
     return;
   }
-  const before = snapshot();
-  const state = await getJSON(`/api/state?name=${encodeURIComponent(current.name)}`);
-  if (!state || state.error || cur()?.name !== current.name) return;
-  pushUndoState(before);
-  Object.assign(current, normalizeLibraryImage({ ...current, ...state }, true));
-  restore(JSON.stringify({
-    params: state.params, grade: state.grade || { ...GRADE_DEFAULTS },
-    crop: state.crop || null, masks: state.masks || [], heals: state.heals || [],
-    optics: state.optics || { ...OPTICS_DEFAULTS },
-  }), null, false);
-  _lastHistorySnapshot = editHistorySnapshot();
-  invalidateEditedThumbnail(current);
+  const currentChanged = current && names.includes(current.name) && S.editingName === current.name;
+  const before = currentChanged ? snapshot() : null;
+  for (const image of S.images) {
+    if (!names.includes(image.name)) continue;
+    if (image !== current) photoUndo.clear(image.name);
+    // The event carries the accepted patch, even if an older browser request
+    // subsequently overwrites it on disk. Repair after that in-flight request,
+    // while keeping unrelated local fields and explicit retry after a failure.
+    if (editSaveQueue.getPending(image.name)) enqueuePhotoPatch(image, patch);
+    else {
+      Object.assign(image, cloneValue(patch));
+      if (image.stateLoadEdits) Object.assign(image.stateLoadEdits, cloneValue(patch));
+    }
+    invalidateEditedThumbnail(image);
+  }
+  if (currentChanged) {
+    pushUndoState(before);
+    restore(JSON.stringify({ ...JSON.parse(before), ...patch }), null, false);
+    _lastHistorySnapshot = editHistorySnapshot();
+    HISTORY?.refresh(current.name, true);
+    const label = event.origin && event.origin !== 'window'
+      ? `Updated by ${event.origin}` : 'Photo updated externally';
+    toast(label, { label: 'Undo', run: undo });
+  }
   refreshLists();
   renderKeywords();
   renderVersions();
-  HISTORY?.refresh(current.name, true);
-  const label = event.origin && event.origin !== 'window'
-    ? `Updated by ${event.origin}` : 'Photo updated externally';
-  toast(label, { label: 'Undo', run: undo });
 }
 
 async function executeUICommand(command, args = {}, event = {}) {

--- a/web/catalog-ui.js
+++ b/web/catalog-ui.js
@@ -6,6 +6,12 @@
  * beyond what it is currently showing.
  */
 
+// Source names, card filenames, and watch names are text from disks and
+// people, never markup.
+const escapeHTML = (value) => String(value ?? '')
+  .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
 export function createCatalogUI(ctx) {
   const { el, post, get, toast, sendNative } = ctx;
   let catalog = null;
@@ -55,11 +61,11 @@ export function createCatalogUI(ctx) {
     }
     container.innerHTML = sources.map((source) => `
       <div class="source-row${source.available ? '' : ' unavailable'}"
-           data-id="${source.id}">
+           data-id="${escapeHTML(source.id)}">
         <button class="source-star${source.favorite ? ' on' : ''}"
                 data-act="favorite" title="Favourite">★</button>
-        <span class="source-name" title="${source.path}">${source.name}</span>
-        <span class="source-count">${source.count || 0}</span>
+        <span class="source-name" title="${escapeHTML(source.path)}">${escapeHTML(source.name)}</span>
+        <span class="source-count">${Number(source.count) || 0}</span>
         <button class="source-act" data-act="rescan" title="Rescan">⟳</button>
         <button class="source-act" data-act="remove" title="Remove from catalog">×</button>
       </div>`).join('') || 'No sources yet.';
@@ -351,8 +357,8 @@ export function createCatalogUI(ctx) {
           grid.innerHTML = (ingestPlan.items || []).slice(0, 200).map((item) => `
             <label class="ingest-cell">
               <input type="checkbox" checked data-source="${encodeURIComponent(item.source)}">
-              <span class="ingest-cell-name">${item.name}</span>
-              <span class="ingest-cell-dest">${item.destination.split('/').slice(-2).join('/')}</span>
+              <span class="ingest-cell-name">${escapeHTML(item.name)}</span>
+              <span class="ingest-cell-dest">${escapeHTML(String(item.destination || '').split('/').slice(-2).join('/'))}</span>
             </label>`).join('');
           el('ingestStatus').textContent =
             `${ingestPlan.total} photos to copy`
@@ -410,10 +416,6 @@ export function createCatalogUI(ctx) {
   }
 
   /* ------------------------------------------------------------- watches */
-
-  const escapeHTML = (value) => String(value ?? '')
-    .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
 
   function renderWatches(statuses = []) {
     const byId = new Map(statuses.map((status) => [status.id, status]));

--- a/web/edit-save-queue.js
+++ b/web/edit-save-queue.js
@@ -16,6 +16,7 @@ function freezePayload(value) {
 
 /**
  * Debounce independently per photo and serialize requests for each photo.
+ * A bounded shared transport pool prevents bulk actions from flooding the server.
  * send(name, payload) must reject on an unsuccessful write. enqueue() never
  * returns a rejecting promise; background failures are retained in getStatus()
  * and onStatus(). A failed photo pauses until retry(), retaining its newest edit.
@@ -25,12 +26,17 @@ function freezePayload(value) {
 export function createEditSaveQueue({
   send,
   delay = 400,
+  maxConcurrent = 4,
   onStatus = () => {},
   setTimeout: schedule = globalThis.setTimeout.bind(globalThis),
   clearTimeout: unschedule = globalThis.clearTimeout.bind(globalThis),
 }) {
   if (typeof send !== 'function') throw new TypeError('An edit save function is required');
-  const entries = new Map();
+  if (!Number.isSafeInteger(maxConcurrent) || maxConcurrent < 1) {
+    throw new RangeError('maxConcurrent must be a positive integer');
+  }
+  const entries = new Map(), ready = new Set();
+  let runningCount = 0;
 
   function getStatus() {
     const active = [...entries.values()];
@@ -56,17 +62,32 @@ export function createEditSaveQueue({
     entry.timer = null;
   }
 
+  function pump() {
+    while (runningCount < maxConcurrent && ready.size) {
+      const entry = ready.values().next().value;
+      ready.delete(entry);
+      if (!entry.error && !entry.running && entry.queued) begin(entry);
+    }
+  }
+
   function start(entry) {
     if (entry.error || entry.running || !entry.queued) return;
     clearTimer(entry);
+    ready.add(entry);
+    pump();
+  }
+
+  function begin(entry) {
     const job = entry.queued;
     entry.queued = null;
     entry.running = job;
+    runningCount++;
     notify();
     // Own both outcomes here so debounce/immediate saves cannot leave an
     // unhandled rejection when their caller has no reason to await a write.
     Promise.resolve().then(() => send(entry.name, job.payload)).then(() => {
       entry.running = null;
+      runningCount--;
       const waiting = [];
       for (const waiter of entry.waiters) {
         if (waiter.revision <= job.revision) waiter.resolve();
@@ -78,8 +99,10 @@ export function createEditSaveQueue({
       // Flush barriers bypass a later edit's debounce, but ordinary subsequent
       // input retains its own debounce window.
       if (entry.queued && (entry.timer === null || waiting.length)) start(entry);
+      else pump();
     }, reason => {
       entry.running = null;
+      runningCount--;
       entry.error = reason instanceof Error ? reason : new Error(String(reason));
       if (!entry.queued) entry.queued = job;
       clearTimer(entry);
@@ -87,6 +110,7 @@ export function createEditSaveQueue({
       entry.waiters = [];
       waiting.forEach(waiter => waiter.reject(entry.error));
       notify();
+      pump();
     });
   }
 
@@ -100,14 +124,18 @@ export function createEditSaveQueue({
     }
     entry.queued = {revision: ++entry.revision, payload: snapshot};
     clearTimer(entry);
-    if (!entry.error && !immediate) {
+    // A flush waiting for a transport slot must not be postponed by later
+    // input. A normal edit still gets its full debounce while slots are busy.
+    const urgent = immediate || (!entry.running && entry.waiters.length > 0);
+    if (!urgent) ready.delete(entry);
+    if (!entry.error && !urgent) {
       entry.timer = schedule(() => {
         entry.timer = null;
         start(entry);
       }, delay);
     }
     notify();
-    if (immediate) start(entry);
+    if (urgent) start(entry);
   }
 
   function selectedEntries(name) {

--- a/web/history-panel.js
+++ b/web/history-panel.js
@@ -8,6 +8,11 @@
 const STEP_LIMIT = 200;
 const COALESCE_MS = 2000;
 
+// Step labels and origins arrive from the CLI and other clients as free text.
+const escapeHTML = (value) => String(value ?? '')
+  .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
 export function createHistoryPanel(ctx) {
   const { el, post, get, toast } = ctx;
   const list = el('historyList');
@@ -44,11 +49,11 @@ export function createHistoryPanel(ctx) {
       return;
     }
     list.innerHTML = steps.map((step) => `
-      <button class="history-step" data-id="${step.id}" type="button">
-        <span class="history-label">${step.label || 'Edit'}</span>
+      <button class="history-step" data-id="${escapeHTML(step.id)}" type="button">
+        <span class="history-label">${escapeHTML(step.label || 'Edit')}</span>
         <span class="history-meta">${timeText(step.created)}${
           step.origin && step.origin !== 'edit'
-            ? ` · ${step.origin}` : ''}</span>
+            ? ` · ${escapeHTML(step.origin)}` : ''}</span>
       </button>`).join('');
   }
 
@@ -94,41 +99,74 @@ export function createHistoryPanel(ctx) {
   function channelFor(name) {
     if (!channels.has(name)) channels.set(name, {
       name, label: '', stateJSON: null, deadline: 0, pending: null,
-      timer: null, tail: Promise.resolve(true), queued: 0,
+      timer: null, tail: Promise.resolve(true), queue: [], failed: false, error: null,
     });
     return channels.get(name);
+  }
+
+  function notifyStatus() {
+    const active = [...channels.values()];
+    ctx.onStatus?.({
+      pendingNames: active.filter(channel => channel.pending || channel.queue.length)
+        .map(channel => channel.name),
+      failedNames: active.filter(channel => channel.failed).map(channel => channel.name),
+      error: active.find(channel => channel.failed)?.error || null,
+    });
   }
 
   function retire(channel) {
     // Retain a recipe only for its active coalescing window or outstanding
     // writes, rather than keeping every visited photo's large mask snapshot.
-    if (!channel.timer && !channel.pending && !channel.queued) {
+    if (!channel.timer && !channel.pending && !channel.queue.length &&
+        channels.get(channel.name) === channel) {
       channels.delete(channel.name);
     }
   }
 
-  function enqueue(channel, path, body) {
-    channel.queued++;
+  function sendQueued(channel, retry = false) {
     channel.tail = channel.tail.then(async () => {
-      const response = await post(path, body);
-      if (response?.error || response?.ok === false) {
-        throw new Error(response.error || 'History request failed');
+      if (retry) {
+        channel.failed = false;
+        channel.error = null;
+        notifyStatus();
       }
-      if (channel.name === currentName) {
-        loadedName = null;
-        void refresh(channel.name);
+      if (channel.failed) return false;
+      while (channel.queue.length) {
+        const { path, body } = channel.queue[0];
+        try {
+          const response = await post(path, body);
+          if (response?.error || response?.ok === false) {
+            throw new Error(response.error || 'History request failed');
+          }
+        } catch (error) {
+          // Keep the failed operation at the head. In particular, neither a
+          // later edit nor Clear may overtake a write awaiting Retry save.
+          channel.failed = true;
+          channel.error = path === '/api/history/clear'
+            ? 'Could not clear photo history' : 'Could not save photo history';
+          toast(channel.error);
+          notifyStatus();
+          return false;
+        }
+        channel.queue.shift();
+        notifyStatus();
+        if (channel.name === currentName) {
+          loadedName = null;
+          void refresh(channel.name);
+        }
       }
       return true;
-    }).catch(() => {
-      channel.stateJSON = null;
-      toast(path === '/api/history/clear'
-        ? 'Could not clear photo history' : 'Could not save photo history');
-      return false;
     }).finally(() => {
-      channel.queued--;
       retire(channel);
+      notifyStatus();
     });
     return channel.tail;
+  }
+
+  function enqueue(channel, path, body) {
+    channel.queue.push({ path, body });
+    notifyStatus();
+    return sendQueued(channel);
   }
 
   function flushPending(channel) {
@@ -160,6 +198,7 @@ export function createHistoryPanel(ctx) {
       if (stateJSON === channel.stateJSON) return;
       channel.stateJSON = stateJSON;
       channel.pending = packet;
+      notifyStatus();
       return;
     }
     flushPending(channel);
@@ -173,8 +212,14 @@ export function createHistoryPanel(ctx) {
 
   function flush(name = null) {
     const selected = [...channels.values()].filter(channel => !name || channel.name === name);
-    for (const channel of selected) finishWindow(channel);
-    return Promise.all(selected.map(channel => channel.tail))
+    const results = selected.map(channel => {
+      // Retry failures already observed by this call. A write that first fails
+      // during this flush remains pending and makes this attempt return false.
+      const retry = channel.failed;
+      finishWindow(channel);
+      return sendQueued(channel, retry);
+    });
+    return Promise.all(results)
       .then(results => results.every(Boolean));
   }
 
@@ -210,10 +255,11 @@ export function createHistoryPanel(ctx) {
   }
 
   render();
+  notifyStatus();
   return {
-    refresh, record, flush,
+    refresh, record, flush, retry: flush,
     get hasPending() {
-      return [...channels.values()].some(channel => channel.pending || channel.queued > 0);
+      return [...channels.values()].some(channel => channel.pending || channel.queue.length > 0);
     },
     get limit() { return STEP_LIMIT; },
   };

--- a/web/metadata-panel.js
+++ b/web/metadata-panel.js
@@ -23,6 +23,12 @@ const FIELDS = {
 
 const GPS_FIELDS = { iptcLat: 'gps_lat', iptcLon: 'gps_lon' };
 
+// Keyword names are typed by people or imported from sidecars written by
+// other software, so they are text, never markup.
+const escapeHTML = (value) => String(value ?? '')
+  .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
 export function createMetadataPanel(ctx) {
   const { el, post, get, toast } = ctx;
   let currentName = null;
@@ -138,10 +144,10 @@ export function createMetadataPanel(ctx) {
         const depth = (keyword.path.match(/ > /g) || []).length;
         return `<button class="keyword-node" type="button"
                   data-path="${encodeURIComponent(keyword.path)}"
-                  data-id="${keyword.id}"
+                  data-id="${escapeHTML(keyword.id)}"
                   style="--depth:${depth}">
-                  <span>${keyword.name}</span>
-                  <span class="keyword-count">${keyword.count || 0}</span>
+                  <span>${escapeHTML(keyword.name)}</span>
+                  <span class="keyword-count">${Number(keyword.count) || 0}</span>
                 </button>`;
       }).join('');
     } catch (error) {


### PR DESCRIPTION
Pending saves could overwrite pasted adjustments, culling flags, or an external edit, while failed history writes were discarded. These operations now share the per-photo save queue with at most four simultaneous requests; accepted state events carry their update values, and failed history operations remain available for ordered retry.

Also completes the pending catalog/UI fixes: source, keyword, collection, and history text is escaped; date-only upper bounds include the entire day; batch rename uses each photo's metadata and handles virtual copies without renaming the same file twice. The full macOS release signer now defers sealing the main app until its nested CLI is signed.

Validation: 913 local tests passed (6 skips), followed by 31 save queue/integration tests and 14 history tests after the final queue limit. The new real-bundle signing regression test passed. The full native package and strict code-signature verification passed. The on-screen photo journey is blocked by the locked macOS session (Metal cannot acquire a drawable); it has not been reported as passing.
