### PR TITLE
Match macOS window-control size and edge spacing

### DIFF
--- a/app/main.swift
+++ b/app/main.swift
@@ -15,7 +15,24 @@ import Sparkle
 
 private enum WindowChrome {
     static let topBarHeight: CGFloat = 48
-    static let trafficLightClearance: CGFloat = 78
+    // A plain titled window uses a tight inset intended for a short title bar.
+    // Take the system metrics from a unified toolbar for our full-height header.
+    static let nativeTrafficLightFrames: [NSRect] = {
+        let reference = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered, defer: false)
+        reference.toolbar = NSToolbar(identifier: "LightTableChromeMetrics")
+        reference.toolbarStyle = .unified
+        reference.contentView?.superview?.layoutSubtreeIfNeeded()
+        return [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton]
+            .compactMap { reference.standardWindowButton($0)?.frame }
+    }()
+    static var trafficLightClearance: CGFloat {
+        guard let first = nativeTrafficLightFrames.first,
+              let last = nativeTrafficLightFrames.last else { return 98 }
+        return ceil(last.maxX + first.minX)
+    }
     static let fallbackBottomDragStripHeight: CGFloat = 8
     static let controlSafetyInset: CGFloat = 2
 }
@@ -841,22 +858,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
               let titlebarView = buttons.first?.superview,
               buttons.allSatisfy({ $0.superview === titlebarView }) else { return }
 
-        // AppKit owns the horizontal metrics; retain them across size normalization.
-        let nativeHorizontalOrigins = buttons.map { $0.frame.origin.x }
-        for button in buttons {
-            button.controlSize = .regular
-            button.sizeToFit()
-        }
-
+        guard !window.styleMask.contains(.fullScreen) else { return }
         let centerFromTop = WindowChrome.topBarHeight / 2
-        for (button, nativeX) in zip(buttons, nativeHorizontalOrigins) {
-            var frame = button.frame
-            frame.origin.x = nativeX
-            frame.origin.y = titlebarView.isFlipped
-                ? centerFromTop - frame.height / 2
-                : titlebarView.bounds.maxY - centerFromTop - frame.height / 2
-            button.frame = frame
+        let center = titlebarView.convert(
+            NSPoint(x: 0, y: window.frame.height - centerFromTop), from: nil)
+        for (button, nativeFrame) in zip(buttons, WindowChrome.nativeTrafficLightFrames) {
+            var frame = nativeFrame
+            frame.origin.y = center.y - frame.height / 2
+            if button.frame != frame { button.frame = frame }
         }
+    }
+
+    func windowDidUpdate(_ notification: Notification) {
+        guard notification.object as? NSWindow === window else { return }
+        // AppKit can restore its title-bar frames after resize/key-window layout.
+        layoutTrafficLights()
     }
 
     func windowDidResize(_ notification: Notification) {

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -708,20 +708,15 @@ process.stdout.write(JSON.stringify({
 
     def test_native_traffic_lights_match_the_unified_header_geometry(self):
         shell = (ROOT / "app" / "main.swift").read_text()
-        self.assertIn("static let trafficLightClearance: CGFloat = 78", shell)
-        self.assertNotIn("trafficLightLeadingInset", shell)
-        self.assertNotIn("trafficLightSpacing", shell)
-        self.assertIn(
-            "let nativeHorizontalOrigins = buttons.map { $0.frame.origin.x }",
-            shell,
-        )
-        self.assertIn(
-            "for (button, nativeX) in zip(buttons, nativeHorizontalOrigins)",
-            shell,
-        )
-        self.assertIn("button.controlSize = .regular", shell)
-        self.assertIn("let centerFromTop = WindowChrome.topBarHeight / 2", shell)
-        self.assertIn("layoutTrafficLights()", shell)
+        self.assertIn('reference.toolbarStyle = .unified', shell)
+        self.assertIn('reference.standardWindowButton($0)?.frame', shell)
+        self.assertIn('return ceil(last.maxX + first.minX)', shell)
+        self.assertIn('zip(buttons, WindowChrome.nativeTrafficLightFrames)', shell)
+        self.assertNotIn('button.sizeToFit()', shell)
+        self.assertIn('let centerFromTop = WindowChrome.topBarHeight / 2', shell)
+        self.assertIn('func windowDidUpdate', shell)
+        self.assertIn('guard !window.styleMask.contains(.fullScreen)', shell)
+        self.assertIn('layoutTrafficLights()', shell)
 
     def test_native_menu_bar_uses_editor_commands_and_state(self):
         shell = (ROOT / "app" / "main.swift").read_text()

--- a/web/style.css
+++ b/web/style.css
@@ -232,7 +232,7 @@ input[type=checkbox]:disabled { opacity:.4; }
   user-select:none;
 }
 /* A desktop host may reserve native window-control space over this surface. */
-.native-shell .topbar { padding-left:var(--native-window-controls-w,78px); }
+.native-shell .topbar { padding-left:var(--native-window-controls-w,98px); }
 .brand-group, .search-group, .top-actions { display:flex; align-items:center; gap:8px; min-width:0; }
 .search-group { gap:12px; }
 .brand {


### PR DESCRIPTION
LightTable kept the narrow window-control inset from a plain title bar inside its taller custom header, leaving the traffic lights too close to the window edge. Read button sizes and horizontal positions from AppKit's unified toolbar, center them in the 48-point header, and reserve matching space for the adjacent sidebar control. Reapply placement after native layout updates while leaving full-screen positioning to AppKit.

Validation: Swift typecheck and signed review-app build passed. The focused native chrome and performance suites ran 75 tests: 74 passed and 1 skipped. Verified the real app visually and through native geometry measurements before and after resize, with 14-point button frames, a 19-point leading inset, and a 24-point center from the top. Repeated native layout updates retained the same geometry.
