### PR TITLE
Keep assisted culling buttons inside the sidebar

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -516,6 +516,8 @@ input[type=checkbox]:disabled { opacity:.4; }
 .ai-cull-disclosure { max-height:260px; overflow-y:auto; }
 .ai-cull-disclosure .cull-group { margin-top:8px; }
 .ai-cull-disclosure .cull-group-title { margin-bottom:2px; color:var(--muted-2); font-size:10px; font-weight:600; text-transform:uppercase; }
+.ai-cull-disclosure .btnrow { flex-direction:column; }
+.ai-cull-disclosure .btnrow button { white-space:normal; overflow-wrap:anywhere; }
 #gridSize { width:100%; }
 
 /* Grid */


### PR DESCRIPTION
The assisted-culling action labels overflow their equal-width buttons in the library sidebar. Stack the two actions at full width and allow longer labels to wrap so each label stays inside its button.

Validation: reproduced the clipping in the running local app, then verified no button or menu overflow at 220px and 196px sidebar widths. Browser console had no errors; `git diff --check` passed. The change is limited to two CSS rules.
