### PR TITLE
Serve the sampling helper for every native surface

### DIFF
--- a/server.py
+++ b/server.py
@@ -1779,8 +1779,6 @@ _BASE_CACHE_BUDGET_BYTES = sum((
     _NATIVE_SURFACE_CACHE_MAX_BYTES, _RENDER_CACHE_MAX_BYTES,
     _ORIGINAL_CACHE_MAX_BYTES, _THUMB_CACHE_MAX_BYTES,
 ))
-NATIVE_BROWSER_HELPER_MAX_WIDTH = int(os.environ.get(
-    "LIGHTTABLE_NATIVE_HELPER_WIDTH", "1100"))
 NATIVE_BROWSER_HELPER_OUTPUT_WIDTH = int(os.environ.get(
     "LIGHTTABLE_NATIVE_HELPER_OUTPUT_WIDTH", "256"))
 
@@ -3201,10 +3199,13 @@ def preview_response(meta: dict, key: str, jpg: Path, native: Path,
     if jpg.exists():
         response["img"] = f"/api/render/image?key={key}"
     if native.exists():
-        surface = native_surface_payload(key, native)
-        response["native"] = surface
-        if surface["width"] <= NATIVE_BROWSER_HELPER_MAX_WIDTH:
-            response["helper"] = f"/api/render/helper?key={key}"
+        response["native"] = native_surface_payload(key, native)
+        # Every native surface advertises a sampling helper. The endpoint
+        # downscales to NATIVE_BROWSER_HELPER_OUTPUT_WIDTH, so a wide settled
+        # render costs no more than an interactive one. Gating on the source
+        # width left the settled render with no sampling pixels at all, which
+        # blanked the scopes, Auto tone, and the white balance/point samplers.
+        response["helper"] = f"/api/render/helper?key={key}"
     return response
 
 

--- a/tests/scope-sampling.test.mjs
+++ b/tests/scope-sampling.test.mjs
@@ -1,0 +1,276 @@
+/* Behavioural cover for the scope panel and the sampling texture it reads.
+ *
+ * The scopes draw from a small WebGL "helper" surface. When the render
+ * response for a settled preview stopped offering that helper, every scope
+ * silently drew an empty canvas. These tests execute the drawing functions
+ * against a recording 2D context so a scope that stops putting pixels on the
+ * canvas, or maps luminance to the wrong row, fails here.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import vm from 'node:vm';
+
+const appSource = readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+
+const slice = (from, to) => {
+  const start = appSource.indexOf(from);
+  const end = appSource.indexOf(to);
+  assert.ok(start >= 0, `app.js must define ${from}`);
+  assert.ok(end > start, `app.js must define ${to} after ${from}`);
+  return appSource.slice(start, end);
+};
+
+/* A 2D context that keeps the pixels the scopes write, so assertions can look
+ * at the canvas rather than at the calls that produced it. */
+function recordingCanvas(width, height) {
+  const buffer = new Uint8ClampedArray(width * height * 4);
+  const noop = () => {};
+  const ctx = {
+    strokeStyle: '', fillStyle: '', lineWidth: 1, font: '',
+    globalCompositeOperation: 'source-over',
+    beginPath: noop, closePath: noop, moveTo: noop, lineTo: noop,
+    stroke: noop, fill: noop, arc: noop, fillRect: noop, fillText: noop,
+    clearRect: noop,
+    measureText: () => ({ width: 8 }),
+    getImageData: (x, y, w, h) => ({ width: w, height: h, data: buffer.slice() }),
+    putImageData: (image) => { buffer.set(image.data); },
+  };
+  return {
+    ctx,
+    cv: { width, height },
+    /* Rows carrying any drawn density, top row first. */
+    litRows() {
+      const rows = [];
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          if (buffer[(y * width + x) * 4 + 3]) { rows.push(y); break; }
+        }
+      }
+      return rows;
+    },
+    litColumns(row) {
+      const columns = [];
+      for (let x = 0; x < width; x++) {
+        if (buffer[(row * width + x) * 4 + 3]) columns.push(x);
+      }
+      return columns;
+    },
+  };
+}
+
+/* The shape GradeRenderer.sample() returns: tightly packed RGBA. */
+function sampleOf(width, height, pixel) {
+  const px = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = pixel(x, y);
+      const offset = (y * width + x) * 4;
+      px[offset] = r; px[offset + 1] = g; px[offset + 2] = b; px[offset + 3] = 255;
+    }
+  }
+  return { px, w: width, h: height };
+}
+
+function scopes({ canvas, sample = null } = {}) {
+  const refreshes = [];
+  const context = vm.createContext({
+    S: { clip: false, gl: sample === null ? null : { sample: () => sample } },
+    $: () => ({ ...(canvas ? canvas.cv : {}),
+      getContext: () => (canvas ? canvas.ctx : null) }),
+    refreshWebGLSamplingSurface: () => refreshes.push(true),
+  });
+  vm.runInContext(
+    `${slice("let scopeMode = 'histogram';", "document.querySelectorAll('[data-scope]')")}
+     globalThis.scopeApi = {
+       drawWaveformScope, drawVectorscope, drawHistogramScope, drawHistogram,
+       setMode(mode) { scopeMode = mode; },
+     };`,
+    context);
+  return { ...context.scopeApi, refreshes };
+}
+
+const WIDTH = 300;
+const HEIGHT = 110;
+/* The waveform maps 0..255 onto the full canvas height, brightest at the top. */
+const rowFor = (value) => HEIGHT - 1 - Math.round((value / 255) * (HEIGHT - 1));
+
+test('the waveform draws pixels for a normal sample', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawWaveformScope(surface.ctx, surface.cv,
+    sampleOf(64, 48, (x) => [x * 4, x * 4, x * 4]));
+  assert.ok(surface.litRows().length > 8,
+    'a gradient must light up many waveform rows, not an empty canvas');
+});
+
+test('the waveform places luminance at the matching IRE row', () => {
+  for (const value of [0, 128, 255]) {
+    const surface = recordingCanvas(WIDTH, HEIGHT);
+    scopes().drawWaveformScope(surface.ctx, surface.cv,
+      sampleOf(32, 24, () => [value, value, value]));
+    assert.deepEqual(surface.litRows(), [rowFor(value)],
+      `a flat ${value} sample belongs on exactly one row`);
+  }
+  assert.equal(rowFor(0), HEIGHT - 1, 'black sits at 0 IRE, the bottom row');
+  assert.equal(rowFor(255), 0, 'white sits at 100 IRE, the top row');
+});
+
+test('the waveform weights luminance rather than averaging channels', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  /* Pure green is much brighter than pure blue under Rec.709 weights. */
+  scopes().drawWaveformScope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [0, 255, 0]));
+  assert.deepEqual(surface.litRows(), [rowFor(255 * 0.7152)]);
+});
+
+test('the RGB parade separates the channels into three columns', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawWaveformScope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [255, 0, 0]), true);
+  const section = Math.floor(WIDTH / 3);
+  const red = surface.litColumns(rowFor(255));
+  const dark = surface.litColumns(rowFor(0));
+  assert.ok(red.length > 0 && red.every((x) => x < section),
+    'a pure red frame lights only the red section at full height');
+  assert.ok(dark.every((x) => x >= section),
+    'the green and blue sections stay at the bottom of the parade');
+});
+
+test('the vectorscope puts a neutral frame at the centre', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawVectorscope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [128, 128, 128]));
+  assert.deepEqual(surface.litRows(), [Math.round(HEIGHT / 2)],
+    'a neutral frame carries no chroma, so it lands on the centre row');
+});
+
+test('the vectorscope pushes a saturated frame away from the centre', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawVectorscope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [220, 30, 30]));
+  const rows = surface.litRows();
+  assert.equal(rows.length, 1);
+  assert.ok(rows[0] < HEIGHT / 2 - 5,
+    'red carries a positive Cr, which plots above the centre line');
+});
+
+
+/* ------------------------------------------------ scope mode dispatch */
+
+test('each scope mode draws through drawHistogram', () => {
+  const modes = ['histogram', 'waveform', 'parade', 'vectorscope'];
+  for (const mode of modes) {
+    const surface = recordingCanvas(WIDTH, HEIGHT);
+    const api = scopes({
+      canvas: surface,
+      sample: sampleOf(48, 32, (x, y) => [x * 5, y * 7, 128]),
+    });
+    api.setMode(mode);
+    api.drawHistogram();
+    assert.equal(api.refreshes.length, 1,
+      `${mode} must refresh the sampling surface before reading it`);
+    if (mode !== 'histogram') {
+      assert.ok(surface.litRows().length > 0,
+        `${mode} must put pixels on the canvas`);
+    }
+  }
+});
+
+test('a scope with no sampling surface draws nothing instead of stale pixels', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  const api = scopes({ canvas: surface, sample: null });
+  api.setMode('waveform');
+  api.drawHistogram();
+  assert.deepEqual(surface.litRows(), [],
+    'without a helper texture the scope leaves a cleared canvas');
+});
+
+/* ----------------------------------------- the sampling helper request */
+
+/* scheduleNativeHelper defers the WebGL sampling texture until interaction
+ * settles. It runs against a fake clock so the ordering is deterministic. */
+function helperHarness() {
+  let now = 0;
+  let nextTimer = 0;
+  const timers = new Map();
+  const loaded = [];
+  const context = vm.createContext({
+    record(url, options) { loaded.push({ url, options: { ...options } }); },
+    performance: { now: () => now },
+    setTimeout(fn, ms) {
+      const id = ++nextTimer;
+      timers.set(id, { fn, at: now + (ms || 0) });
+      return id;
+    },
+    clearTimeout(id) { timers.delete(id); },
+  });
+  vm.runInContext(
+    `let nativeHelperTimer = null;
+     let lastContinuousInputAt = 0;
+     const S = { seq: 0 };
+     function setWebGLBaseImage(url, options) {
+       globalThis.record(url, options);
+       return Promise.resolve({});
+     }
+     ${slice('function scheduleNativeHelper(', 'function setNativeBaseImage(')}
+     globalThis.api = {
+       schedule: scheduleNativeHelper,
+       renderStarts() { return ++S.seq; },
+     };`,
+    context);
+  const api = context.api;
+  return {
+    loaded,
+    renderStarts: api.renderStarts,
+    schedule: api.schedule,
+    advance(ms) {
+      const target = now + ms;
+      for (;;) {
+        const due = [...timers.entries()]
+          .filter(([, timer]) => timer.at <= target)
+          .sort((a, b) => a[1].at - b[1].at)[0];
+        if (!due) break;
+        timers.delete(due[0]);
+        now = due[1].at;
+        due[1].fn();
+      }
+      now = target;
+    },
+  };
+}
+
+test('the settled render loads the sampling helper the interactive one lost', () => {
+  const h = helperHarness();
+  const interactive = h.renderStarts();
+  h.schedule('/api/render/helper?key=interactive', interactive);
+  /* The full-resolution render supersedes it before the deferred fetch runs. */
+  h.advance(161);
+  const settled = h.renderStarts();
+  h.schedule('/api/render/helper?key=settled', settled);
+  h.advance(400);
+  assert.deepEqual(h.loaded.map((entry) => entry.url),
+    ['/api/render/helper?key=settled'],
+    'exactly one helper loads, and it belongs to the settled render');
+  assert.deepEqual(h.loaded[0].options,
+    { preserveCanvasSize: true, forceWebGLDraw: true, generation: settled });
+});
+
+test('a superseded helper never overwrites the current sampling texture', () => {
+  const h = helperHarness();
+  const stale = h.renderStarts();
+  h.schedule('/api/render/helper?key=stale', stale);
+  h.renderStarts();
+  h.advance(400);
+  assert.deepEqual(h.loaded, [],
+    'the generation guard drops a helper whose render was replaced');
+});
+
+test('a render without a helper leaves the pending request armed', () => {
+  const h = helperHarness();
+  const generation = h.renderStarts();
+  h.schedule('/api/render/helper?key=only', generation);
+  h.schedule(undefined, generation);
+  h.advance(400);
+  assert.deepEqual(h.loaded.map((entry) => entry.url),
+    ['/api/render/helper?key=only']);
+});

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -252,6 +252,50 @@ class ResponsivePreviewTests(unittest.TestCase):
             with Image.open(helper) as image:
                 self.assertEqual(image.size, (256, 171))
 
+    def test_every_native_surface_offers_a_sampling_helper(self):
+        """Scopes, Auto tone, and the samplers read a WebGL helper texture.
+
+        A photo is rendered twice: an interactive preview and, once the view
+        settles, a wider full-resolution one. Both have to offer a helper. When
+        the response for the settled render omitted it, the browser was left
+        with no sampled pixels at all and every scope drew an empty canvas.
+        """
+        interactive, settled = 1100, 3000
+        with tempfile.TemporaryDirectory() as directory:
+            folder = Path(directory)
+            for width in (interactive, settled):
+                native = folder / f"render-{width}.rgba"
+                server.write_native_surface(
+                    native, np.zeros((120, width, 3), dtype=np.uint8))
+                response = server.preview_response(
+                    {"ms": 1}, "a" * 32, folder / "missing.jpg", native,
+                    cached=False, refining=False)
+                self.assertEqual(response["native"]["width"], width)
+                self.assertEqual(
+                    response.get("helper"),
+                    f"/api/render/helper?key={'a' * 32}",
+                    f"a {width}px native surface must offer a sampling helper",
+                )
+
+    def test_sampling_helper_cost_does_not_grow_with_the_settled_surface(self):
+        """The helper is always encoded at the sampling width, so serving one
+        for a full-resolution surface stays as cheap as the interactive one."""
+        with tempfile.TemporaryDirectory() as directory:
+            folder = Path(directory)
+            sizes = []
+            for width, height in ((1100, 874), (3000, 2382)):
+                native = folder / f"render-{width}.rgba"
+                helper = folder / f"render-{width}.jpg"
+                server.write_native_surface(
+                    native, np.full((height, width, 3), 127, dtype=np.uint8))
+                server.ensure_jpeg_surface(
+                    helper, native, server.NATIVE_BROWSER_HELPER_OUTPUT_WIDTH)
+                with Image.open(helper) as image:
+                    sizes.append(image.size)
+        self.assertEqual(sizes[0][0], server.NATIVE_BROWSER_HELPER_OUTPUT_WIDTH)
+        self.assertEqual(sizes[1][0], server.NATIVE_BROWSER_HELPER_OUTPUT_WIDTH)
+        self.assertEqual(sizes[0], sizes[1])
+
     def test_resampling_edits_fall_back_to_the_edited_image(self):
         with tempfile.TemporaryDirectory() as directory:
             cache = Path(directory)
@@ -830,6 +874,21 @@ process.stdout.write(JSON.stringify(states.map(nativePreviewCanDraw)));
         self.assertIn("preserveCanvasSize: true", helper)
         self.assertIn("forceWebGLDraw: true", helper)
         self.assertIn("generation,", helper)
+        # A response that carries no dedicated helper still presents a JPEG
+        # surface, and sampling falls back to it rather than going blind.
+        native_loader = self.javascript[
+            self.javascript.index("function setNativeBaseImage"):
+            self.javascript.index("function originalPreviewURL")
+        ]
+        self.assertIn("scheduleNativeHelper(render.helper || render.img, generation)",
+                      native_loader)
+        # Cancelling the pending helper when a render starts stranded the
+        # sampling surface, because the early return skips the generation bump.
+        render_preamble = self.javascript[
+            self.javascript.index("async function doRender("):
+            self.javascript.index("const my = ++S.seq;")
+        ]
+        self.assertNotIn("clearTimeout(nativeHelperTimer)", render_preamble)
         webgl_loader = self.javascript[
             self.javascript.index("function setWebGLBaseImage"):
             self.javascript.index(

--- a/tests/test_scope_sampling.py
+++ b/tests/test_scope_sampling.py
@@ -1,0 +1,16 @@
+"""Run the scope and sampling-helper regressions in the Python CI suite."""
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+@unittest.skipUnless(shutil.which('node'), 'Node.js required')
+class ScopeSamplingTests(unittest.TestCase):
+    def test_scopes_and_sampling_helper(self):
+        test_file = Path(__file__).with_name('scope-sampling.test.mjs')
+        result = subprocess.run(
+            ['node', '--test', str(test_file)],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/web/app.js
+++ b/web/app.js
@@ -3156,7 +3156,9 @@ function renderPhysicalPreview() {
 async function doRender(scheduledAt = performance.now(), options = {}) {
   clearTimeout(prefetchTimer);
   clearTimeout(refineTimer);
-  clearTimeout(nativeHelperTimer);
+  // A pending helper is left alone. Its own generation guard drops a
+  // superseded fetch, while the early return below happens before the
+  // generation is bumped, so cancelling here stranded the sampling surface.
   const im = cur();
   if (!im) return;
   readControls();
@@ -3469,8 +3471,9 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
   scheduleNativeViewportLayout();
 
   // Histogram, WB sampling, and reference matching retain a 256px WebGL
-  // helper, generated only after interaction settles.
-  scheduleNativeHelper(render.helper, generation);
+  // helper, generated only after interaction settles. A response without a
+  // helper still presents a JPEG surface, which seeds sampling just as well.
+  scheduleNativeHelper(render.helper || render.img, generation);
 
   return new Promise((resolve) => {
     nativePreviewPending.set(generation, { resolve });


### PR DESCRIPTION
## The bug

In the native Metal build every scope drew an empty canvas — histogram, waveform, parade and vectorscope alike — and Auto tone, the white balance dropper and the point colour sampler all reported that they were waiting for a preview.

Those tools do not read the Metal surface. They read a small WebGL "helper" texture that the render response advertises. `preview_response` only attached that helper when the native surface was at most 1100px wide, so the settled full-resolution render offered none.

On a Retina display at Auto width a photo renders twice: an interactive 1100px frame, which carried a helper, and a settled bucket such as 3000px, which did not. The settled render superseded the interactive one before its deferred fetch ran, so `S.gl` was never created and `drawHistogram()` returned early for the rest of the session. The render cache confirmed it — 1100px and 3000px surface pairs with the helper endpoint never once requested.

## The fix

Every native surface now advertises a helper. The gate is removed rather than raised, because the helper is downscaled to 256px whatever the source size, so a wide surface is no more expensive to serve:

| Surface | Helper encode | Result |
|---|---|---|
| 1100 × 874 | 12 ms | 256 × 171 |
| 3000 × 2382 | 27 ms | 256 × 171 |
| 6000 × 4000 | 80 ms | 256 × 171 |

It is encoded lazily once interaction settles, serialized, and cached to disk, so it never sits on the interactive path.

Two smaller repairs in the browser. `doRender` no longer cancels a pending helper: its early return runs before the generation is bumped, which stranded the request. And a response with no dedicated helper now seeds sampling from the JPEG surface it does present.

Verified end to end on a 4128 × 2752 fixture — both the interactive and the settled render supply a 256 × 171 texture whose pixels span 0 to 248.

## Tests

The scope panel's only coverage was an assertion that the string `drawWaveformScope` appeared in `app.js`, and the server-side helper test used a 4px surface that always passed the gate. Neither could see this.

`tests/scope-sampling.test.mjs` now executes the real code. The drawing functions run against a recording 2D context, and the deferred helper request runs against a fake clock:

- luminance lands on the matching IRE row, black at the bottom and white at the top
- Rec.709 weighting rather than a flat channel average
- the parade splits into three columns
- the vectorscope centres a neutral frame and pushes red above the centre line
- every scope mode draws through `drawHistogram`, and a missing sampling surface leaves a cleared canvas
- the settled render loads the helper the interactive one lost, a superseded helper never overwrites the current texture, and a helper-less render leaves the pending request armed

On the server, a preview response must offer a helper at both preview widths, and the encode stays bounded to the sampling width.

Mutation-checked: removing the waveform's vertical flip, disabling the pixel write, swapping the luma weights for a flat average, disabling waveform dispatch, and reintroducing the timer cancellation each fail between one and seven of the new tests. The width-gate test fails on the old server with `a 3000px native surface must offer a sampling helper`.

## Test run

1021 Python tests and all 11 Node files. 13 failures and 1 error in `test_film_pipeline` and `test_settings` are identical on pristine `main` in the same worktree and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)