### PR TITLE
Integrate setup, help, performance, and platform reliability improvements

### DIFF
--- a/.github/workflows/help-content.yml
+++ b/.github/workflows/help-content.yml
@@ -1,0 +1,27 @@
+name: In-app help
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  help:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Source-linked help and search
+        run: |
+          python3 scripts/help_content.py check
+          python3 -m unittest discover -s tests -p 'test_help_content.py' -v
+          node --test tests/help-search.test.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ is the catalog's only writer and owns its render caches and resident GPU engine.
   results from a successful state write.
 - External edits are attributed in History, refresh in the open window, and
   provide Undo. Respect the window's automation preference.
+- When changing user-facing behavior, run `python3 scripts/help_content.py status`
+  and review affected articles in `docs/help/`. Keep help, source evidence, and
+  the bundled content in the same change. Follow `docs/help/README.md`; never
+  automatically acknowledge reviews to silence a failing help check.
 - Plan destructive work first. Generic destructive route calls require `--yes`,
   and originals may only move through the recoverable trash workflow.
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,104 @@
+# Preview and export performance
+
+The September 2026 changes target first open, film controls, actual-size viewing,
+export, and initial thumbnail fill. Export pixels and user state remain durable;
+only reproducible caches use atomic publication without filesystem synchronization.
+Malformed generated TIFF/JPEG files are discarded and rebuilt.
+
+## Implemented paths
+
+- Embedded RAW camera JPEGs use DCT draft decoding and a source-versioned,
+  byte-bounded cache shared by provisional film input and Before/Match.
+  JPEG/HEIC previews decode and color-convert at preview size; full-resolution
+  TIFF conversion remains available for exports.
+- Startup executes a small native render for the default and last-used stock/
+  paper pairs, compiling the actual film and native packing shaders. Ordinary
+  native responses obtain camera/lens identity from the catalog; enabled lens
+  corrections still retrieve focal length/aperture from full metadata.
+- Resident spectral state and developed-film checkpoints survive print-stage
+  changes, including enlarger filtration, preflash, paper, glare, scanner blur,
+  sharpening, and output recipes. Direct-positive scanner reference adjustments
+  that physically affect capture correctly invalidate the film checkpoint.
+- Film requests adapt their interval to measured round trips. HTTP/1.1 reuses
+  connections; event streams remain close-delimited and rejected requests close
+  their connection so unread bodies cannot become another request.
+- Export, prefetch, and edited-thumbnail renders use a separate resident engine
+  and admission gate. An input probe skips repeated full RAW decoding. Export
+  responses/status expose phase timings for input exchange, engine work, ICC,
+  metadata, finishing, and publication.
+- The GPU rotates, packs RGBA, and computes the native mean. Immutable POSIX
+  shared surfaces feed mmap-backed Metal textures without an HTTP fetch or
+  texture upload. A bounded server cache owns/unlinks them; disk and browser
+  fallbacks are produced lazily. This is shared-memory transport, not IOSurface.
+- Native 1:1 renders request an output-oriented pixel rectangle. The renderer
+  retains full-frame metering and pixel pitch, uses absolute grain/glare
+  coordinates, and includes the required spatial-kernel margin. Panning retains
+  a full-frame fallback while the next tile arrives. Browser previews, diffusion,
+  and unsupported edit combinations retain full-frame behavior.
+- Scan-time source thumbnails use one bounded, cancellable background worker,
+  yielding to interaction. Measured RAW thumbnails retain rawpy: ImageIO was
+  slower on the tested NEF and CR2 files.
+- macOS packaging adds a reproducible, relocatable OpenMP decoder for Bayer
+  while preserving the stock decoder for X-Trans. See
+  [RAW runtime details](packaging/README-rawpy.md) for the source pins, macOS 13
+  dependency checks, and the unresolved upstream X-Trans limitation.
+
+## Measured verification
+
+Measurements below are local runs on the same Apple-silicon Mac. Engine tests
+use synthetic textured input to make exact comparisons repeatable; cold input
+and application journeys use real-photo fixtures. They are not input-to-photon
+latency claims.
+
+| Measurement | Before | After |
+| --- | ---: | ---: |
+| Cold NEF input preparation plus Match, 1100px | 174ms | 72ms |
+| Cold 24MP JPEG preview preparation | 573ms | 47ms |
+| 24MP Bayer DNG decode, stock versus 8-thread decoder | 741ms | 437ms |
+| Downstream film controls, 1100px GPU median | 12.43ms | 4.49ms |
+| Downstream film controls, 2200px GPU median | 52.24ms | 18.40ms |
+| Eligible 2200px full render versus viewport GPU median | 42.61ms | 3.61ms |
+| Native pack/publish, 2200px median | CPU packing replaced | 0.595ms |
+
+Checkpoint tests compare 53 cases at both 1100 and 2200px byte for byte, plus an
+independently rebuilt spectral-pipeline reference. Viewport tests compare 48
+cases at each size against exact full-frame float32 crops, including rotation,
+panning, frame edges, grain, glare, scanner kernels, and full-frame fallbacks.
+Native transport tests compare every RGBA byte for disk/shared and full/viewport
+outputs, and real Metal tests cover padded rows, mapping lifetime after unlink,
+and tile sampling with a retained full-frame texture.
+
+The real macOS photo journey verifies native presentation, navigation, edit
+recovery, film controls, completed actual-size tiles, panning, return to Fit,
+and export in a disposable catalog. Export integration also verifies a second
+export uses resident input and that a preview completes during another export.
+The final native journey's uncached viewport film adjustment completed in 41ms
+including the request and Metal presentation acknowledgement. The separate RAW
+integration run completed a preview in 27ms during a 507ms export; repeated
+export avoided decoding and completed in 460ms versus 1363ms on the first run.
+
+Local JSON evidence and the actual macOS screenshot are retained in
+`bench/results/remaining-performance/` (ignored build evidence). The native
+journey used a separate ad-hoc signed review app with the new decoder runtime;
+the personal app was not replaced, and a full distributable release was not
+built or published.
+
+The final Python suite ran 1044 tests successfully with four skips: the optional
+Git LFS RAW scan fixture suite and three Windows signing checks requiring
+PowerShell. All 18 Rust tests passed. Separate real RAW comparisons and native
+Metal journeys provide the RAW and macOS runtime evidence described above.
+
+## Repeatable checks
+
+```sh
+python -m unittest discover -s tests -q
+cargo test --locked --manifest-path rust-engine/Cargo.toml
+python rust-engine/bench_resident_cache.py --data engine/data --width 2200
+python rust-engine/bench_resident_cache.py --data engine/data --width 128 --fresh-pipeline-check
+python rust-engine/bench_viewport.py --data engine/data --width 2200
+python rust-engine/bench_native_surface.py --data engine/data --width 2200
+python scripts/native-app-smoke.py --app /path/to/LightTable.app --layer pr
+```
+
+The native checks need real Metal/shared-memory access and a connected macOS
+window session. A headless or sandbox-denied run cannot establish native proof.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Rust and GPU-driven render core, and physical film simulation built on
 [Get started](#get-started) ·
 [Contribute](#contributing)
 
+For searchable guides inside the app, click **Help** in the top bar or press
+**F1** or **?**. Help is bundled for offline use and linked from inspector
+sections. Contributors can follow [Maintaining in-app help](docs/help/README.md)
+to keep articles and their implementation evidence current.
+
 [![LightTable's native macOS Film workspace, showing film stock and physical print controls](https://lighttable.app/screenshots/film-controls.webp)](https://lighttable.app/screenshots.html)
 
 ## Maintainers wanted

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,6 +8,7 @@ license, and attribution notices remain in their source files and license texts.
 - [Sparkle](https://github.com/sparkle-project/Sparkle), version 2.9.6, supplies macOS updates. Its framework retains its license notices.
 - SCUNet network code is Apache-2.0 and the selected Kai Zhang denoising weights carry the recorded MIT license. `scripts/fetch-models.py` records the sources and hashes; release bundles include the model license texts and conversion provenance.
 - Python dependencies and native components retain their individual distribution metadata. Their pinned versions are recorded in `requirements-runtime.lock`, `packaging/runtime-windows.lock`, and Cargo lockfiles.
+- macOS builds compile rawpy 0.26.1 and LibRaw 0.22.0 with OpenMP. `scripts/build-rawpy-openmp.sh` pins source commits; `scripts/build-rawpy-native.sh` pins source archives for LLVM OpenMP 19.1.7, libjpeg-turbo 3.2.0, Jasper 4.2.8, and Little CMS 2.19.1, compiled for macOS 13. Their license texts are installed in `licenses/rawpy-openmp`. The GPL demosaic packs remain disabled. `packaging/libraw-xtrans-determinism.patch` disables the in-place X-Trans tile loop's unsafe parallelism; other LibRaw stages retain OpenMP.
 - Small real-photo test fixtures retain their individual CC0 source records in `tests/fixtures/photos/provenance.json`. They are excluded from installed app payloads.
 
 Build scripts fetch pinned upstream sources rather than copying development

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -27,6 +27,10 @@ registry key is `LightTable`, publisher is `Nicholas Reville`, and the
 `QuietUninstallString` supports `/S` for WinGet and other package managers.
 Uninstall removes shipped files, shortcuts, and the CLI's PATH entry. Catalogs,
 preferences, caches, photos, and unrelated files in the install directory remain.
+Nothing LightTable writes at runtime lands in the install directory: the
+catalog, preferences, desktop settings, server log, render caches, compiled
+Python bytecode, compiled numba kernels, and the WebView2 profile all live
+under `%LOCALAPPDATA%\LightTable`.
 
 For the portable ZIP, extract its `LightTable` folder, open `LightTable.exe`, or
 run `LightTable\lighttable.cmd --help`. A package manager can shim
@@ -99,12 +103,51 @@ replacement for the macOS implementation.
 This separation is intentional: platform work should not add a conditional to
 the measured render loop unless the operating system genuinely requires one.
 
+## Runtime layout
+
+The embedded Python runtime ships a `python313._pth` file, and CPython treats
+that file as a request for isolated mode: `PYTHONPATH`, `PYTHONUNBUFFERED`,
+`PYTHONPYCACHEPREFIX`, and every other `PYTHON*` variable are ignored. The
+desktop shell and `lighttable.cmd` therefore pass what matters as interpreter
+options: `-u` keeps `server.log` current, and `-X pycache_prefix` caches
+bytecode under `%LOCALAPPDATA%\LightTable\python-bytecode` so the second
+launch skips recompiling the application and its scientific dependencies.
+`NUMBA_CACHE_DIR` (honoured, because it is not a `PYTHON*` variable) keeps
+compiled kernels under `%LOCALAPPDATA%\LightTable\compiled-runtime`, and the
+WebView2 profile lives under `%LOCALAPPDATA%\LightTable\WebView2` rather than
+beside the executable. The install directory stays read-only in practice.
+
+The shell opens its window immediately with a dark loading page and starts the
+render server on a background thread, so the first frame no longer waits for
+Python imports and catalog opening. Choosing another folder stops the running
+server before starting its replacement, because one catalog holds one process
+lease; a choice made while a start is in flight waits its turn, and a folder
+whose server cannot start returns to the previous one with a toast. The window
+remembers its size and maximized state, fits the current display, and uses the
+dark title bar and WebView2 colour scheme.
+
+Every helper the server starts (the resident engine, the one-shot exporter, the
+export worker, git) runs with `CREATE_NO_WINDOW`; under a console-less parent a
+console-subsystem child would otherwise open a visible command window. The
+OpenMP, numba, and BLAS pools use half the logical processors, between four and
+eight, instead of the fixed four the macOS host uses.
+
 ## Performance path
 
 The resident renderer remains a separate long-lived process on both platforms,
 so GPU device creation, pipeline compilation, profile loading, and decoded
 inputs stay warm. Adding Windows therefore does not force the Mac through a
 portable renderer or a cross-platform desktop framework.
+
+Decoded RGB16 pixels reach the resident engine through memory on Windows as
+they do on macOS. `multiprocessing.shared_memory` creates a named file mapping,
+the engine opens it with `OpenFileMappingW`, maps exactly the protocol length,
+and copies the pixels into its resident input cache before replying; the Python
+side releases the mapping afterwards. A full-resolution RAW export therefore no
+longer writes and re-reads a six-byte-per-pixel TIFF, and first previews at a
+new size skip the disk as well. The TIFF route remains the fallback, and an
+engine that reports the exchange unavailable is remembered so later renders go
+straight to TIFF.
 
 If future measurement shows that webview texture upload and paint dominate at
 large preview sizes, each native host can add a child WGPU viewport while
@@ -121,3 +164,7 @@ require another application rewrite or a forked Windows pipeline.
    packaged runtime.
 4. Open the installed app on Windows and verify a RAW preview, a processed-file
    preview, folder operations, preset save, and an RGB16 TIFF export.
+5. Confirm a RAW export reports `input_transport: shared-memory-rgb16`, that a
+   second launch starts faster than the first, that no command window appears
+   while rendering, and that switching folders shows the loading page rather
+   than a frozen window.

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -29,6 +29,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>LightTable reads your Photos library to copy original photos into your LightTable import folder. Your Photos library is never changed.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/app/NativePreview.metal
+++ b/app/NativePreview.metal
@@ -15,6 +15,7 @@ struct GradeUniforms {
     float4 detail1;     // luminance noise, color noise, red/cyan CA, blue/yellow CA
     float4 curveOn;
     float4 viewport;    // UV scale x/y, offset x/y
+    float4 sourceRegion; // tile span and origin in full-frame UV
     float4 compare;     // original-image wipe position, 0 disables
     float4 reference0;  // active, split mode, amount, scale
     float4 reference1;  // x/y offset, reserved
@@ -87,16 +88,25 @@ vertex VertexOut nativePreviewVertex(uint vertexID [[vertex_id]]) {
 
 constant float3 LUMA = float3(0.2126, 0.7152, 0.0722);
 
-float3 sampleSource(texture2d<float> image, sampler linearSampler,
-                    float2 coordinate, float2 texel,
-                    float redCyan, float blueYellow) {
+float3 sampleFrame(texture2d<float> image, texture2d<float> fallback,
+                   sampler linearSampler, float2 coordinate, float4 region) {
     coordinate = clamp(coordinate, 0.0, 1.0);
-    float3 base = image.sample(linearSampler, coordinate).rgb;
+    float2 tile = (coordinate - region.zw) / region.xy;
+    if (any(tile < 0.0) || any(tile > 1.0)) {
+        return fallback.sample(linearSampler, coordinate).rgb;
+    }
+    return image.sample(linearSampler, tile).rgb;
+}
+
+float3 sampleSource(texture2d<float> image, texture2d<float> fallback, sampler linearSampler,
+                    float2 coordinate, float2 texel,
+                    float redCyan, float blueYellow, float4 region) {
+    float3 base = sampleFrame(image, fallback, linearSampler, coordinate, region);
     float2 radial = coordinate - 0.5;
-    float red = image.sample(linearSampler, clamp(
-        coordinate + radial * texel * redCyan * 6.0, 0.0, 1.0)).r;
-    float blue = image.sample(linearSampler, clamp(
-        coordinate + radial * texel * blueYellow * 6.0, 0.0, 1.0)).b;
+    float red = sampleFrame(image, fallback, linearSampler,
+        coordinate + radial * texel * redCyan * 6.0, region).r;
+    float blue = sampleFrame(image, fallback, linearSampler,
+        coordinate + radial * texel * blueYellow * 6.0, region).b;
     return float3(red, base.g, blue);
 }
 
@@ -120,16 +130,16 @@ float2 manualSourceCoordinate(float2 uv, constant GradeUniforms &grade,
     return projected * factor * halfSize / dimensions + 0.5;
 }
 
-float3 sampleEditedSource(texture2d<float> image, sampler linearSampler,
+float3 sampleEditedSource(texture2d<float> image, texture2d<float> fallback, sampler linearSampler,
                           float2 outputCoordinate, constant GradeUniforms &grade,
                           float2 texel, float redCyan, float blueYellow) {
     float radiusSquared = 0.0;
-    float2 dimensions = float2(image.get_width(), image.get_height());
+    float2 dimensions = float2(image.get_width(), image.get_height()) / grade.sourceRegion.xy;
     float2 coordinate = manualSourceCoordinate(
         outputCoordinate, grade, dimensions, radiusSquared);
     if (any(coordinate < 0.0) || any(coordinate > 1.0)) return 0.0;
     float3 color = sampleSource(
-        image, linearSampler, coordinate, texel, redCyan, blueYellow);
+        image, fallback, linearSampler, coordinate, texel, redCyan, blueYellow, grade.sourceRegion);
     if (grade.optics1.y != 0.0) {
         float radial = clamp(radiusSquared / 2.0, 0.0, 1.5);
         color *= 1.0 + grade.optics1.y * 0.8 * radial;
@@ -138,11 +148,11 @@ float3 sampleEditedSource(texture2d<float> image, sampler linearSampler,
 }
 
 float3 applyHeals(float3 color, float2 uv,
-                  texture2d<float> image, sampler linearSampler,
+                  texture2d<float> image, texture2d<float> fallback, sampler linearSampler,
                   constant GradeUniforms &grade,
                   constant HealUniform *heals,
                   float2 texel, float redCyan, float blueYellow) {
-    float2 dimensions = float2(image.get_width(), image.get_height());
+    float2 dimensions = float2(image.get_width(), image.get_height()) / grade.sourceRegion.xy;
     float minimum = max(min(dimensions.x, dimensions.y), 1.0);
     uint count = min(uint(max(grade.optics1.z, 0.0)), 16u);
     for (uint index = 0; index < count; index++) {
@@ -159,17 +169,17 @@ float3 applyHeals(float3 color, float2 uv,
         if (spot.settings.w < 1.5) {
             float2 ring = radius * minimum / dimensions * 1.25;
             replacement = (
-                sampleEditedSource(image, linearSampler, target + float2(ring.x, 0.0),
+                sampleEditedSource(image, fallback, linearSampler, target + float2(ring.x, 0.0),
                     grade, texel, redCyan, blueYellow)
-                + sampleEditedSource(image, linearSampler, target - float2(ring.x, 0.0),
+                + sampleEditedSource(image, fallback, linearSampler, target - float2(ring.x, 0.0),
                     grade, texel, redCyan, blueYellow)
-                + sampleEditedSource(image, linearSampler, target + float2(0.0, ring.y),
+                + sampleEditedSource(image, fallback, linearSampler, target + float2(0.0, ring.y),
                     grade, texel, redCyan, blueYellow)
-                + sampleEditedSource(image, linearSampler, target - float2(0.0, ring.y),
+                + sampleEditedSource(image, fallback, linearSampler, target - float2(0.0, ring.y),
                     grade, texel, redCyan, blueYellow)) * 0.25;
         } else {
             replacement = sampleEditedSource(
-                image, linearSampler, uv + source - target,
+                image, fallback, linearSampler, uv + source - target,
                 grade, texel, redCyan, blueYellow);
         }
         color = mix(color, replacement, clamp(weight, 0.0, 1.0));
@@ -324,18 +334,18 @@ float3 applySoftProof(float3 color, float4 proof, float2 position) {
 }
 
 float3 localGrade(float3 color, float4 tone, float4 localColorValue,
-                  float4 detail, float2 uv, texture2d<float> image,
+                  float4 detail, float2 uv, texture2d<float> image, texture2d<float> fallback,
                   sampler linearSampler, constant GradeUniforms &grade,
                   float2 texel) {
     if (detail.x != 0.0 || detail.y != 0.0) {
         float3 blur = (color
-            + sampleEditedSource(image, linearSampler, uv + float2(texel.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
                                  grade, texel, grade.detail1.z, grade.detail1.w)
-            + sampleEditedSource(image, linearSampler, uv - float2(texel.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
                                  grade, texel, grade.detail1.z, grade.detail1.w)
-            + sampleEditedSource(image, linearSampler, uv + float2(0.0, texel.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, texel.y),
                                  grade, texel, grade.detail1.z, grade.detail1.w)
-            + sampleEditedSource(image, linearSampler, uv - float2(0.0, texel.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, texel.y),
                                  grade, texel, grade.detail1.z, grade.detail1.w)) / 5.0;
         float3 localDetail = color - blur;
         color = clamp(color + localDetail * detail.x * 1.1, 0.0, 1.0);
@@ -380,7 +390,7 @@ float3 localGrade(float3 color, float4 tone, float4 localColorValue,
 }
 
 float3 applyLocal(float3 color, float geometric, constant LocalUniform &local,
-                  float2 uv, texture2d<float> image, sampler linearSampler,
+                  float2 uv, texture2d<float> image, texture2d<float> fallback, sampler linearSampler,
                   constant GradeUniforms &grade, float2 texel) {
     float4 tone = local.tone;
     float4 localColorValue = local.color;
@@ -403,7 +413,7 @@ float3 applyLocal(float3 color, float geometric, constant LocalUniform &local,
     float weight = clamp(geometric * localColorValue.w * lower * upper
                          * colorWeight, 0.0, 1.0);
     return mix(color, localGrade(color, tone, localColorValue, local.detail,
-        uv, image, linearSampler, grade, texel), weight);
+        uv, image, fallback, linearSampler, grade, texel), weight);
 }
 
 fragment float4 nativePreviewFragment(
@@ -413,6 +423,7 @@ fragment float4 nativePreviewFragment(
     texture2d<float> original [[texture(2)]],
     texture2d<float> masks [[texture(3)]],
     texture2d<float> reference [[texture(4)]],
+    texture2d<float> fallback [[texture(5)]],
     sampler linearSampler [[sampler(0)]],
     constant GradeUniforms &grade [[buffer(0)]],
     constant HealUniform *heals [[buffer(1)]],
@@ -446,20 +457,20 @@ fragment float4 nativePreviewFragment(
     float redCyan = grade.detail1.z;
     float blueYellow = grade.detail1.w;
     float3 color = sampleEditedSource(
-        image, linearSampler, uv, grade, texel, redCyan, blueYellow);
+        image, fallback, linearSampler, uv, grade, texel, redCyan, blueYellow);
     color = applyHeals(
-        color, uv, image, linearSampler, grade, heals,
+        color, uv, image, fallback, linearSampler, grade, heals,
         texel, redCyan, blueYellow);
 
     if (luminanceNoise != 0.0 || colorNoise != 0.0) {
         float3 blur = (color
-            + sampleEditedSource(image, linearSampler, uv + float2(texel.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv - float2(texel.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv + float2(0.0, texel.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv - float2(0.0, texel.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)) / 5.0;
         float luminance = dot(color, LUMA);
         float blurLuminance = dot(blur, LUMA);
@@ -478,13 +489,13 @@ fragment float4 nativePreviewFragment(
 
     if (texture != 0.0 || clarity != 0.0) {
         float3 blur = (color
-            + sampleEditedSource(image, linearSampler, uv + float2(texel.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv - float2(texel.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv + float2(0.0, texel.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv - float2(0.0, texel.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)) / 5.0;
         float3 detail = color - blur;
         color = clamp(color + detail * texture * 1.1, 0.0, 1.0);
@@ -495,13 +506,13 @@ fragment float4 nativePreviewFragment(
     if (sharpness != 0.0) {
         float2 radius = texel * sharpenRadius;
         float3 blur = (color
-            + sampleEditedSource(image, linearSampler, uv + float2(radius.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(radius.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv - float2(radius.x, 0.0),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(radius.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv + float2(0.0, radius.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, radius.y),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, linearSampler, uv - float2(0.0, radius.y),
+            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, radius.y),
                                  grade, texel, redCyan, blueYellow)) / 5.0;
         float3 detail = color - blur;
         float luminanceDetail = dot(detail, LUMA);
@@ -658,13 +669,13 @@ fragment float4 nativePreviewFragment(
         float4 maskValues = masks.sample(linearSampler, clamp(maskUv, 0.0, 1.0));
         int base = tile * 4;
         color = applyLocal(color, maskValues.r, locals[base], uv,
-            image, linearSampler, grade, texel);
+            image, fallback, linearSampler, grade, texel);
         color = applyLocal(color, maskValues.g, locals[base + 1], uv,
-            image, linearSampler, grade, texel);
+            image, fallback, linearSampler, grade, texel);
         color = applyLocal(color, maskValues.b, locals[base + 2], uv,
-            image, linearSampler, grade, texel);
+            image, fallback, linearSampler, grade, texel);
         color = applyLocal(color, maskValues.a, locals[base + 3], uv,
-            image, linearSampler, grade, texel);
+            image, fallback, linearSampler, grade, texel);
     }
     color = applySoftProof(color, grade.softProof, input.position.xy);
     if (grade.reference0.x > 0.5) {

--- a/app/NativePreview.swift
+++ b/app/NativePreview.swift
@@ -1,5 +1,11 @@
 import AppKit
 import MetalKit
+import Darwin
+
+// Darwin imports shm_open as unavailable because its mode argument is variadic.
+// Opening an existing server-owned segment needs only the two fixed arguments.
+@_silgen_name("shm_open")
+private func openNativeSharedMemory(_ name: UnsafePointer<CChar>, _ flags: Int32) -> Int32
 
 struct NativeSurfaceDescription {
     let url: URL
@@ -8,17 +14,92 @@ struct NativeSurfaceDescription {
     let height: Int
     let rowBytes: Int
     let headerBytes: Int
+    let sharedMemory: SharedNativeSurface?
+    let imageRegion: SIMD4<Float>
 
     init?(payload: [String: Any], baseURL: URL) {
         guard let rawURL = payload["url"] as? String,
               let url = URL(string: rawURL, relativeTo: baseURL)?.absoluteURL
         else { return nil }
         self.url = url
+        if let region = payload["viewport"] as? [String: Any] {
+            guard let x = region["x"] as? Int, let y = region["y"] as? Int,
+                  let w = region["width"] as? Int, let h = region["height"] as? Int,
+                  let fullW = region["fullWidth"] as? Int, let fullH = region["fullHeight"] as? Int,
+                  x >= 0, y >= 0, w > 0, h > 0, fullW > 0, fullH > 0,
+                  x <= fullW - w, y <= fullH - h else { return nil }
+            imageRegion = SIMD4<Float>(Float(w) / Float(fullW), Float(h) / Float(fullH),
+                Float(x) / Float(fullW), Float(y) / Float(fullH))
+        } else {
+            imageRegion = SIMD4<Float>(1, 1, 0, 0)
+        }
         format = payload["format"] as? String ?? "image"
         width = payload["width"] as? Int ?? 0
         height = payload["height"] as? Int ?? 0
         rowBytes = payload["rowBytes"] as? Int ?? 0
         headerBytes = payload["headerBytes"] as? Int ?? 0
+        sharedMemory = ["localhost", "127.0.0.1", "::1"].contains(url.host ?? "")
+            ? (payload["sharedMemory"] as? [String: Any]).flatMap(SharedNativeSurface.init)
+            : nil
+    }
+}
+
+/// Immutable, per-render POSIX shared memory. The server owns the name and
+/// unlinks it on cache eviction; an already mapped texture remains valid.
+struct SharedNativeSurface {
+    let name: String
+    let length: Int
+    let rowBytes: Int
+
+    init?(payload: [String: Any]) {
+        guard let name = payload["name"] as? String,
+              name.hasPrefix("/lt-"), name.utf8.count < 32,
+              !name.dropFirst().contains("/"),
+              let length = payload["length"] as? Int,
+              let rowBytes = payload["rowBytes"] as? Int,
+              (payload["offset"] as? Int ?? 0) == 0,
+              length > 0, length <= 256 * 1024 * 1024,
+              rowBytes > 0, rowBytes % 256 == 0,
+              length % Int(getpagesize()) == 0 else { return nil }
+        self.name = name
+        self.length = length
+        self.rowBytes = rowBytes
+    }
+
+    func texture(device: MTLDevice, width: Int, height: Int) throws -> MTLTexture {
+        guard let layout = PackedRGBA8Layout(width: width, height: height),
+              rowBytes >= layout.rowBytes,
+              height <= length / rowBytes,
+              rowBytes % device.minimumLinearTextureAlignment(for: .rgba8Unorm) == 0
+        else { throw NativePreviewError.invalidDimensions }
+        let fd = name.withCString { openNativeSharedMemory($0, O_RDWR) }
+        guard fd >= 0 else { throw NativePreviewError.missingData }
+        defer { close(fd) }
+        var info = stat()
+        guard fstat(fd, &info) == 0, info.st_size >= length else {
+            throw NativePreviewError.invalidDimensions
+        }
+        let mapping = mmap(nil, length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)
+        guard let mapping, mapping != MAP_FAILED else {
+            throw NativePreviewError.missingData
+        }
+        guard let buffer = device.makeBuffer(bytesNoCopy: mapping, length: length,
+            options: .storageModeShared, deallocator: { pointer, size in
+                munmap(pointer, size)
+            }) else {
+            munmap(mapping, length)
+            throw NativePreviewError.textureAllocation
+        }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba8Unorm, width: width, height: height, mipmapped: false)
+        descriptor.usage = .shaderRead
+        descriptor.storageMode = .shared
+        guard let texture = buffer.makeTexture(descriptor: descriptor,
+            offset: 0, bytesPerRow: rowBytes) else {
+            throw NativePreviewError.textureAllocation
+        }
+        // The texture retains its backing buffer, whose deallocator owns mmap.
+        return texture
     }
 }
 
@@ -29,6 +110,7 @@ struct NativePreviewTimings {
     let gpuMs: Double
     let totalMs: Double
     var textureCacheHit: Bool = false
+    var sharedMemory: Bool = false
 
     var payload: [String: Any] {
         [
@@ -38,6 +120,7 @@ struct NativePreviewTimings {
             "gpuMs": gpuMs,
             "totalMs": totalMs,
             "textureCacheHit": textureCacheHit,
+            "sharedMemory": sharedMemory,
         ]
     }
 }
@@ -104,6 +187,7 @@ private struct GradeUniforms {
     var detail1 = SIMD4<Float>(repeating: 0)
     var curveOn = SIMD4<Float>(repeating: 0)
     var viewport = SIMD4<Float>(1, 1, 0, 0)
+    var sourceRegion = SIMD4<Float>(1, 1, 0, 0)
     var compare = SIMD4<Float>(repeating: 0)
     var reference0 = SIMD4<Float>(0, 0, 0.5, 1)
     var reference1 = SIMD4<Float>(repeating: 0)
@@ -244,6 +328,8 @@ final class NativePreviewRenderer {
     private let sampler: MTLSamplerState
     private let textureLoader: MTKTextureLoader
     private var imageTexture: MTLTexture?
+    private var fullFrameTexture: MTLTexture?
+    private var imageRegion = SIMD4<Float>(1, 1, 0, 0)
     private let textureCache = ByteBudgetCache<MTLTexture>(budget: 256 * 1024 * 1024)
     private var preloadTasks: [URL: URLSessionDataTask] = [:]
     private var preloadEpoch = 0
@@ -270,6 +356,7 @@ final class NativePreviewRenderer {
     func beginNavigation(generation: Int) {
         requestedGeneration = generation
         awaitingPhoto = true
+        fullFrameTexture = nil
         pendingInteraction = nil
         loadTask?.cancel()
         originalLoadTask?.cancel()
@@ -575,7 +662,8 @@ final class NativePreviewRenderer {
 
     private func cacheTexture(_ texture: MTLTexture, surface: NativeSurfaceDescription) {
         guard let layout = PackedRGBA8Layout(width: texture.width, height: texture.height) else { return }
-        textureCache.insert(texture, key: cacheKey(surface), cost: layout.byteCount)
+        textureCache.insert(texture, key: cacheKey(surface),
+            cost: texture.buffer?.length ?? layout.byteCount)
     }
 
     func cancelPreloads(epoch: Int? = nil) {
@@ -638,7 +726,7 @@ final class NativePreviewRenderer {
             awaitingPhoto = false
             prepare?()
             updateGrade(grade, renderNow: false)
-            imageTexture = cached
+            setImageTexture(cached, surface: surface)
             render { gpuMs in
                 guard let gpuMs else {
                     completion(.failure(NativePreviewError.drawableUnavailable)); return
@@ -650,75 +738,116 @@ final class NativePreviewRenderer {
             }
             return
         }
-        var request = URLRequest(url: surface.url)
-        request.cachePolicy = .returnCacheDataElseLoad
-        let task = URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
-            guard let self else { return }
-            if let error {
-                if (error as NSError).code != NSURLErrorCancelled {
+        let fetchHTTP = { [weak self] in
+            guard let self, generation == self.requestedGeneration else { return }
+            var request = URLRequest(url: surface.url)
+            request.cachePolicy = .returnCacheDataElseLoad
+            let task = URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
+                guard let self else { return }
+                if let error {
+                    if (error as NSError).code != NSURLErrorCancelled {
+                        DispatchQueue.main.async { completion(.failure(error)) }
+                    }
+                    return
+                }
+                guard let data else {
+                    DispatchQueue.main.async {
+                        completion(.failure(NativePreviewError.missingData))
+                    }
+                    return
+                }
+                let fetched = ProcessInfo.processInfo.systemUptime
+                do {
+                    let decodedStarted = ProcessInfo.processInfo.systemUptime
+                    let texture: MTLTexture
+                    let decodedAt: Double
+                    let uploadedAt: Double
+                    if surface.format == "rgba8" {
+                        let validated = try self.validateRawSurface(data, expected: surface)
+                        decodedAt = ProcessInfo.processInfo.systemUptime
+                        texture = try self.uploadRawSurface(
+                            data, offset: validated.headerBytes,
+                            width: validated.width, height: validated.height,
+                            rowBytes: validated.rowBytes)
+                        uploadedAt = ProcessInfo.processInfo.systemUptime
+                    } else {
+                        texture = try self.textureLoader.newTexture(
+                            data: data,
+                            options: [
+                                .SRGB: false,
+                                .textureUsage: NSNumber(value: MTLTextureUsage.shaderRead.rawValue),
+                                .textureStorageMode: NSNumber(value: MTLStorageMode.shared.rawValue),
+                            ])
+                        decodedAt = ProcessInfo.processInfo.systemUptime
+                        uploadedAt = decodedAt
+                    }
+                    DispatchQueue.main.async {
+                        guard generation == self.requestedGeneration else { return }
+                        self.awaitingPhoto = false
+                        prepare?()
+                        self.updateGrade(grade, renderNow: false)
+                        self.cacheTexture(texture, surface: surface)
+                        self.setImageTexture(texture, surface: surface)
+                        self.render { gpuMs in
+                            guard let gpuMs else {
+                                completion(.failure(
+                                    NativePreviewError.drawableUnavailable))
+                                return
+                            }
+                            let finished = ProcessInfo.processInfo.systemUptime
+                            completion(.success(NativePreviewTimings(
+                                fetchMs: (fetched - started) * 1000,
+                                decodeMs: (decodedAt - decodedStarted) * 1000,
+                                uploadMs: (uploadedAt - decodedAt) * 1000,
+                                gpuMs: gpuMs,
+                                totalMs: (finished - started) * 1000)))
+                        }
+                    }
+                } catch {
                     DispatchQueue.main.async { completion(.failure(error)) }
                 }
-                return
             }
-            guard let data else {
-                DispatchQueue.main.async {
-                    completion(.failure(NativePreviewError.missingData))
+            self.loadTask = task
+            task.resume()
+        }
+        if let shared = surface.sharedMemory, surface.format == "rgba8" {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                guard let self else { return }
+                guard let texture = try? shared.texture(device: self.device,
+                    width: surface.width, height: surface.height) else {
+                    DispatchQueue.main.async(execute: fetchHTTP)
+                    return
                 }
-                return
-            }
-            let fetched = ProcessInfo.processInfo.systemUptime
-            do {
-                let decodedStarted = ProcessInfo.processInfo.systemUptime
-                let texture: MTLTexture
-                let decodedAt: Double
-                let uploadedAt: Double
-                if surface.format == "rgba8" {
-                    let validated = try self.validateRawSurface(data, expected: surface)
-                    decodedAt = ProcessInfo.processInfo.systemUptime
-                    texture = try self.uploadRawSurface(
-                        data, offset: validated.headerBytes,
-                        width: validated.width, height: validated.height,
-                        rowBytes: validated.rowBytes)
-                    uploadedAt = ProcessInfo.processInfo.systemUptime
-                } else {
-                    texture = try self.textureLoader.newTexture(
-                        data: data,
-                        options: [
-                            .SRGB: false,
-                            .textureUsage: NSNumber(value: MTLTextureUsage.shaderRead.rawValue),
-                            .textureStorageMode: NSNumber(value: MTLStorageMode.shared.rawValue),
-                        ])
-                    decodedAt = ProcessInfo.processInfo.systemUptime
-                    uploadedAt = decodedAt
-                }
+                let mappedAt = ProcessInfo.processInfo.systemUptime
                 DispatchQueue.main.async {
                     guard generation == self.requestedGeneration else { return }
                     self.awaitingPhoto = false
                     prepare?()
                     self.updateGrade(grade, renderNow: false)
                     self.cacheTexture(texture, surface: surface)
-                    self.imageTexture = texture
+                    self.setImageTexture(texture, surface: surface)
                     self.render { gpuMs in
                         guard let gpuMs else {
-                            completion(.failure(
-                                NativePreviewError.drawableUnavailable))
+                            completion(.failure(NativePreviewError.drawableUnavailable))
                             return
                         }
-                        let finished = ProcessInfo.processInfo.systemUptime
                         completion(.success(NativePreviewTimings(
-                            fetchMs: (fetched - started) * 1000,
-                            decodeMs: (decodedAt - decodedStarted) * 1000,
-                            uploadMs: (uploadedAt - decodedAt) * 1000,
-                            gpuMs: gpuMs,
-                            totalMs: (finished - started) * 1000)))
+                            fetchMs: (mappedAt - started) * 1000,
+                            decodeMs: 0, uploadMs: 0, gpuMs: gpuMs,
+                            totalMs: (ProcessInfo.processInfo.systemUptime - started) * 1000,
+                            sharedMemory: true)))
                     }
                 }
-            } catch {
-                DispatchQueue.main.async { completion(.failure(error)) }
             }
+        } else {
+            fetchHTTP()
         }
-        loadTask = task
-        task.resume()
+    }
+
+    private func setImageTexture(_ texture: MTLTexture, surface: NativeSurfaceDescription) {
+        imageTexture = texture
+        imageRegion = surface.imageRegion
+        if imageRegion == SIMD4<Float>(1, 1, 0, 0) { fullFrameTexture = texture }
     }
 
     private func validateRawSurface(
@@ -823,7 +952,7 @@ final class NativePreviewRenderer {
         let height = max(1, imageTexture?.height ?? 1)
         output.tone3 = SIMD4<Float>(
             value("dehaze"), value("vignette"),
-            1 / Float(width), 1 / Float(height))
+            imageRegion.x / Float(width), imageRegion.y / Float(height))
         output.detail0 = SIMD4<Float>(
             value("sharpness"), value("sharpenRadius", 1),
             value("sharpenDetail", 0.25), value("sharpenMasking"))
@@ -837,6 +966,7 @@ final class NativePreviewRenderer {
             grade["curveG"] == nil ? 0 : 1,
             grade["curveB"] == nil ? 0 : 1)
         output.viewport = viewport
+        output.sourceRegion = imageRegion
         output.compare = SIMD4<Float>(
             originalTexture == nil ? 0 : comparePosition, 0, 0, 0)
         let referenceActive = reference["active"] as? Bool ?? false
@@ -1074,6 +1204,7 @@ final class NativePreviewRenderer {
         encoder.setFragmentTexture(originalTexture ?? imageTexture, index: 2)
         encoder.setFragmentTexture(maskTexture, index: 3)
         encoder.setFragmentTexture(referenceTexture ?? imageTexture, index: 4)
+        encoder.setFragmentTexture(fullFrameTexture ?? imageTexture, index: 5)
         encoder.setFragmentSamplerState(sampler, index: 0)
         encoder.setFragmentBytes(
             &uniforms, length: MemoryLayout<GradeUniforms>.stride, index: 0)

--- a/app/main.swift
+++ b/app/main.swift
@@ -2134,8 +2134,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
     }
 
     @objc func openHelp(_ sender: Any?) {
-        guard let url = URL(string: "https://lighttable.app/") else { return }
-        NSWorkspace.shared.open(url)
+        sendEvent(["type": "menuCommand", "command": "help"])
     }
 
     @objc func performEditorCommand(_ sender: NSMenuItem) {

--- a/app/main.swift
+++ b/app/main.swift
@@ -5,6 +5,8 @@
 
 import AppKit
 import Darwin
+import CryptoKit
+import Photos
 import PhotosUI
 import UniformTypeIdentifiers
 import UserNotifications
@@ -601,6 +603,260 @@ final class EditRecoveryStore {
     }
 }
 
+// MARK: - Original Photos library import
+
+/// One resource at a time, streamed to disk. Photos is only read; completed
+/// copies are atomically promoted to deterministic paths so a retry adds new
+/// originals without duplicating those already imported.
+private final class PhotosLibraryImporter {
+    private struct Item {
+        let resource: PHAssetResource
+        let identity: String
+    }
+    private final class Transfer {
+        let temporary: URL
+        let destination: URL
+        let handle: FileHandle
+        var request: PHAssetResourceDataRequestID?
+        var error: Error?
+        init(temporary: URL, destination: URL, handle: FileHandle) {
+            self.temporary = temporary
+            self.destination = destination
+            self.handle = handle
+        }
+    }
+    private let directory: URL
+    private let event: ([String: Any]) -> Void
+    private let queue = DispatchQueue(label: "lighttable.photos-library-import", qos: .utility)
+    private let cancellationLock = NSLock()
+    private var cancelled = false
+    private var items: [Item] = []
+    private var index = 0
+    private var imported = 0
+    private var existing = 0
+    private var failures = 0
+    private var transfer: Transfer?
+    private var finished = false
+    private var lockDescriptor: Int32 = -1
+    private var lastProgressTime = Date.distantPast
+
+    init(directory: URL, event: @escaping ([String: Any]) -> Void) {
+        self.directory = directory
+        self.event = event
+    }
+
+    private var isCancelled: Bool {
+        cancellationLock.lock()
+        defer { cancellationLock.unlock() }
+        return cancelled
+    }
+
+    func start() {
+        queue.async { [self] in
+            guard !isCancelled else { finish("cancelled"); return }
+            lockDescriptor = Darwin.open(directory.appendingPathComponent(
+                ".lighttable-library-import.lock").path, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR)
+            guard lockDescriptor >= 0, flock(lockDescriptor, LOCK_EX | LOCK_NB) == 0 else {
+                finish("error", message: "Another LightTable window may be importing this library. Close that import and try again.")
+                return
+            }
+            emit("running", message: "Reading your Photos library…")
+            let options = PHFetchOptions()
+            options.includeHiddenAssets = true
+            options.includeAllBurstAssets = true
+            let assets = PHAsset.fetchAssets(with: .image, options: options)
+            assets.enumerateObjects { asset, _, stop in
+                if self.isCancelled { stop.pointee = true; return }
+                autoreleasepool {
+                    // Do not import adjusted versions or the video part of a
+                    // Live Photo. A RAW+JPEG pair has two original resources.
+                    let originals = PHAssetResource.assetResources(for: asset)
+                        .filter { $0.type == .photo || $0.type == .alternatePhoto }
+                    var occurrences: [String: Int] = [:]
+                    for resource in originals {
+                        let key = "\(asset.localIdentifier)|\(resource.type.rawValue)|\(resource.uniformTypeIdentifier)|\(resource.originalFilename)"
+                        let occurrence = occurrences[key, default: 0]
+                        occurrences[key] = occurrence + 1
+                        self.items.append(Item(resource: resource, identity: "\(key)|\(occurrence)"))
+                    }
+                }
+            }
+            guard !isCancelled else { finish("cancelled"); return }
+            emit("running", message: "Copying original photos…")
+            next()
+        }
+    }
+
+    func cancel() {
+        cancellationLock.lock()
+        cancelled = true
+        cancellationLock.unlock()
+        queue.async { [self] in
+            guard !finished else { return }
+            discardTransfer()
+            finish("cancelled")
+        }
+    }
+
+    /// Quit cannot wait for a download, but it must close and remove its partial
+    /// file. The directory lock and completed copies remain crash-safe too.
+    func shutdown() {
+        cancellationLock.lock()
+        cancelled = true
+        cancellationLock.unlock()
+        queue.sync {
+            discardTransfer()
+            finish("cancelled")
+        }
+    }
+
+    private static func digest(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func destination(for item: Item) -> URL {
+        let digest = Self.digest(item.identity)
+        let name = URL(fileURLWithPath: item.resource.originalFilename)
+        let invalid = CharacterSet(charactersIn: "/:\0").union(.controlCharacters)
+        let stem = name.deletingPathExtension().lastPathComponent
+            .components(separatedBy: invalid).joined(separator: "_")
+        var safeStem = String((stem.isEmpty ? "Photo" : stem).prefix(80))
+        while safeStem.utf8.count > 100 { safeStem.removeLast() }
+        let ext = name.pathExtension.isEmpty
+            ? (UTType(item.resource.uniformTypeIdentifier)?.preferredFilenameExtension ?? "")
+            : name.pathExtension
+        let safeExtension = String(ext.components(separatedBy: invalid).joined(separator: "_").prefix(16))
+        return directory.appendingPathComponent("Originals", isDirectory: true)
+            .appendingPathComponent(String(digest.prefix(2)), isDirectory: true)
+            .appendingPathComponent("\(safeStem)-\(digest)" + (safeExtension.isEmpty ? "" : ".\(safeExtension)"))
+    }
+
+    private func next() {
+        guard !finished else { return }
+        guard !isCancelled else { finish("cancelled"); return }
+        guard index < items.count else { finish("completed"); return }
+        let item = items[index]
+        let destination = destination(for: item)
+        let parent = destination.deletingLastPathComponent()
+        // Each deterministic destination is only created after the whole
+        // resource has been flushed. A partial file never counts as imported.
+        if let values = try? destination.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+           values.isRegularFile == true, (values.fileSize ?? 0) > 0 {
+            existing += 1
+            advance()
+            return
+        }
+        do {
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            let temporary = parent.appendingPathComponent(".lighttable-\(Self.digest(item.identity)).partial")
+            if FileManager.default.fileExists(atPath: temporary.path) {
+                try FileManager.default.removeItem(at: temporary)
+            }
+            guard FileManager.default.createFile(atPath: temporary.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            let current = Transfer(temporary: temporary, destination: destination,
+                                   handle: try FileHandle(forWritingTo: temporary))
+            transfer = current
+            let options = PHAssetResourceRequestOptions()
+            options.isNetworkAccessAllowed = true
+            options.progressHandler = { [weak self, weak current] progress in
+                guard let self, let current else { return }
+                self.queue.async {
+                    guard self.transfer === current, !self.finished else { return }
+                    self.emit("running", message: "Downloading an original from iCloud…", progress: progress)
+                }
+            }
+            current.request = PHAssetResourceManager.default().requestData(
+                for: item.resource, options: options,
+                dataReceivedHandler: { [weak self, weak current] data in
+                    guard let self, let current else { return }
+                    // Synchronous backpressure keeps at most one PhotoKit data
+                    // chunk pending, even when disk is slower than the download.
+                    self.queue.sync {
+                        guard self.transfer === current, current.error == nil else { return }
+                        do { try current.handle.write(contentsOf: data) }
+                        catch { current.error = error }
+                    }
+                }, completionHandler: { [weak self, weak current] error in
+                    guard let self, let current else { return }
+                    self.queue.async {
+                        guard self.transfer === current, !self.finished else { return }
+                        self.complete(current, error: error)
+                    }
+                })
+        } catch {
+            failures += 1
+            advance()
+        }
+    }
+
+    private func complete(_ current: Transfer, error: Error?) {
+        if isCancelled { discardTransfer(); finish("cancelled"); return }
+        do {
+            if let error = current.error ?? error { throw error }
+            try current.handle.synchronize()
+            try current.handle.close()
+            let values = try current.temporary.resourceValues(forKeys: [.fileSizeKey])
+            guard (values.fileSize ?? 0) > 0 else { throw CocoaError(.fileReadCorruptFile) }
+            // moveItem does not overwrite a user's existing file.
+            try FileManager.default.moveItem(at: current.temporary, to: current.destination)
+            imported += 1
+        } catch {
+            try? current.handle.close()
+            try? FileManager.default.removeItem(at: current.temporary)
+            failures += 1
+        }
+        transfer = nil
+        advance()
+    }
+
+    private func advance() {
+        index += 1
+        emit("running", message: "Copying original photos…")
+        // Yield between resources so cancellation is handled even when a large
+        // rerun consists entirely of already imported files.
+        queue.async { [self] in next() }
+    }
+
+    private func discardTransfer() {
+        guard let current = transfer else { return }
+        transfer = nil
+        if let request = current.request { PHAssetResourceManager.default().cancelDataRequest(request) }
+        try? current.handle.close()
+        try? FileManager.default.removeItem(at: current.temporary)
+    }
+
+    private func finish(_ state: String, message: String? = nil) {
+        guard !finished else { return }
+        finished = true
+        if lockDescriptor >= 0 {
+            _ = flock(lockDescriptor, LOCK_UN)
+            Darwin.close(lockDescriptor)
+            lockDescriptor = -1
+        }
+        emit(state, message: message ?? (state == "cancelled"
+            ? "Import stopped. Completed copies are safe; run it again to continue."
+            : (items.isEmpty ? "No photo originals were found in your Photos library."
+                : (failures > 0 ? "Import finished with some originals unavailable. Run it again to retry."
+                    : "Your photo originals are ready in LightTable."))))
+        items.removeAll()
+    }
+
+    private func emit(_ state: String, message: String, progress: Double? = nil) {
+        let now = Date()
+        if state == "running", now.timeIntervalSince(lastProgressTime) < 0.2 { return }
+        lastProgressTime = now
+        var payload: [String: Any] = [
+            "type": "photosLibraryImport", "state": state, "completed": index,
+            "total": items.count, "imported": imported, "existing": existing,
+            "failures": failures, "message": message, "path": directory.path,
+        ]
+        if let progress { payload["resourceProgress"] = progress }
+        DispatchQueue.main.async { [event] in event(payload) }
+    }
+}
+
 // MARK: - App
 
 final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
@@ -627,6 +883,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
     private var schemeCommandItems: [String: NSMenuItem] = [:]
     private var photoPicker: PHPickerViewController?
     private var pendingPhotosImportEvent: [String: Any]?
+    private var photosLibraryImporter: PhotosLibraryImporter?
+    private var photosLibraryImportEvent: [String: Any]?
+    private var photosLibraryAuthorizationID: UUID?
+    private var firstRun = false
+    private var pendingSetupFolderEvent: [String: Any]?
+    private var pendingSetupCatalogEvent: [String: Any]?
     private let photoImportQueue = DispatchQueue(
         label: "lighttable.photos-import", qos: .userInitiated)
     /// Consecutive unexpected server exits. Reset after a session that ran
@@ -651,12 +913,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
             return
         }
 
-        sources = loadSources()
+        let defaults = UserDefaults.standard
         let environmentFolder = ProcessInfo.processInfo.environment[
             "LIGHTTABLE_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        folder = (environmentFolder?.isEmpty == false ? environmentFolder : nil)
-            ?? UserDefaults.standard.string(forKey: "photoFolder")
-            ?? sources.first?.path ?? defaultPhotoFolder
+        firstRun = environmentFolder?.isEmpty != false
+            && defaults.object(forKey: "photoFolder") == nil
+            && defaults.object(forKey: "folderSources") == nil
+            && defaults.integer(forKey: "firstRunCompleted") < 1
+        sources = firstRun ? [] : loadSources()
+        if firstRun {
+            do { folder = try gettingStartedFolder().path }
+            catch { showFatal("Could not prepare your library: \(error.localizedDescription)"); return }
+        } else {
+            folder = (environmentFolder?.isEmpty == false ? environmentFolder : nil)
+                ?? defaults.string(forKey: "photoFolder")
+                ?? sources.first?.path ?? defaultPhotoFolder
+        }
         var isDir: ObjCBool = false
         if !FileManager.default.fileExists(atPath: folder, isDirectory: &isDir)
             || !isDir.boolValue {
@@ -667,7 +939,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
         launch(folder: folder)
     }
 
-    func applicationWillTerminate(_ note: Notification) { server.stop() }
+    func applicationWillTerminate(_ note: Notification) {
+        photosLibraryImporter?.shutdown()
+        server.stop()
+    }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         if closeApproved || webView == nil { return .terminateNow }
@@ -966,7 +1241,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
         nativePreview?.hide()
         let automated = ProcessInfo.processInfo.environment[
             "LIGHTTABLE_DIR"]?.isEmpty == false
-        if !automated {
+        if !automated && !(firstRun && sources.isEmpty) {
             addSource(clean)
             UserDefaults.standard.set(clean, forKey: "photoFolder")
         }
@@ -1200,6 +1475,129 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
         }
     }
 
+    private func gettingStartedFolder() throws -> URL {
+        let root = FileManager.default.urls(for: .applicationSupportDirectory,
+                                             in: .userDomainMask).first!
+        let destination = root.appendingPathComponent("LightTable", isDirectory: true)
+            .appendingPathComponent("Getting Started", isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        return destination
+    }
+
+    private func finishFirstRun() {
+        firstRun = false
+        pendingSetupFolderEvent = nil
+        pendingSetupCatalogEvent = nil
+        if photosLibraryImportEvent?["state"] as? String != "running" {
+            photosLibraryImportEvent = nil
+        }
+        let defaults = UserDefaults.standard
+        defaults.set(1, forKey: "firstRunCompleted")
+        // Skip keeps the empty workspace on the next launch too.
+        defaults.set(folder, forKey: "photoFolder")
+        saveSources()
+        sendEvent(sourcePayload())
+    }
+
+    private func completeSetupCatalogImport(_ body: [String: Any]) {
+        var seen = Set<String>()
+        let paths = (body["paths"] as? [String] ?? []).compactMap { path -> String? in
+            guard (path as NSString).isAbsolutePath else { return nil }
+            let clean = normalized(path)
+            guard isDirectory(clean), seen.insert(clean).inserted else { return nil }
+            return clean
+        }
+        paths.forEach { addSource($0) }
+        pendingSetupCatalogEvent = [
+            "type": "setupCatalogImported",
+            "matched": max(0, body["matched"] as? Int ?? 0),
+            "unmatched": max(0, body["unmatched"] as? Int ?? 0),
+        ]
+        if let first = paths.first {
+            launch(folder: first)
+        } else if let pendingSetupCatalogEvent {
+            sendEvent(pendingSetupCatalogEvent)
+        }
+    }
+
+    private func publishPhotosLibraryEvent(_ payload: [String: Any]) {
+        photosLibraryImportEvent = payload
+        sendEvent(payload)
+    }
+
+    private func importEntirePhotosLibrary() {
+        guard photosLibraryImporter == nil, photosLibraryAuthorizationID == nil else {
+            if let photosLibraryImportEvent { sendEvent(photosLibraryImportEvent) }
+            return
+        }
+        let authorizationID = UUID()
+        photosLibraryAuthorizationID = authorizationID
+        publishPhotosLibraryEvent([
+            "type": "photosLibraryImport", "state": "running", "completed": 0,
+            "total": 0, "imported": 0, "existing": 0, "failures": 0,
+            "message": "Waiting for permission to read your Photos library…",
+        ])
+        // The OS permission request is only reached by the explicit import
+        // action, never by startup, capability checks, or selecting the card.
+        PHPhotoLibrary.requestAuthorization(for: .readWrite) { [weak self] status in
+            DispatchQueue.main.async {
+                guard let self, self.photosLibraryAuthorizationID == authorizationID else { return }
+                self.photosLibraryAuthorizationID = nil
+                guard status == .authorized else {
+                    self.publishPhotosLibraryEvent([
+                        "type": "photosLibraryImport", "state": "error", "completed": 0,
+                        "total": 0, "imported": 0, "existing": 0, "failures": 0,
+                        "message": status == .limited
+                            ? "Importing the entire library needs full Photos access. Allow access in System Settings, or choose individual photos instead."
+                            : "Photos access was not allowed. You can enable it in System Settings → Privacy & Security → Photos, or start with a folder.",
+                    ])
+                    return
+                }
+                do {
+                    let directory = try self.photosImportRoot()
+                    let importer = PhotosLibraryImporter(directory: directory) { [weak self] payload in
+                        guard let self else { return }
+                        self.publishPhotosLibraryEvent(payload)
+                        guard let state = payload["state"] as? String, state != "running" else { return }
+                        self.photosLibraryImporter = nil
+                        let available = (payload["imported"] as? Int ?? 0) + (payload["existing"] as? Int ?? 0)
+                        if available > 0 {
+                            self.addSource(directory.path)
+                            self.sendEvent(self.sourcePayload())
+                            self.launch(folder: directory.path)
+                        }
+                    }
+                    self.photosLibraryImporter = importer
+                    importer.start()
+                } catch {
+                    self.publishPhotosLibraryEvent([
+                        "type": "photosLibraryImport", "state": "error", "completed": 0,
+                        "total": 0, "imported": 0, "existing": 0, "failures": 0,
+                        "message": "Could not create the Photos import folder: \(error.localizedDescription)",
+                    ])
+                }
+            }
+        }
+    }
+
+    private func cancelEntirePhotosLibraryImport() {
+        if photosLibraryAuthorizationID != nil {
+            photosLibraryAuthorizationID = nil
+            publishPhotosLibraryEvent([
+                "type": "photosLibraryImport", "state": "cancelled", "completed": 0,
+                "total": 0, "imported": 0, "existing": 0, "failures": 0,
+                "message": "Import cancelled. No photos were copied.",
+            ])
+        }
+        photosLibraryImporter?.cancel()
+    }
+
+    private func replaySetupEvents() {
+        if let photosLibraryImportEvent { sendEvent(photosLibraryImportEvent) }
+        if let pendingSetupFolderEvent { sendEvent(pendingSetupFolderEvent) }
+        if let pendingSetupCatalogEvent { sendEvent(pendingSetupCatalogEvent) }
+    }
+
     private func presentPhotosPicker() {
         let alert = NSAlert()
         alert.messageText = "Import from Apple Photos"
@@ -1385,6 +1783,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
         [
             "type": "sources",
             "active": folder,
+            "firstRun": firstRun,
+            "photosLibraryImportAvailable": true,
             "sources": sources.map { source in
                 ["path": source.path,
                  "name": (source.path as NSString).lastPathComponent,
@@ -1406,6 +1806,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         sendEvent(sourcePayload())
+        replaySetupEvents()
         if let pendingPhotosImportEvent {
             sendEvent(pendingPhotosImportEvent)
             self.pendingPhotosImportEvent = nil
@@ -1475,6 +1876,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
             openSecondaryLoupe()
         case "requestSources":
             sendEvent(sourcePayload())
+            replaySetupEvents()
+        case "completeFirstRun":
+            finishFirstRun()
+        case "setupCatalogImported":
+            completeSetupCatalogImport(body)
+        case "setupChooseFolder":
+            if let picked = pickFolder(title: "Choose your first photo folder") {
+                addSource(picked)
+                pendingSetupFolderEvent = ["type": "setupFolderSelected", "path": picked]
+                launch(folder: picked)
+            } else {
+                sendEvent(["type": "setupFolderCancelled"])
+            }
+        case "importApplePhotosLibrary":
+            importEntirePhotosLibrary()
+        case "cancelApplePhotosLibraryImport":
+            cancelEntirePhotosLibraryImport()
         case "showServerLog":
             showLog(nil)
         case "openRecoveryFolder":

--- a/app/main.swift
+++ b/app/main.swift
@@ -391,7 +391,7 @@ final class ServerController {
             env["NUMBA_CACHE_DIR"] = cacheDirectory
                 .appendingPathComponent("compiled-runtime").path
         }
-        env["OMP_NUM_THREADS"] = "4"
+        env["OMP_NUM_THREADS"] = env["OMP_NUM_THREADS"] ?? "8"
         env["NUMBA_NUM_THREADS"] = "4"
         env["OPENBLAS_NUM_THREADS"] = "4"
         env["PYTHONUNBUFFERED"] = "1"

--- a/build-app.sh
+++ b/build-app.sh
@@ -50,6 +50,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundleExecutable</key><string>LightTable</string>
   <key>CFBundleIconFile</key><string>LightTable</string>
   <key>LSMinimumSystemVersion</key><string>13.0</string>
+  <key>NSPhotoLibraryUsageDescription</key><string>LightTable reads your Photos library to copy original photos into your LightTable import folder. Your Photos library is never changed.</string>
   <key>NSHighResolutionCapable</key><true/>
   <key>NSHumanReadableCopyright</key><string>Local tool. spektrafilm is GPLv3.</string>
   <key>NSAppTransportSecurity</key><dict>

--- a/catalog.py
+++ b/catalog.py
@@ -1485,6 +1485,7 @@ class Catalog:
     def image_row(self, image_id: int) -> dict | None:
         row = self.connection.execute(
             "SELECT i.*, f.relpath, f.source_id, f.header_hash, f.kind,"
+            "       f.camera_make, f.camera_model, f.lens,"
             "       s.path AS source_path"
             " FROM images i JOIN files f ON f.id=i.file_id"
             " JOIN sources s ON s.id=f.source_id WHERE i.id=?",

--- a/catalog_import.py
+++ b/catalog_import.py
@@ -13,10 +13,10 @@ rather than by parser. Three rules shape everything in this module:
   still import what it can. Every table and column goes through `_has()`
   first, so drift becomes a recorded warning and a skipped category instead of
   a traceback halfway through a long job.
-* **Nothing is created on the user's behalf.** The importer matches files a
-  scan has already added to the catalog. A root folder that lies outside every
-  registered source is counted and reported so the caller can offer to add it;
-  this module never adds a source itself, and never writes beside the photos.
+* **Sources are opt-in.** By default the importer matches files already in
+  LightTable. With explicit add_sources it registers only referenced originals
+  through the normal scanner, adding their containing folders as needed. It
+  never scans an entire drive root or writes beside the photos.
 
 What is skipped is named rather than approximated, in the voice
 `preset_io` uses for preset conversion: the `.lrcat-data` folder holding AI
@@ -286,11 +286,15 @@ def _root_rows(conn: sqlite3.Connection, root_map=None) -> list[dict]:
             ' ORDER BY "absolutePath"').fetchall():
         original = _norm(row["absolutePath"])
         mapped = _remap(original, root_map)
+        available = bool(mapped) and Path(mapped).is_dir()
+        if available:
+            # Catalog sources use canonical paths (e.g. /private/tmp on Mac).
+            mapped = _norm(str(Path(mapped).resolve()))
         out.append({
             "id": int(row["id_local"]),
             "path": mapped,
             "originalPath": original,
-            "exists": bool(mapped) and Path(mapped).is_dir(),
+            "exists": available,
             "files": counts.get(row["id_local"], 0),
         })
     return out
@@ -1270,12 +1274,55 @@ def _import_stacks(conn, cat, targets, result, progress) -> None:
 
 # ------------------------------------------------------------------- the job
 
+def _register_catalog_originals(cat, files, result, progress, cancel) -> None:
+    """Index only catalog-referenced originals, never recurse a Lightroom root.
+
+    Lightroom roots may be entire volumes. Registering individual files avoids
+    indexing unrelated folders just because they share that volume.
+    """
+    import catalog_scan
+
+    sources = [Path(source["path"]).resolve() for source in cat.sources()]
+    added_sources: set[int] = set()
+    unavailable = 0
+    for done, record in enumerate(files.values(), 1):
+        if cancel():
+            result["cancelled"] = True
+            break
+        if record["imageId"] is not None:
+            continue
+        path = Path(record["path"])
+        if not path.is_absolute() or path.suffix.lower() not in catalog_scan.ALL_EXTS:
+            continue
+        try:
+            if not path.is_file():
+                continue
+            path = path.resolve()
+            if not any(path.is_relative_to(source) for source in sources):
+                source_id = cat.add_source(path.parent)
+                added_sources.add(source_id)
+                sources.append(path.parent)
+            catalog_scan.register_file(cat, path)
+        except (OSError, ValueError):
+            unavailable += 1
+        if done % 25 == 0:
+            _report(progress, "indexing originals", done, len(files))
+    for source_id in added_sources:
+        # Preserve pre-existing LightTable folder edits before applying the
+        # user's chosen Lightroom conflict policy.
+        catalog_scan.import_state_file(cat, source_id)
+    if unavailable:
+        _warn(result, f"{unavailable} originals could not be read")
+    _report(progress, "indexing originals", len(files), len(files))
+
+
 def import_catalog(cat: catalog_module.Catalog, path: Path | str, *,
                    options: dict | None = None,
                    progress: Callable[[dict], None] | None = None,
                    root_map: dict | None = None,
                    should_cancel: Callable[[], bool] | None = None,
-                   report_photo: Callable[[dict], None] | None = None) -> dict:
+                   report_photo: Callable[[dict], None] | None = None,
+                   add_sources: bool = False) -> dict:
     """Import one Lightroom catalog into `cat`, reporting what did not fit.
 
     `options` selects the categories: `metadata`, `keywords`, `collections`,
@@ -1289,6 +1336,8 @@ def import_catalog(cat: catalog_module.Catalog, path: Path | str, *,
     turns the Film pipeline off wherever develop settings are imported, the
     same default an imported preset gets.
 
+    `add_sources` indexes referenced originals and adds their folders before
+    importing edits; omitted, this only matches photos already in LightTable.
     `root_map` re-points roots that have moved, as `{old path: new path}`.
     `progress` receives `{"stage", "done", "total"}`, and `should_cancel` is
     consulted between photographs so a long import can be stopped.
@@ -1314,7 +1363,15 @@ def import_catalog(cat: catalog_module.Catalog, path: Path | str, *,
             _warn(result, f"masks and AI data live in {data.name} and are "
                           "skipped, as they are for presets")
         _report(progress, "opening", 0, 1)
+        if add_sources:
+            candidates = _match_files(conn, cat, root_map,
+                                      {"warnings": [], "skipped": {}}, progress)
+            _register_catalog_originals(cat, candidates, result, progress, cancel)
         files = _match_files(conn, cat, root_map, result, progress)
+        used_sources = {record["sourceId"] for record in files.values()
+                        if record["imageId"] is not None}
+        result["sourceFolders"] = [source["path"] for source in cat.sources()
+                                   if source["id"] in used_sources]
         keywords = _keyword_paths(conn, result) if opts["keywords"] else {}
         targets = _import_images(conn, cat, opts, files, keywords, result,
                                  progress, cancel)

--- a/catalog_scan.py
+++ b/catalog_scan.py
@@ -243,6 +243,7 @@ def read_metadata(path: Path) -> dict:
 
 def scan_source(cat: catalog_module.Catalog, source_id: int, *,
                 progress: Callable[[dict], None] | None = None,
+                on_local_file: Callable[[int, str], object] | None = None,
                 read_metadata_for_new: bool = True,
                 limit: int = 500000) -> dict:
     """Bring one source's rows in step with the filesystem.
@@ -335,6 +336,18 @@ def scan_source(cat: catalog_module.Catalog, source_id: int, *,
                     cat.upsert_file(conn, source_id, record)
                     if not was_missing:
                         updated += 1
+
+        # Notify only after the rows commit, so a thumbnail worker can resolve
+        # qualified names immediately. The callback only queues bounded work;
+        # source decoding never runs inside the catalog write transaction.
+        if on_local_file:
+            for record in records:
+                if record.get("availability", "local") == "local" \
+                        and record.get("kind") != "video":
+                    try:
+                        on_local_file(source_id, record["relpath"])
+                    except Exception:
+                        pass  # disposable warm-up cannot invalidate a scan
 
     scan_errors: list[str] = []
 
@@ -661,9 +674,11 @@ class ScanService:
     """
 
     def __init__(self, cat: catalog_module.Catalog,
-                 render_busy: Callable[[], bool] | None = None):
+                 render_busy: Callable[[], bool] | None = None,
+                 on_local_file: Callable[[int, str], object] | None = None):
         self.catalog = cat
         self._render_busy = render_busy or (lambda: False)
+        self._on_local_file = on_local_file
         self._thread: threading.Thread | None = None
         self._queue: list[int] = []
         self._adopt: set[int] = set()
@@ -711,7 +726,8 @@ class ScanService:
                     break
                 time.sleep(0.2)
             try:
-                result = scan_source(self.catalog, source_id)
+                result = scan_source(self.catalog, source_id,
+                                     on_local_file=self._on_local_file)
                 with self._lock:
                     adopt = source_id in self._adopt
                     self._adopt.discard(source_id)

--- a/color_pipeline.py
+++ b/color_pipeline.py
@@ -12,6 +12,8 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
+from collections import OrderedDict
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +21,9 @@ import tifffile
 from PIL import Image, ImageOps
 
 import platform_image
+
+# Leave CPU capacity for the second renderer and the UI during RAW decode.
+os.environ.setdefault("OMP_NUM_THREADS", "8")
 
 
 ICC_PROFILES = {
@@ -320,25 +325,25 @@ def decode_raw(path: Path | str, params: dict | None = None,
     source residuals then restores low-frequency scene colour without
     restoring high-frequency sensor noise.
     """
-    import rawpy
+    import raw_decode_runtime
 
     params = params or {}
     mode = str(params.get("wb_mode", "as_shot"))
     if mode not in RAW_WB_MODES:
         mode = "as_shot"
-    with rawpy.imread(str(path)) as raw:
+    with raw_decode_runtime.open_raw(path) as (raw, decoder):
         sensor_width = int(getattr(raw.sizes, "width", 0) or 0)
         preview_half_size = bool(
             max_width and sensor_width and int(max_width) * 2 <= sensor_width)
-        kwargs = raw_postprocess_options(
-            params, half_size=half_size or preview_half_size)
+        kwargs = raw_decode_runtime.native_options(raw_postprocess_options(
+            params, half_size=half_size or preview_half_size), decoder)
         if mode == "as_shot":
             kwargs["use_camera_wb"] = True
         else:
             kwargs["user_wb"] = list(raw.daylight_whitebalance)
         try:
             rgb = raw.postprocess(**kwargs)
-        except rawpy.LibRawError:
+        except decoder.LibRawError:
             # Some non-Bayer sensors do not support DCB or FBDD. Preserve the
             # selected colour/recovery settings and fall back to the camera's
             # supported demosaic rather than making the photo unreadable.
@@ -435,23 +440,53 @@ def decode_raw_display(path: Path | str, params: dict | None = None,
     return (display * 65535.0 + 0.5).astype(np.uint16)
 
 
+_EMBEDDED_PREVIEWS: OrderedDict[tuple, np.ndarray] = OrderedDict()
+_EMBEDDED_PREVIEW_LOCK = threading.Lock()
+_EMBEDDED_PREVIEW_BYTES = 32 * 1024 * 1024
+
+
 def raw_embedded_preview(path: Path | str, max_width: int) -> np.ndarray:
-    """Extract the camera JPEG/bitmap preview without demosaicing the RAW."""
+    """Decode a bounded camera preview once for film input and Before/Match."""
     import rawpy
 
-    with rawpy.imread(str(path)) as raw:
-        thumb = raw.extract_thumb()
-    if thumb.format == rawpy.ThumbFormat.JPEG:
-        image = ImageOps.exif_transpose(
-            Image.open(io.BytesIO(thumb.data))).convert("RGB")
-    else:
-        image = Image.fromarray(thumb.data, "RGB")
-    if image.width > max_width:
-        image = image.resize(
-            (max_width, max(1, round(image.height * max_width / image.width))),
-            Image.Resampling.LANCZOS,
-        )
-    return np.asarray(image, dtype=np.uint8)
+    path = Path(path)
+    max_width = max(1, int(max_width))
+    # Before uses up to 1600px. Share that draft with smaller interactive inputs
+    # instead of reopening the RAW (and JPEG) for the Match factor.
+    decode_width = max(1600, max_width)
+    stat = path.stat()
+    key = (str(path.resolve()), stat.st_size, stat.st_mtime_ns, decode_width)
+    with _EMBEDDED_PREVIEW_LOCK:
+        pixels = _EMBEDDED_PREVIEWS.get(key)
+        if pixels is None:
+            with rawpy.imread(str(path)) as raw:
+                thumb = raw.extract_thumb()
+            if thumb.format == rawpy.ThumbFormat.JPEG:
+                with Image.open(io.BytesIO(thumb.data)) as opened:
+                    orientation = opened.getexif().get(274, 1)
+                    oriented_width = opened.height if orientation in (5, 6, 7, 8) else opened.width
+                    ratio = min(1.0, decode_width / max(1, oriented_width))
+                    opened.draft("RGB", (max(1, round(opened.width * ratio)),
+                                         max(1, round(opened.height * ratio))))
+                    image = ImageOps.exif_transpose(opened).convert("RGB")
+            else:
+                image = Image.fromarray(thumb.data, "RGB")
+            if image.width > decode_width:
+                image = image.resize((decode_width, max(1, round(
+                    image.height * decode_width / image.width))), Image.Resampling.LANCZOS)
+            pixels = np.array(image, dtype=np.uint8)
+            pixels.flags.writeable = False
+            if pixels.nbytes <= _EMBEDDED_PREVIEW_BYTES:
+                _EMBEDDED_PREVIEWS[key] = pixels
+                while sum(value.nbytes for value in _EMBEDDED_PREVIEWS.values()) > _EMBEDDED_PREVIEW_BYTES:
+                    _EMBEDDED_PREVIEWS.popitem(last=False)
+        else:
+            _EMBEDDED_PREVIEWS.move_to_end(key)
+    if pixels.shape[1] > max_width:
+        image = Image.fromarray(pixels).resize((max_width, max(1, round(
+            pixels.shape[0] * max_width / pixels.shape[1]))), Image.Resampling.LANCZOS)
+        return np.asarray(image, dtype=np.uint8)
+    return pixels
 
 
 def raw_embedded_thumbnail(path: Path | str, destination: Path,

--- a/docs/help/README.md
+++ b/docs/help/README.md
@@ -1,0 +1,63 @@
+# Maintaining in-app help
+
+Help is authored alongside the implementation in the JSON arrays in this
+directory. `web/help-content.json` is the generated, offline reader bundle.
+The app loads it only when Help opens. No network search or external service
+is used. The top-bar Help button, F1, `?`, the macOS Help menu, and inspector
+section help buttons all open the same reader.
+
+Each article includes stable `id`, `title`, `category`, `summary`, search
+`keywords`, `sections` (plain-text paragraphs, steps, and optional tips), related
+article IDs, and `sources`. A source names a repository-relative implementation
+file and an exact `anchor` from that file. Use actual user-visible labels and
+behavior. Link both the UI and backend where the backend determines the result.
+Do not use roadmaps as evidence of shipped functionality.
+
+## When code changes
+
+1. Run `python3 scripts/help_content.py status`. It lists affected articles and
+   the source files that changed. Removed anchors fail validation immediately.
+2. Read the implementation diff, follow the workflow, and revise affected
+   articles if behavior, labels, availability, or limitations changed.
+3. Acknowledge only the articles reviewed:
+   `python3 scripts/help_content.py review article-id another-article-id`.
+   An article can remain verbatim when the source change does not affect its
+   explanation. The acknowledgement records that decision against current code.
+4. Run `python3 scripts/help_content.py build`, then
+   `python3 scripts/help_content.py check`. Commit the articles, review lock,
+   generated bundle, and code together.
+
+`review --all` is for an intentional review of the entire help collection,
+including the initial content import. Never run it automatically to silence a
+failing check. `check`, tests, CI, and `build` do not acknowledge reviews.
+
+The validator rejects duplicate IDs, empty articles, missing source files or
+anchors, invalid related links, unreviewed source/content versions, and a stale
+reader bundle. `tests/test_help_content.py` runs the same check in the normal
+test suite. A lightweight help workflow also runs it before runtime installation.
+
+## What synchronization means
+
+`review-lock.json` records SHA-256 fingerprints of each article and its complete
+source files. Whole-file tracking is deliberately conservative: a change to a
+large shared file can require checking several articles even if only one
+feature changed. Prefer smaller feature modules for evidence when possible.
+Anchors keep the dependency explicit and catch renamed or removed controls.
+The first version does not infer semantic changes or automatically rewrite prose.
+It also cannot detect a new feature that nobody has documented or a dependency
+that an author failed to link. During feature review, add or update the matching
+help article and its sources; verify the reader using the shipped UI.
+
+## Search and UI
+
+Search ranks titles, keywords, summaries, and full article text, supports partial
+words, and ignores common question words. Categories narrow the results. Add
+common user vocabulary to `keywords`, including names people might know from
+other photo editors when useful. Keep code paths and evidence out of product
+prose; the builder strips them from the reader bundle. Content is rendered with
+text nodes, never raw HTML.
+
+UI logic lives in `web/help-panel.js`, styling in `web/help.css`, and pure search
+logic in `web/help-search.js`. The panel contains focus, returns it on dismissal,
+and suspends photo keyboard/menu actions while open. At narrow widths it switches
+between the article list and reader using Back to articles.

--- a/docs/help/editing.json
+++ b/docs/help/editing.json
@@ -294,28 +294,78 @@
     "title": "Crop, straighten, rotate, and correct perspective",
     "category": "Editing",
     "summary": "Set a frame and aspect ratio, adjust orientation and perspective, then accept or cancel the crop session.",
-    "keywords": ["crop", "aspect ratio", "straighten", "rotate", "flip", "perspective", "geometry", "upright", "level", "portrait", "landscape", "resize"],
+    "keywords": [
+      "crop",
+      "aspect ratio",
+      "straighten",
+      "rotate",
+      "flip",
+      "perspective",
+      "geometry",
+      "upright",
+      "level",
+      "portrait",
+      "landscape",
+      "resize"
+    ],
     "sections": [
       {
         "title": "Set the frame",
-        "paragraphs": ["Open Crop in the editing toolbar. Aspect ratio offers Free, Original, standard proportions, and Custom. The crop readout shows the frame and the amount retained."],
-        "steps": ["Choose an aspect ratio. Use Custom to enter your own width-to-height proportion, and the swap button to change orientation.", "Drag a handle to resize the crop or drag inside the frame to move it. Drag outside the existing frame to draw a new crop.", "Use arrow keys to nudge the selection; hold Shift for larger steps.", "Click Done or press Enter to accept. Click Cancel or press Escape to restore the frame from when you opened Crop."],
-        "tips": ["The ratio Lock control lets you keep the current aspect ratio while resizing."]
+        "paragraphs": [
+          "Open Crop in the editing toolbar. Aspect ratio offers Free, Original, standard proportions, and Custom. The crop readout shows the frame and the amount retained."
+        ],
+        "steps": [
+          "Choose an aspect ratio. Use Custom to enter your own width-to-height proportion, and the swap button to change orientation.",
+          "Drag a handle to resize the crop; the photo zooms to keep the frame centred. Drag inside the frame to move the photo under it, or outside it to draw a new crop.",
+          "Use arrow keys to nudge the selection; hold Shift for larger steps.",
+          "Click Done or press Enter to accept. Click Cancel or press Escape to restore the frame from when you opened Crop."
+        ],
+        "tips": [
+          "The ratio Lock control lets you keep the current aspect ratio while resizing."
+        ]
       },
       {
         "title": "Refine geometry",
-        "paragraphs": ["Crop & Rotate also contains Straighten, 90-degree rotation, horizontal and vertical flips, and Perspective controls."],
-        "steps": ["Try Auto level for a tilted horizon, then refine Straighten if needed.", "Use Rotate left, Rotate right, or the flip buttons for orientation changes.", "Expand Perspective and try Auto upright, or adjust Vertical, Horizontal, and Scale manually.", "Inspect the edges and final framing, then click Done."],
-        "tips": ["Auto level uses lines it can find; inspect the result instead of assuming the detected angle suits the photograph.", "Crop’s Reset resets the crop, rotation, flips, and perspective together."]
+        "paragraphs": [
+          "Crop & Rotate also contains Straighten, 90-degree rotation, horizontal and vertical flips, and Perspective controls."
+        ],
+        "steps": [
+          "Try Auto level for a tilted horizon, then refine Straighten if needed.",
+          "Use Rotate left, Rotate right, or the flip buttons for orientation changes.",
+          "Expand Perspective and try Auto upright, or adjust Vertical, Horizontal, and Scale manually.",
+          "Inspect the edges and final framing, then click Done."
+        ],
+        "tips": [
+          "Auto level uses lines it can find; inspect the result instead of assuming the detected angle suits the photograph.",
+          "Crop’s Reset resets the crop, rotation, flips, and perspective together."
+        ]
       }
     ],
-    "related": ["editing-lens-corrections", "editing-history-snapshots"],
+    "related": [
+      "editing-lens-corrections",
+      "editing-history-snapshots"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Reset crop, rotation, flips, and perspective"},
-      {"path": "web/index.html", "anchor": "Drag outside the frame to draw a new crop."},
-      {"path": "web/index.html", "anchor": "Enter accepts; Escape restores the frame from when you opened Crop."},
-      {"path": "web/index.html", "anchor": "Levels the frame from the lines it can find."},
-      {"path": "web/index.html", "anchor": "<button class=\"quiet full\" id=\"autoUpright\">Auto upright</button>"}
+      {
+        "path": "web/index.html",
+        "anchor": "Reset crop, rotation, flips, and perspective"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Drag the handles to resize; the photo zooms to keep the frame centred."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Enter accepts; Escape restores the frame from when you opened Crop."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Levels the frame from the lines it can find."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<button class=\"quiet full\" id=\"autoUpright\">Auto upright</button>"
+      }
     ]
   },
   {

--- a/docs/help/editing.json
+++ b/docs/help/editing.json
@@ -1,0 +1,531 @@
+[
+  {
+    "id": "editing-save-recovery",
+    "title": "Save edits and recover unsaved changes",
+    "category": "Editing",
+    "summary": "Edits save automatically. Check the save status, retry a failed save, or choose which edits to recover after reopening.",
+    "keywords": ["save", "autosave", "unsaved", "recovery", "crash", "original", "non-destructive", "retry", "saving"],
+    "sections": [
+      {
+        "title": "Check that your work is saved",
+        "paragraphs": ["Adjustments are stored as edit settings for the photo. The editor saves changes automatically as you finish interactions; you do not need a separate Save command for each adjustment."],
+        "steps": ["Make your adjustment, then check the save status in the app.", "Wait for Saving… to change to Saved. Saving also includes pending edit-history writes.", "If the status says Edits not saved, use Retry save. Keep the window open while a save is failing."],
+        "tips": ["Saved · recovery needs attention means the save completed but the local recovery system reported a problem. Use the available retry control and read the status message."]
+      },
+      {
+        "title": "Choose recovered or saved edits",
+        "paragraphs": ["If local recovery finds outstanding changes when the library opens, Recover unsaved edits? lists the affected photos. Restore edits replaces their saved settings with the recovered settings. Keep saved edits keeps the catalog version and discards those recovery drafts."],
+        "steps": ["Read the affected photo names and choose Restore edits or Keep saved edits.", "If you restore, wait for saving to complete before closing the app."],
+        "tips": ["Recovery may be unavailable if local storage or the desktop recovery journal fails. The app reports that condition; it is not a guarantee that every unsaved edit can be recovered.", "If an original is unavailable or has changed, its recovery record is kept instead of being applied to a potentially different photo."]
+      }
+    ],
+    "related": ["editing-history-snapshots"],
+    "sources": [
+      {"path": "web/app.js", "anchor": "function renderEditSaveStatus(status)"},
+      {"path": "web/app.js", "anchor": "Still unable to save. Your changes are kept in this window."},
+      {"path": "web/app.js", "anchor": "Restoring replaces their saved edits with these recovered changes."},
+      {"path": "web/app.js", "anchor": "its original is unavailable or has changed."},
+      {"path": "web/edit-save-queue.js", "anchor": "export function createEditSaveQueue"}
+    ]
+  },
+  {
+    "id": "editing-history-snapshots",
+    "title": "Undo edits, restore History, and save snapshots",
+    "category": "Editing",
+    "summary": "Use Undo for recent work, History for stored editing steps, and named snapshots for looks you want to revisit.",
+    "keywords": ["undo", "redo", "history", "snapshot", "version", "restore", "revert", "reset"],
+    "sections": [
+      {
+        "title": "Undo or restore an earlier step",
+        "paragraphs": ["Undo and redo follow each photo during the current session. In catalog libraries, History persists after quitting. Nearby adjustments can be combined into a history step, so the list is not a record of every slider position."],
+        "steps": ["Use Command-Z on Mac or Ctrl-Z on Windows to undo. Add Shift to redo.", "Open History in the editing toolbar to see the current photo’s stored steps, newest first.", "Click a step to restore its settings. Restoring a step is itself an undoable edit."],
+        "tips": ["Persistent History requires a catalog library. Folder-only use still supports session Undo and Redo.", "Clear removes the photo’s stored history steps; it is not an adjustment-reset command."]
+      },
+      {
+        "title": "Keep a named look",
+        "paragraphs": ["A snapshot stores the photo’s current adjustment settings, crop, masks, Remove corrections, and optics. It is a saved editing state for this photo."],
+        "steps": ["Open History, expand Snapshots, and click Create snapshot.", "Enter a useful name, such as Soft portrait or Before retouching.", "Click the snapshot’s name to apply it later. Use Undo if you want to return to the state you just replaced."],
+        "tips": ["The photo keeps up to 50 snapshots; creating another beyond that limit drops the oldest snapshot from the list.", "The × beside a snapshot deletes that named snapshot, not the original photo."]
+      }
+    ],
+    "related": ["editing-save-recovery", "editing-presets"],
+    "sources": [
+      {"path": "web/history-panel.js", "anchor": "The pane lists\n * steps newest first; restoring one creates another undoable edit."},
+      {"path": "web/history-panel.js", "anchor": "Persistent history is available in catalog libraries. Undo and redo still work in this session."},
+      {"path": "web/history-panel.js", "anchor": "const COALESCE_MS = 2000;"},
+      {"path": "web/app.js", "anchor": "im.versions = [version, ...(im.versions || [])].slice(0, 50);"},
+      {"path": "web/index.html", "anchor": "Undo (Ctrl/⌘Z)"},
+      {"path": "web/index.html", "anchor": "Redo (Ctrl/⌘Shift+Z)"}
+    ]
+  },
+  {
+    "id": "editing-tone",
+    "title": "Adjust exposure, contrast, and tonal range",
+    "category": "Editing",
+    "summary": "Use Light controls and the histogram to set brightness and contrast, then check the result against the original.",
+    "keywords": ["exposure", "brightness", "light", "tone", "contrast", "highlights", "shadows", "whites", "blacks", "auto", "histogram", "clipping", "before"],
+    "sections": [
+      {
+        "title": "Start with Light",
+        "paragraphs": ["Open Edit and expand Light. Exposure changes overall brightness; Highlights and Shadows let you target bright and dark regions. Whites and Blacks adjust the ends of the tonal range. Contrast changes their separation."],
+        "steps": ["Set Exposure for the main subject.", "Adjust Highlights and Shadows to balance bright and dark regions, then refine Whites, Blacks, and Contrast.", "Use the Clipping warning button beside the histogram to inspect clipping.", "Compare your result with the original using the before control, or hold B while the photo is active."],
+        "tips": ["Light’s Reset resets that group. Use Undo when you want to reverse just your latest adjustment."]
+      },
+      {
+        "title": "Use Auto as a starting point",
+        "paragraphs": ["Auto in the Light heading analyzes the available image preview and sets Exposure, Blacks, and Whites. It does not set every editing control."],
+        "steps": ["Wait until the photo preview appears, then click Auto.", "Review the result and refine the sliders for the photograph."],
+        "tips": ["If Auto says it is waiting for the image preview, let the preview load and try again.", "The scope menu also offers Waveform, RGB Parade, and Vectorscope for inspecting tone and color."]
+      }
+    ],
+    "related": ["editing-white-balance", "editing-curves", "editing-history-snapshots"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<details class=\"sec\" id=\"lightSection\" open>"},
+      {"path": "web/index.html", "anchor": "Clipping warning"},
+      {"path": "web/index.html", "anchor": "data-scope=\"vectorscope\""},
+      {"path": "web/app.js", "anchor": "S.grade.exposure = clamp(Math.log2(0.45 / Math.max(mean, 0.02)), -1.5, 1.5);"},
+      {"path": "web/app.js", "anchor": "Auto tone: waiting for image preview…"},
+      {"path": "web/index.html", "anchor": "<b>B</b><span>Show original</span>"}
+    ]
+  },
+  {
+    "id": "editing-white-balance",
+    "title": "Set white balance and overall color",
+    "category": "Editing",
+    "summary": "Use Temp and Tint or sample a neutral area, then adjust Vibrance and Saturation.",
+    "keywords": ["white balance", "wb", "temperature", "temp", "tint", "neutral", "eyedropper", "color cast", "vibrance", "saturation"],
+    "sections": [
+      {
+        "title": "Neutralize a color cast",
+        "paragraphs": ["The Color section in Edit contains Temp and Tint, plus a white-balance eyedropper beside Temp. These are the Edit panel’s finishing controls."],
+        "steps": ["Open Edit and expand Color.", "Click the white-balance eyedropper beside Temp, then click an area in the photo that should be neutral gray.", "Refine Temp and Tint by eye if the sampled result is too warm, cool, green, or magenta.", "Adjust Vibrance and Saturation to control the overall intensity of color."],
+        "tips": ["Choose a visible neutral patch. A nearly black sample produces Too dark to sample; an unavailable preview produces a waiting message.", "Click the eyedropper again to leave sampling mode without choosing a point.", "Color’s Reset also resets its associated color adjustments, including Color Mixer, Point Color, and Color Grading. Use a tool’s own Reset for a narrower change."]
+      }
+    ],
+    "related": ["editing-tone", "editing-color-mixer-point-color", "editing-color-grading"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Click a neutral area to set white balance"},
+      {"path": "web/index.html", "anchor": "Edit-panel Exposure and Temp/Tint are creative finishing controls."},
+      {"path": "web/app.js", "anchor": "if (rr + gg + bb < 0.06) return toast('Too dark to sample');"},
+      {"path": "web/app.js", "anchor": "S.wbPick = !S.wbPick;"},
+      {"path": "web/app.js", "anchor": "delete S.grade.pointColor;"}
+    ]
+  },
+  {
+    "id": "editing-curves",
+    "title": "Shape contrast and color with curves",
+    "category": "Editing",
+    "summary": "Add and move curve points for the combined RGB channel or individual red, green, and blue channels.",
+    "keywords": ["curve", "curves", "tone curve", "rgb", "red", "green", "blue", "contrast", "control point", "s curve"],
+    "sections": [
+      {
+        "title": "Edit a curve",
+        "paragraphs": ["In the Curve graph, the horizontal direction runs from darker input tones to brighter input tones. Moving a point up raises its output; moving it down lowers it. RGB adjusts the combined curve, while R, G, and B affect individual channels."],
+        "steps": ["Open Edit and expand Curve.", "Choose RGB, R, G, or B.", "Click the graph to add a point, then drag it to shape the curve. Drag an existing handle to move it.", "Double-click an interior point to remove it. The two endpoint handles remain.", "Use Curve’s Reset to reset the curves, or Undo to reverse the latest change."],
+        "tips": ["Use a few points and compare the photo as you work; channel curves can introduce strong color casts.", "A stored or imported curve retains its exact saved table until you edit it. The app rebuilds representative handles for editing, so the first adjustment can reshape an imported curve beyond the point you move."]
+      }
+    ],
+    "related": ["editing-tone", "editing-color-grading", "editing-presets"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<button class=\"curveCh on\" data-ch=\"L\">RGB</button>"},
+      {"path": "web/app.js", "anchor": "(function curveEvents()"},
+      {"path": "web/app.js", "anchor": "if (i > 0 && i < pts.length - 1)"},
+      {"path": "web/app.js", "anchor": "handles for editing while drawing the exact table until the first edit."}
+    ]
+  },
+  {
+    "id": "editing-color-mixer-point-color",
+    "title": "Change individual colors with Color Mixer and Point Color",
+    "category": "Editing",
+    "summary": "Adjust a broad color band or sample a specific hue and refine its range, brightness, and uniformity.",
+    "keywords": ["hsl", "color mixer", "colour mixer", "point color", "sample", "hue", "uniformity", "luminance", "saturation", "range"],
+    "sections": [
+      {
+        "title": "Adjust a color band",
+        "paragraphs": ["Color Mixer sits inside Edit → Color. It changes colors within the selected band throughout the photo."],
+        "steps": ["Choose one of the colored band buttons in Color Mixer.", "Adjust Hue to shift that band, Saturation to change its color intensity, and Luminance to change its brightness.", "Select another band to continue, or use Color Mixer’s Reset to clear the mixer adjustments."]
+      },
+      {
+        "title": "Sample a particular color",
+        "paragraphs": ["Point Color gives a sampled hue its own controls. It affects matching colors throughout the photo; use a local mask when you also need to restrict the area."],
+        "steps": ["Click Sample color under Point Color, then click a colorful patch in the photo.", "Adjust Range to narrow or widen the hues affected, then refine Hue shift, Saturation, and Luminance.", "Use Uniform hue, Uniform saturation, or Uniform luminance to make colors in the range more like the sampled patch.", "Choose a saved point in the selector to edit it, or use Delete point to remove it."],
+        "tips": ["Neutral gray patches cannot provide a useful hue sample; choose a more colorful area when prompted.", "Point Color keeps up to eight sampled points. If you sample again when eight already exist, the eighth point is replaced.", "Point Color’s Reset clears the sampled points without requiring a full Color reset."]
+      }
+    ],
+    "related": ["editing-white-balance", "editing-color-grading", "editing-masks-ranges-refinements"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<div class=\"hsl-dots\" id=\"hslBands\"></div>"},
+      {"path": "web/index.html", "anchor": "Uniformity evens the sampled colour across its range. Sample the patch the rest should match."},
+      {"path": "web/app.js", "anchor": "? S.grade.pointColor.slice(0, 7) : [];"},
+      {"path": "web/app.js", "anchor": "toast('Point color sampled');"}
+    ]
+  },
+  {
+    "id": "editing-color-grading",
+    "title": "Color grade shadows, midtones, and highlights",
+    "category": "Editing",
+    "summary": "Give tonal regions different color treatments and control how those treatments blend.",
+    "keywords": ["color grading", "colour grading", "split toning", "shadows", "midtones", "highlights", "global grade", "blending", "balance"],
+    "sections": [
+      {
+        "title": "Build a grade",
+        "paragraphs": ["Color Grading in Edit provides separate Shadows, Midtones, and Highlights selections, plus a global grade. Each has Hue, Saturation, and Luminance controls."],
+        "steps": ["Expand Color Grading and select Shadows, Midtones, or Highlights.", "Choose a Hue, then increase Saturation to make the color treatment visible. Adjust Luminance for that tonal region if needed.", "Repeat for the other regions, or click Edit global grade to change the global treatment.", "Refine Blending and Balance, comparing the photo as you adjust them.", "Use Color Grading’s Reset to clear the grade."],
+        "tips": ["Changing Hue with Saturation at zero does not add visible color. Start with a modest saturation value.", "Use Color Mixer or Point Color when you want to target an existing hue, and a mask when you want to target a location in the photo."]
+      }
+    ],
+    "related": ["editing-color-mixer-point-color", "editing-curves", "editing-masks-brush-gradients"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<div class=\"grading-wheels\" id=\"gradingWheels\">"},
+      {"path": "web/index.html", "anchor": "Edit global grade"},
+      {"path": "web/index.html", "anchor": "data-color-grade-master=\"blending\""},
+      {"path": "web/color-tools.js", "anchor": "export function emptyColorGrading(tones)"}
+    ]
+  },
+  {
+    "id": "editing-detail-effects-enhance",
+    "title": "Sharpen, reduce noise, and use Enhance",
+    "category": "Editing",
+    "summary": "Inspect detail at 1:1, apply ordinary detail controls, or run local learned denoise when available.",
+    "keywords": ["detail", "sharpening", "noise", "denoise", "noise reduction", "enhance", "super resolution", "upscale", "texture", "clarity", "dehaze", "vignette", "sensor"],
+    "sections": [
+      {
+        "title": "Judge detail at 1:1",
+        "paragraphs": ["The Detail section includes Sharpening, Radius, Detail, Masking, Luminance NR, and Color NR. Effects contains Texture, Clarity, Dehaze, and Vignette."],
+        "steps": ["Open a photo and use Space to switch between Fit and 1:1.", "Expand Detail in Edit. Adjust noise reduction and sharpening while looking at both textured and smooth areas.", "Use Effects for texture, local contrast, haze, or edge shading, then check the whole photo at Fit.", "Use the relevant section’s Reset if you want to start that group again."],
+        "tips": ["Detail controls work in both Film and Develop modes. Avoid judging sharpening from a small Fit preview alone."]
+      },
+      {
+        "title": "Run learned denoise on a RAW photo",
+        "paragraphs": ["RAW photos can show Sensor noise reduction and Learned denoise controls. Learned denoise runs locally when you press Apply denoise; moving Strength does not run it live."],
+        "steps": ["Select a RAW photo and expand Detail.", "Check that Apply denoise is available, choose Strength, and click Apply denoise.", "Watch the progress message. Use Cancel if you need to stop the job.", "Inspect the completed preview at 1:1."],
+        "tips": ["Availability depends on the local model, helper, and supported platform. Development builds may lack the model, and the app reports this instead of pretending denoise succeeded."]
+      },
+      {
+        "title": "Create an enhanced derivative in the Mac app",
+        "paragraphs": ["Photo → Enhance Photo… offers Denoise and Super resolution and writes a new 16-bit master when the selected operation succeeds. The original remains untouched."],
+        "steps": ["Select the photo, choose Photo → Enhance Photo…, and read the availability message.", "Choose the enhancement and click Enhance if available.", "After completion, find the new result in the refreshed library and inspect it."],
+        "tips": ["Super resolution has no bundled model and requires a compatible local model. A listed option alone does not mean that operation is available.", "Enhancement can generate detail; evaluate the output before treating it as a faithful record of fine texture."]
+      }
+    ],
+    "related": ["editing-tone", "editing-effects", "editing-history-snapshots"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Judge sharpening and noise reduction at 1:1. These controls work in both Film and Develop modes."},
+      {"path": "web/index.html", "anchor": "<b>Space</b><span>Toggle Fit / 1:1</span>"},
+      {"path": "web/app.js", "anchor": "Runs locally when Apply is pressed; the slider is not live."},
+      {"path": "web/app.js", "anchor": "Writes a new 16-bit master; the original is untouched."},
+      {"path": "enhance_workflow.py", "anchor": "Super-resolution has no bundled model."},
+      {"path": "enhance_workflow.py", "anchor": "Enhance output is model-generated detail, not measured detail."},
+      {"path": "app/main.swift", "anchor": "addEditorItem(photoMenu, title: \"Enhance Photo…\","}
+    ]
+  },
+  {
+    "id": "editing-effects",
+    "title": "Adjust Texture, Clarity, Dehaze, and Vignette",
+    "category": "Editing",
+    "summary": "Refine surface detail, local contrast, haze, and edge brightness from the Effects section.",
+    "keywords": ["effects", "texture", "clarity", "dehaze", "haze", "vignette", "soften", "detail", "local contrast", "dark edges", "bright edges"],
+    "sections": [
+      {
+        "title": "Refine detail and contrast",
+        "paragraphs": ["Expand Effects in Edit. Texture changes fine local detail, while Clarity applies local contrast with greater emphasis on midtones. Positive values strengthen these effects; negative values soften them."],
+        "steps": ["Adjust Texture while looking at a textured part of the photo, such as fabric, foliage, or skin.", "Adjust Clarity while checking contrast around the subject and edges.", "Inspect at 1:1 and then return to Fit to judge the overall result."],
+        "tips": ["For a localized treatment, use a mask’s Texture and Clarity controls."]
+      },
+      {
+        "title": "Change haze and edge brightness",
+        "paragraphs": ["Dehaze changes the image’s haze-like tonal and color treatment. Vignette changes edge brightness: positive values darken the edges and negative values brighten them."],
+        "steps": ["Increase Dehaze to strengthen a hazy image, or try a negative value for a softer treatment. Check both contrast and color as you adjust it.", "Set Vignette for the edge treatment you want and inspect the corners.", "Hold B to compare with the original, or use Effects’ Reset to reset Texture, Clarity, Dehaze, and Vignette together."],
+        "tips": ["Effects’ Vignette is a creative edge treatment. Use Lens corrections when you want to correct lens shading."]
+      }
+    ],
+    "related": ["editing-detail-effects-enhance", "editing-lens-corrections", "editing-masks-brush-gradients", "editing-tone"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<summary><span>Effects</span><a class=\"reset\" href=\"#\" data-reset=\"effects\">Reset</a></summary>"},
+      {"path": "grade.py", "anchor": "\"texture\": 0.0,      # -1..1, one-pixel local detail"},
+      {"path": "grade.py", "anchor": "\"clarity\": 0.0,      # -1..1, midtone-weighted local contrast"},
+      {"path": "grade.py", "anchor": "haze = g[\"dehaze\"] * 0.12"},
+      {"path": "grade.py", "anchor": "falloff = np.clip(1.0 - g[\"vignette\"] * 0.9 * (r ** 2.2), 0.0, 2.0)[..., None]"},
+      {"path": "web/app.js", "anchor": "effects: ['texture', 'clarity', 'dehaze', 'vignette'],"},
+      {"path": "web/index.html", "anchor": "data-local=\"clarity\""}
+    ]
+  },
+  {
+    "id": "editing-photo-merge",
+    "title": "Merge HDR brackets, panoramas, and focus stacks",
+    "category": "Editing",
+    "summary": "Combine a sequence of distinct originals into a new 16-bit TIFF, then edit the merged result.",
+    "keywords": ["photo merge", "merge", "hdr", "high dynamic range", "exposure fusion", "bracket", "panorama", "pano", "stitch", "focus stack", "focus stacking", "tiff", "alignment"],
+    "sections": [
+      {
+        "title": "Start a merge in the Mac app",
+        "paragraphs": ["Photo Merge uses a neutral render of each original and creates a new 16-bit TIFF in LightTable Merges. Apply your final look, crop, and local adjustments to the merged result. The source originals remain available."],
+        "steps": ["Select at least two distinct originals in the library. Multiple virtual copies of one original count as one source.", "Choose Photo → Photo Merge… in the Mac menu.", "Choose HDR · exposure fusion, Panorama · feature aligned, or Focus stack · sharpness fused.", "Optionally enter a Result name, then click Merge.", "Watch the preparation, alignment, blending, and saving progress. When the app reports completion and refreshes the library, open the TIFF in LightTable Merges and inspect it."],
+        "tips": ["Only one merge can run at a time. An existing filename is preserved; a new merge with the same name receives a numbered suffix.", "Merge normally processes each input at up to 6,000 pixels on its long edge. The merged result may therefore have less detail than the full-resolution source sequence.", "If a merge reports an error, read the specific message and correct the input selection before trying again."]
+      },
+      {
+        "title": "Choose suitable inputs",
+        "paragraphs": ["HDR accepts 2–9 exposure-bracketed photos with matching dimensions. It aligns and exposure-fuses display-rendered frames to balance useful tones. Review moving subjects and edges for blending artifacts.", "Panorama accepts 2–20 overlapping frames. Select neighboring frames in sequence so adjacent inputs share visual detail. The app aligns features and blends overlaps; featureless areas or insufficient overlap can prevent a reliable stitch. Panorama canvases are limited to 120 megapixels.", "Focus stack accepts 2–60 focus-bracketed photos with matching dimensions. Use a tripod or focus-rail sequence with shared framing. The app aligns the frames, combines sharp regions, and crops to their common aligned area."],
+        "steps": ["For HDR, inspect highlights, shadows, and anything that moved between exposures.", "For Panorama, inspect seams and the outer boundary, then crop the result as needed.", "For Focus stack, inspect transitions between sharp regions, foreground edges, and the final crop at 1:1."],
+        "tips": ["HDR here is exposure fusion into a rendered TIFF. It does not produce a scene-linear RAW or DNG master.", "An alignment failure can mean the frames lack enough overlap or a common area. Try a more consistent sequence rather than adding unrelated frames."]
+      }
+    ],
+    "related": ["editing-crop-geometry", "editing-tone", "editing-detail-effects-enhance"],
+    "sources": [
+      {"path": "app/main.swift", "anchor": "addEditorItem(photoMenu, title: \"Photo Merge…\","},
+      {"path": "web/index.html", "anchor": "HDR · exposure fusion"},
+      {"path": "web/app.js", "anchor": "return [...new Set(transferTargets().map((image) => image.sourceName || image.name))];"},
+      {"path": "server.py", "anchor": "return neutral_tiff_for(name, entry.get(\"params\") or default_params)"},
+      {"path": "server.py", "anchor": "folder = FOLDER / \"LightTable Merges\""},
+      {"path": "server.py", "anchor": "\"outputSpace\": \"prophoto\", \"bitDepth\": 16,"},
+      {"path": "server.py", "anchor": "MERGE_MAX_EDGE = int(os.environ.get(\"LIGHTTABLE_MERGE_MAX_EDGE\", \"6000\"))"},
+      {"path": "server.py", "anchor": "return {\"error\": \"a merge is already running\"}"},
+      {"path": "merge_workflow.py", "anchor": "Align and exposure-fuse 2-9 bracketed, display-referred frames."},
+      {"path": "merge_workflow.py", "anchor": "HDR inputs must have matching dimensions"},
+      {"path": "merge_workflow.py", "anchor": "Feature-align and feather 2-20 overlapping frames into one panorama."},
+      {"path": "merge_workflow.py", "anchor": "output_width * output_height > 120_000_000"},
+      {"path": "merge_workflow.py", "anchor": "Align and sharpness-fuse 2-60 focus-bracketed frames."},
+      {"path": "merge_workflow.py", "anchor": "Map a focus rail sequence into its middle frame and common crop."},
+      {"path": "merge_workflow.py", "anchor": "candidate = path.with_name(f\"{path.stem}-{index}{path.suffix}\")"}
+    ]
+  },
+  {
+    "id": "editing-crop-geometry",
+    "title": "Crop, straighten, rotate, and correct perspective",
+    "category": "Editing",
+    "summary": "Set a frame and aspect ratio, adjust orientation and perspective, then accept or cancel the crop session.",
+    "keywords": ["crop", "aspect ratio", "straighten", "rotate", "flip", "perspective", "geometry", "upright", "level", "portrait", "landscape", "resize"],
+    "sections": [
+      {
+        "title": "Set the frame",
+        "paragraphs": ["Open Crop in the editing toolbar. Aspect ratio offers Free, Original, standard proportions, and Custom. The crop readout shows the frame and the amount retained."],
+        "steps": ["Choose an aspect ratio. Use Custom to enter your own width-to-height proportion, and the swap button to change orientation.", "Drag a handle to resize the crop or drag inside the frame to move it. Drag outside the existing frame to draw a new crop.", "Use arrow keys to nudge the selection; hold Shift for larger steps.", "Click Done or press Enter to accept. Click Cancel or press Escape to restore the frame from when you opened Crop."],
+        "tips": ["The ratio Lock control lets you keep the current aspect ratio while resizing."]
+      },
+      {
+        "title": "Refine geometry",
+        "paragraphs": ["Crop & Rotate also contains Straighten, 90-degree rotation, horizontal and vertical flips, and Perspective controls."],
+        "steps": ["Try Auto level for a tilted horizon, then refine Straighten if needed.", "Use Rotate left, Rotate right, or the flip buttons for orientation changes.", "Expand Perspective and try Auto upright, or adjust Vertical, Horizontal, and Scale manually.", "Inspect the edges and final framing, then click Done."],
+        "tips": ["Auto level uses lines it can find; inspect the result instead of assuming the detected angle suits the photograph.", "Crop’s Reset resets the crop, rotation, flips, and perspective together."]
+      }
+    ],
+    "related": ["editing-lens-corrections", "editing-history-snapshots"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Reset crop, rotation, flips, and perspective"},
+      {"path": "web/index.html", "anchor": "Drag outside the frame to draw a new crop."},
+      {"path": "web/index.html", "anchor": "Enter accepts; Escape restores the frame from when you opened Crop."},
+      {"path": "web/index.html", "anchor": "Levels the frame from the lines it can find."},
+      {"path": "web/index.html", "anchor": "<button class=\"quiet full\" id=\"autoUpright\">Auto upright</button>"}
+    ]
+  },
+  {
+    "id": "editing-lens-corrections",
+    "title": "Apply lens and chromatic-aberration corrections",
+    "category": "Editing",
+    "summary": "Use a matched or manually selected lens profile, or make manual corrections when an exact profile is unavailable.",
+    "keywords": ["lens", "profile", "distortion", "vignette", "shading", "chromatic aberration", "fringing", "red cyan", "blue yellow", "optics"],
+    "sections": [
+      {
+        "title": "Choose and verify a correction",
+        "paragraphs": ["Expand Lens corrections in Edit. The profile card explains the automatic camera/lens match and whether a usable profile is available."],
+        "steps": ["Read the profile name and match explanation.", "Enable Use matched lens profile when a profile is available, then choose Correct distortion and Correct lens shading as needed.", "If necessary, choose a different entry in Lens profile and compare the correction against the original.", "Refine the manual Distortion and Vignette controls. For color fringes, adjust Red / Cyan and Blue / Yellow under Chromatic aberration."],
+        "tips": ["No exact lens profile found leaves manual distortion and perspective controls available.", "Profile distortion and shading checkboxes are enabled only when the selected profile supplies that correction and the profile is enabled.", "A manually selected profile needs visual checking; the selection does not establish that it is an exact match.", "Lens and fringe corrections remain non-destructive through export."]
+      }
+    ],
+    "related": ["editing-crop-geometry", "editing-detail-effects-enhance"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Automatic correction uses the bundled camera and lens database."},
+      {"path": "web/index.html", "anchor": "Lens and fringe corrections remain non-destructive through export."},
+      {"path": "web/app.js", "anchor": "No exact lens profile found"},
+      {"path": "web/app.js", "anchor": "Profile selected manually. Verify the correction against the original."},
+      {"path": "web/app.js", "anchor": "!profile || !S.optics.profileEnabled || !profile.hasDistortion"}
+    ]
+  },
+  {
+    "id": "editing-masks-brush-gradients",
+    "title": "Make local adjustments with Brush, Linear, and Radial masks",
+    "category": "Editing",
+    "summary": "Paint or draw a mask, inspect its overlay, and adjust only the selected area.",
+    "keywords": ["mask", "masking", "local adjustment", "brush", "linear gradient", "radial gradient", "feather", "flow", "overlay", "dodge", "burn"],
+    "sections": [
+      {
+        "title": "Create a manual mask",
+        "paragraphs": ["Open Mask in the editing toolbar and choose a tool under Create New Mask. Each mask has its own Light and Color adjustments."],
+        "steps": ["Choose Brush to paint, Linear for a graduated adjustment, or Radial for a round adjustment.", "For Brush, choose Size, Feather, and Flow, then paint over the photo. For Linear or Radial, drag on the photo to set the shape.", "Keep Show Overlay enabled while checking the selected area, then turn it off to judge the photo.", "Adjust the selected mask’s Light or Color sliders. Use Amount in Range to reduce its overall strength.", "Rename the mask using its ••• button so its purpose is easy to recognize later."],
+        "tips": ["Add, Subtract, and Intersect put you in painting refinement modes. For a Linear or Radial mask, choose Edit Shape to return to manipulating its shape.", "Enable temporarily switches a mask’s effect off or on. Invert reverses its selection.", "The editor allows up to sixteen local masks. Delete Mask removes the selected mask; Clear All removes the photo’s masks."]
+      }
+    ],
+    "related": ["editing-masks-ai", "editing-masks-ranges-refinements", "editing-history-snapshots"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<span>Create New Mask</span>"},
+      {"path": "web/index.html", "anchor": "id=\"maskBrushFlow\""},
+      {"path": "web/app.js", "anchor": "else $('maskInstruction').textContent = `Drag on the photo to edit the ${mask.type} mask.`;"},
+      {"path": "web/app.js", "anchor": "Up to sixteen local masks can be active"},
+      {"path": "web/app.js", "anchor": "$('maskEditShape').onclick = () => { S.maskRefineMode = null;"}
+    ]
+  },
+  {
+    "id": "editing-masks-ai",
+    "title": "Select Subject, Sky, Object, Depth, or People",
+    "category": "Editing",
+    "summary": "Create local selections on the device, inspect their accuracy, and refine the result before applying adjustments.",
+    "keywords": ["ai mask", "subject", "sky", "object", "depth", "people", "person", "face", "skin", "hair", "eyes", "teeth", "portrait", "select background"],
+    "sections": [
+      {
+        "title": "Create a smart selection",
+        "paragraphs": ["Mask offers Subject, Sky, Object, Depth, and People selections. These run locally; available methods depend on the selection type and platform."],
+        "steps": ["Open Mask and expand Create New Mask.", "Choose Subject or Sky for an automatic selection. For Object, click Object and then click the object in the photo.", "Choose Depth to make a selection from relative distance, then open Range and adjust Far limit and Near limit. Depth runs from far to near.", "Inspect Show Overlay and refine missed or extra areas before adjusting Light or Color."],
+        "tips": ["Subject, Sky, and Object can use local image-based estimates. They can miss edges or select the wrong region, especially where subject and background look alike.", "Depth uses embedded capture depth when available, otherwise a local estimate. Estimated depth is relative and can be inaccurate.", "Use Invert if you want to adjust the area outside the resulting selection."]
+      },
+      {
+        "title": "Select people or facial regions",
+        "paragraphs": ["People offers Person, Face skin, Eyes, Eyebrows, Lips, Teeth, Hair, and Soften skin. People masks require the Vision helper on macOS 14 or later. Face skin and hair are estimated, and no identity is inferred."],
+        "steps": ["Choose People, then the part you want to adjust.", "Inspect the overlay and use painted refinements around boundaries as needed.", "For Soften skin, review the automatically applied Texture and Clarity reduction, then adjust it to suit the portrait."],
+        "tips": ["Read any availability or detection error in the mask panel. A tool appearing in the menu does not guarantee that the required helper or a usable selection is available."]
+      }
+    ],
+    "related": ["editing-masks-brush-gradients", "editing-masks-ranges-refinements", "editing-copy-paste-match-exposure"],
+    "sources": [
+      {"path": "semantic_masks.py", "anchor": "Private, on-device semantic selections for local adjustment masks."},
+      {"path": "semantic_masks.py", "anchor": "People masks need the Vision helper (macOS 14 or later)"},
+      {"path": "semantic_masks.py", "anchor": "Select the connected colour region under a normalized user point."},
+      {"path": "web/index.html", "anchor": "Depth runs from far to near. Embedded capture depth is used when available; otherwise LightTable estimates locally."},
+      {"path": "web/index.html", "anchor": "Face skin and hair are estimated; no identity is inferred."},
+      {"path": "web/app.js", "anchor": "mask.grade.texture = -0.4;"},
+      {"path": "web/app.js", "anchor": "Click the object to select."}
+    ]
+  },
+  {
+    "id": "editing-masks-ranges-refinements",
+    "title": "Refine masks with painting, ranges, and combined selections",
+    "category": "Editing",
+    "summary": "Add, subtract, or intersect areas, then limit an adjustment by luminance or sampled color.",
+    "keywords": ["mask refinement", "add", "subtract", "intersect", "component", "luminance range", "color range", "colour range", "sample colour", "opacity", "amount", "invert"],
+    "sections": [
+      {
+        "title": "Refine by painting",
+        "paragraphs": ["Select the mask in the mask list before refining it. Add expands the selection; Subtract removes painted areas; Intersect keeps only the painted area of the existing selection."],
+        "steps": ["Choose Add, Subtract, or Intersect beneath Selected Mask.", "Set Size, Feather, and Flow, then paint while watching the overlay.", "While using Add, hold Option on Mac to subtract temporarily.", "Turn the overlay off and inspect the adjustment. Use Undo for a refinement you want to reverse."]
+      },
+      {
+        "title": "Combine a smart selection",
+        "paragraphs": ["Smart selection action controls whether the next smart selection becomes a new mask or combines with the currently selected mask."],
+        "steps": ["Select an existing mask, then expand Create New Mask.", "Choose Add to selected mask, Subtract from selected mask, or Intersect with selected mask in Smart selection action.", "Choose the smart tool, such as Subject or Sky, and inspect the combined result."],
+        "tips": ["Set Smart selection action back to Create new mask when you want the next smart selection to have independent adjustments.", "A mask has a component limit; the panel reports when another smart component cannot be added."]
+      },
+      {
+        "title": "Limit by brightness or color",
+        "paragraphs": ["Range narrows a selected mask further. Luminance Low and High restrict brightness values. Colour range targets a hue, and Amount controls the whole mask’s strength."],
+        "steps": ["Expand Range for the selected mask and adjust Luminance Low and Luminance High while checking the overlay.", "Enable Colour range, then click Sample colour and sample a colorful point, or hold Shift and drag over an area to average it.", "Refine Hue, Range, and Colour amount, then use Amount for the overall adjustment strength."],
+        "tips": ["A nearly neutral area does not provide a useful hue sample. Choose a more colorful area when prompted."]
+      }
+    ],
+    "related": ["editing-masks-brush-gradients", "editing-masks-ai", "editing-color-mixer-point-color"],
+    "sources": [
+      {"path": "web/app.js", "anchor": "Paint the only area this mask should retain."},
+      {"path": "web/app.js", "anchor": "Paint over areas to add to this mask. Hold Option to subtract."},
+      {"path": "web/index.html", "anchor": "Smart selection action"},
+      {"path": "web/app.js", "anchor": "This mask has reached its component limit"},
+      {"path": "web/index.html", "anchor": "Luminance Low"},
+      {"path": "web/app.js", "anchor": "Click a color, or Shift-drag to average an area"}
+    ]
+  },
+  {
+    "id": "editing-remove-heal",
+    "title": "Remove spots and refine Heal or Clone corrections",
+    "category": "Editing",
+    "summary": "Paint over distractions, inspect spot visibility, and move the source or target of a correction.",
+    "keywords": ["remove", "heal", "healing", "clone", "retouch", "dust", "spot removal", "visualize spots", "source", "target", "distraction"],
+    "sections": [
+      {
+        "title": "Create a correction",
+        "paragraphs": ["Open Remove in the editing toolbar. Remove, Heal, and Clone are separate modes. Heal and Clone choose an initial source automatically; inspect that source instead of assuming it is suitable."],
+        "steps": ["Choose Remove, Heal, or Clone, then set Size, Feather, and Opacity.", "Click a spot or drag over a distraction in the photo.", "For small dust spots, enable Visualize Spots and adjust Threshold to make edges easier to inspect.", "Turn Visualize Spots off and inspect the corrected photograph."],
+        "tips": ["Selecting a correction and choosing a different mode changes that correction’s mode."]
+      },
+      {
+        "title": "Refine an existing correction",
+        "paragraphs": ["Select a correction in the list to show its controls. The on-image circles indicate the editable target and, for Heal and Clone, the source."],
+        "steps": ["Drag the target circle to reposition the correction, or choose Move Target and click its new position.", "For Heal or Clone, drag the source circle to a better area. Refresh Source tries a different source position.", "Adjust Feather or Opacity if the correction’s edge or strength needs refinement.", "Toggle Enable this correction to compare, or use Delete correction to remove it."],
+        "tips": ["Remove does not expose a source circle or Refresh Source. Those source controls apply to Heal and Clone.", "Clear All removes the photo’s Remove, Heal, and Clone corrections. Use Undo to reverse an accidental editing change."]
+      }
+    ],
+    "related": ["editing-detail-effects-enhance", "editing-history-snapshots", "editing-copy-paste-match-exposure"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Click or drag over a distraction. Heal and Clone choose a source automatically."},
+      {"path": "web/index.html", "anchor": "Visualize Spots"},
+      {"path": "web/app.js", "anchor": "function setHealToolMode(mode)"},
+      {"path": "web/app.js", "anchor": "$('healRefresh').hidden = spot.mode === 'remove';"},
+      {"path": "web/app.js", "anchor": "Click the new target position."},
+      {"path": "web/index.html", "anchor": "Drag either on-image circle to refine the target or source."}
+    ]
+  },
+  {
+    "id": "editing-presets",
+    "title": "Apply, save, and import editing presets",
+    "category": "Editing",
+    "summary": "Reuse editing recipes and inspect conversion coverage when importing Lightroom, Camera Raw, or Capture One presets.",
+    "keywords": ["preset", "presets", "Lightroom", "Camera Raw", "Capture One", "xmp", "lrtemplate", "costyle", "ltpreset", "import preset", "save look", "replace adjustments"],
+    "sections": [
+      {
+        "title": "Apply an existing recipe",
+        "paragraphs": ["Open Presets in the editing toolbar. Manage presets provides the selected preset’s source and conversion coverage, along with explicit application controls."],
+        "steps": ["Choose a preset and review its summary, especially if it came from another editor.", "Use Apply mapped adjustments to apply the settings the preset supplies.", "Use Replace adjustment settings only when you want to reset adjustments, masks, Remove corrections, and geometry before applying the preset.", "Inspect the photo and use Undo if you want to restore the previous edit."],
+        "tips": ["Replace keeps your crop. It keeps Film unless the preset includes Film settings or you enable Turn Film off for the actions below.", "Presets from other editors are converted approximately because their processing differs. Read skipped settings and conversion notes; matching controls do not promise identical pixels."]
+      },
+      {
+        "title": "Save or import a preset",
+        "paragraphs": ["Manage presets can save the current look or import LightTable recipes, Lightroom/Camera Raw presets, and Capture One styles."],
+        "steps": ["To save, select All adjustment settings or Changed settings only under Save current look, choose whether to include Film settings, and click Save new….", "To import, click Import… and choose the preset files. The Mac app also supports choosing a whole preset folder.", "Review the import result and the new preset’s conversion coverage before applying it.", "To share a selected preset, choose an Export format and click Export…."],
+        "tips": ["LightTable export is lossless for its preset format. Lightroom XMP and Capture One style exports are approximate.", "Supported file choices include .ltpreset, .xmp, .lrtemplate, .costyle, .costylepack, .zip, and .json. An accepted extension does not guarantee that every setting inside can be converted."]
+      }
+    ],
+    "related": ["editing-history-snapshots", "editing-copy-paste-match-exposure", "editing-curves"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Replacing resets adjustments, masks, Remove corrections, and geometry before applying this preset."},
+      {"path": "web/index.html", "anchor": "Your crop is kept. Film is kept unless the preset includes it or you turn it off above."},
+      {"path": "web/index.html", "anchor": "accept=\".ltpreset,.xmp,.lrtemplate,.costyle,.costylepack,.zip,.json\""},
+      {"path": "web/index.html", "anchor": "LightTable · lossless"},
+      {"path": "preset_io.py", "anchor": "Control conversion is approximate because Adobe and LightTable use different render engines."},
+      {"path": "web/index.html", "anchor": "In the Mac app, choose individual files or a whole preset folder."}
+    ]
+  },
+  {
+    "id": "editing-copy-paste-match-exposure",
+    "title": "Copy edits to selected photos and match exposure",
+    "category": "Editing",
+    "summary": "Choose which settings to transfer, review mask-specific limits, or match a group to an active exposure reference.",
+    "keywords": ["copy settings", "paste settings", "batch edit", "sync", "auto sync", "synchronize", "multiple photos", "match total exposure", "selection", "clipboard"],
+    "sections": [
+      {
+        "title": "Transfer selected settings",
+        "paragraphs": ["Copy and Paste transfer the groups you explicitly select. Settings in unchecked groups stay as they are on each destination. This is an explicit copy/paste workflow: later edits to the source do not automatically synchronize to the destinations."],
+        "steps": ["Open the source photo and click Copy edit settings, or press Command-Shift-C on Mac or Ctrl-Shift-C on Windows.", "Check the groups you want to transfer, then click Copy settings.", "Select the destination photo or photos in the library and click Paste edit settings, or use Command-Shift-V / Ctrl-Shift-V.", "Read the completion message. For a batch, Stop ends processing after the current photo; completed photos retain the pasted edits."],
+        "tips": ["Crop and geometry, Local masks, and Healing are separate choices and are not included by default.", "Healing copies spot positions and should only be transferred between photos with matching framing."]
+      },
+      {
+        "title": "Review transferred masks",
+        "paragraphs": ["Selected Local masks replace destination masks. Smart selections are detected again for each different photo. Manual mask shapes are copied, so their placement still needs checking."],
+        "tips": ["Object selections need a new object choice on the destination. Smart masks with painted refinements also need manual recreation; these cause the destination paste to be refused rather than silently copying a source-specific selection.", "If masks cannot be transferred, copy again with Local masks unchecked to apply the other groups.", "Inspect the completion report for failed photos. A batch can finish with some photos changed and others left unchanged."]
+      },
+      {
+        "title": "Match total exposure",
+        "paragraphs": ["Match total exposure uses the active photo as its reference. When capture exposure metadata is available, it compares that information; otherwise it falls back to average image brightness. Review the result when scenes or lighting differ."],
+        "steps": ["Select at least two photos and make the intended reference photo active.", "Let the reference edits finish saving.", "Choose Match total exposure in Photo actions, or Library → Match Total Exposure in the Mac menu.", "Inspect each result. The operation updates the relevant exposure control and limits the resulting adjustment to the supported range."],
+        "tips": ["The reference photo is excluded from the target updates. Matching is a starting point, especially when the photos contain different subjects or framing."]
+      }
+    ],
+    "related": ["editing-tone", "editing-presets", "editing-masks-ai", "editing-remove-heal"],
+    "sources": [
+      {"path": "web/edit-transfer.js", "anchor": "Edit transfer plans preserve every unselected destination setting."},
+      {"path": "web/edit-transfer.js", "anchor": "const defaults = ['film', 'raw', 'tone', 'color', 'detail', 'optics'];"},
+      {"path": "web/edit-transfer.js", "anchor": "Copy spot positions; use only with matching framing"},
+      {"path": "web/edit-transfer.js", "anchor": "needs a new object selection. Exclude masks to paste other edits."},
+      {"path": "web/edit-transfer.js", "anchor": "has painted refinements. Recreate it on this photo or exclude masks."},
+      {"path": "web/app.js", "anchor": "Stopping after the current photo…"},
+      {"path": "server.py", "anchor": "targets = [t for t in targets if t != ref_name]"},
+      {"path": "server.py", "anchor": "delta = float(np.log2(ref_lum / target_lum))"},
+      {"path": "app/main.swift", "anchor": "addEditorItem(libraryMenu, title: \"Match Total Exposure\","}
+    ]
+  }
+]

--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -337,22 +337,85 @@
     "title": "Back up the catalog and troubleshoot recovery",
     "category": "Troubleshooting",
     "summary": "Use verified catalog backups, Library Health, and desktop diagnostics when something goes wrong.",
-    "keywords": ["catalog", "backup", "restore", "recovery", "damaged", "corrupt", "crash", "missing", "safe mode", "diagnostics", "log", "repair"],
-    "sections": [
-      {"title": "Back up and inspect", "paragraphs": ["Settings → Catalog shows the catalog location and backup preferences. These backups cover the catalog database; keep a separate backup of your original photo files."], "steps": ["Choose an Automatic backup interval and Backup location.", "Click Back up now and check for a Verified backup result.", "Open Library Health… to check catalog structure, missing files, and recovery information.", "Use Check now to run the available catalog checks. Missing-file entries are kept with their edits."]},
-      {"title": "Understand recovery choices", "paragraphs": ["Restoring a backup returns catalog data to that backup’s state, so later edits are not in it. When a working catalog is restored, the current catalog is backed up first.", "For a damaged catalog, Library Health may offer salvage, restore, or a fresh catalog. Salvage copies readable rows but loses rows on damaged pages. Starting fresh does not carry over ratings, edits, collections, or history. The current damaged catalog file is preserved in Recovery."]},
-      {"title": "Desktop diagnostics", "paragraphs": ["On macOS, Help → Diagnostics offers Reload Interface, Restart Rendering Service, Show Server Log, Library Health…, and Restart in Safe Mode.", "Safe Mode turns off scanning, watched folders, local AI, and engine warm-up. Use Restart Rendering Service to return to normal operation. If an issue persists, include the visible error and relevant server-log details when reporting it."]}
+    "keywords": [
+      "catalog",
+      "backup",
+      "restore",
+      "recovery",
+      "damaged",
+      "corrupt",
+      "crash",
+      "missing",
+      "safe mode",
+      "diagnostics",
+      "log",
+      "repair"
     ],
-    "related": ["settings-and-defaults", "performance-previews"],
+    "sections": [
+      {
+        "title": "Back up and inspect",
+        "paragraphs": [
+          "Settings → Catalog shows the catalog location and backup preferences. Backups include catalog organization, edits, stored masks, history, and variants. Back up original photos, external presets and profiles, and preferences separately."
+        ],
+        "steps": [
+          "Choose an Automatic backup interval and Backup location.",
+          "Click Back up now and check for a Verified backup result.",
+          "Open Library Health… to check catalog structure, missing files, and recovery information.",
+          "Use Check now to run the available catalog checks. Missing-file entries are kept with their edits."
+        ]
+      },
+      {
+        "title": "Understand recovery choices",
+        "paragraphs": [
+          "Restoring a backup returns catalog data to that backup’s state, so later edits are not in it. When a working catalog is restored, the current catalog is backed up first.",
+          "For a damaged catalog, Library Health may offer salvage, restore, or a fresh catalog. Salvage copies readable rows but loses rows on damaged pages. Starting fresh does not carry over ratings, edits, collections, or history. The current damaged catalog file is preserved in Recovery."
+        ]
+      },
+      {
+        "title": "Desktop diagnostics",
+        "paragraphs": [
+          "On macOS, Help → Diagnostics offers Reload Interface, Restart Rendering Service, Show Server Log, Library Health…, and Restart in Safe Mode.",
+          "Safe Mode turns off scanning, watched folders, local AI, and engine warm-up. Use Restart Rendering Service to return to normal operation. If an issue persists, include the visible error and relevant server-log details when reporting it."
+        ]
+      }
+    ],
+    "related": [
+      "settings-and-defaults",
+      "performance-previews"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Verified backups of the current catalog database."},
-      {"path": "web/settings.js", "anchor": "? `Verified backup: ${result.archive}`"},
-      {"path": "web/recovery.js", "anchor": "Missing files: ${verify.missingFiles} (kept with their edits)"},
-      {"path": "web/recovery.js", "anchor": "Edits made after that backup are not in it."},
-      {"path": "web/recovery.js", "anchor": "The current catalog is backed up first, then replaced by this one."},
-      {"path": "web/recovery.js", "anchor": "backup; rows on damaged pages are lost."},
-      {"path": "web/recovery.js", "anchor": "Safe Mode: scanning, watched folders, local AI, and engine warm-up "},
-      {"path": "app/main.swift", "anchor": "diagnosticsMenu, title: \"Restart Rendering Service\","}
+      {
+        "path": "web/index.html",
+        "anchor": "Backups include your catalog organization, edits, stored masks, history, and variants."
+      },
+      {
+        "path": "web/settings.js",
+        "anchor": "? `Verified backup: ${result.archive}`"
+      },
+      {
+        "path": "web/recovery.js",
+        "anchor": "Missing files: ${verify.missingFiles} (kept with their edits)"
+      },
+      {
+        "path": "web/recovery.js",
+        "anchor": "Edits made after that backup are not in it."
+      },
+      {
+        "path": "web/recovery.js",
+        "anchor": "The current catalog is backed up first, then replaced by this one."
+      },
+      {
+        "path": "web/recovery.js",
+        "anchor": "backup; rows on damaged pages are lost."
+      },
+      {
+        "path": "web/recovery.js",
+        "anchor": "Safe Mode: scanning, watched folders, local AI, and engine warm-up "
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "diagnosticsMenu, title: \"Restart Rendering Service\","
+      }
     ]
   }
 ]

--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -1,0 +1,358 @@
+[
+  {
+    "id": "film-getting-started",
+    "title": "Choose and preview a film stock",
+    "category": "Film",
+    "summary": "Turn on the physical film workflow and compare stocks using your own photo.",
+    "keywords": ["film", "stock", "simulation", "negative", "slide", "browse", "preview", "preset", "film off"],
+    "sections": [
+      {"title": "Start with a stock", "paragraphs": ["Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."], "steps": ["Open a still photo and select Film in the tool rail.", "Turn the Film profile switch on.", "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.", "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."]},
+      {"title": "What the previews include", "paragraphs": ["Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.", "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file."], "tips": ["If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."]}
+    ],
+    "related": ["film-exposure-and-processing", "film-negative-paper-and-slides", "film-grain-and-format"],
+    "sources": [
+      {"path": "web/film-browser.js", "anchor": "Previews use this photo’s edits. Choose a stock to apply it."},
+      {"path": "web/film-browser.js", "anchor": "button.onclick = () => { close(); apply(stock.id, snapshot.name); };"},
+      {"path": "web/index.html", "anchor": "Film processing is bypassed. Edit adjustments remain active."},
+      {"path": "web/app.js", "anchor": "option.disabled = profile.rustOnly && !S.rustAvailable;"},
+      {"path": "web/index.html", "anchor": "Include Film profile and physical settings"}
+    ]
+  },
+  {
+    "id": "film-exposure-and-processing",
+    "title": "Set film exposure and development",
+    "category": "Film",
+    "summary": "Understand Camera EV, capture white balance, metering, and development controls.",
+    "keywords": ["exposure", "camera ev", "meter", "white balance", "temperature", "tint", "development", "contrast", "authentic", "creative"],
+    "sections": [
+      {"title": "Capture controls and finishing controls", "paragraphs": ["Camera EV and Capture white balance act before film exposure. Exposure and Temp/Tint in the Edit panel are finishing adjustments later in the workflow.", "Capture white balance requires a RAW original. For a JPEG, HEIF, TIFF, or another processed file, use Edit Temp/Tint."], "steps": ["Turn on Film, choose a stock, and adjust Camera EV.", "Keep Meter scene automatically enabled for automatic scene metering, or turn it off to set the capture exposure yourself.", "Expand Capture & processing to choose As shot, Daylight, Tungsten, or Custom capture white balance for a RAW photo.", "For Custom, adjust Temperature and Capture tint."]},
+      {"title": "Development and linked defaults", "paragraphs": ["Development appears only when the chosen film profile supplies development times. Print development depends on the selected paper and is hidden for slide film. Development contrast is a separate film control.", "Authentic uses linked physical defaults, including the stock’s recommended paper when paper is unlocked. Creative preserves paper overrides when compatible. Changing stocks can still select that stock’s default development time and exposure; compare the result after changing a stock."]}
+    ],
+    "related": ["film-getting-started", "film-negative-paper-and-slides", "film-reference-match"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Camera EV and capture white balance act before film exposure. Edit-panel Exposure and Temp/Tint are creative finishing controls."},
+      {"path": "web/index.html", "anchor": "Capture white balance requires a RAW original. Use Edit Temp/Tint for a processed file."},
+      {"path": "web/app.js", "anchor": "field.hidden = times.length === 0;"},
+      {"path": "web/film-browser.js", "anchor": "next.development_time = film?.defaultDevelopmentTime || 0;"},
+      {"path": "web/film-browser.js", "anchor": "if (Number.isFinite(film?.defaultExposureEv)) next.exposure_ev = film.defaultExposureEv;"},
+      {"path": "web/index.html", "anchor": "Meter scene automatically"}
+    ]
+  },
+  {
+    "id": "film-negative-paper-and-slides",
+    "title": "Work with negative film, paper, and slides",
+    "category": "Film",
+    "summary": "Choose a print process for negatives and understand why print controls disappear for slide film.",
+    "keywords": ["negative", "positive", "reversal", "slide", "transparency", "paper", "print", "output", "lock paper", "filtration", "preflash"],
+    "sections": [
+      {"title": "Negative film and paper", "paragraphs": ["Negative stocks use a film-to-print process. Paper choices are restricted to profiles compatible with the selected film’s color or monochrome channel model.", "Use Print exposure to adjust the print stage. In Capture & processing, choose Paper and enable Lock paper when stock changes if you want to keep a compatible paper while trying other stocks. An incompatible paper still has to be replaced."], "steps": ["Choose a negative stock in Film.", "Choose an Output recipe: Clean scan, Neutral print scan, or Soft optical print.", "Expand Capture & processing to choose Paper and any available Print development time.", "Expand Physical film stages for Print glare, Print preflash, Yellow filter, and Magenta filter."]},
+      {"title": "Slide film is scanned directly", "paragraphs": ["Positive or reversal stocks use a direct transparency scan with no negative-to-paper stage. Paper, print exposure, print development, and other print-only controls are hidden for these stocks.", "Output recipes are modeled starting points for scan softness, sharpening, and print effects where applicable. They are not measured emulations of particular commercial scanners."]}
+    ],
+    "related": ["film-exposure-and-processing", "film-halation-diffusion-scan"],
+    "sources": [
+      {"path": "film_pipeline.py", "anchor": "# Reversal film has no negative-to-paper stage and is scanned directly."},
+      {"path": "film_pipeline.py", "anchor": "Return print-stage profiles with the film's channel model."},
+      {"path": "web/film-browser.js", "anchor": "if (next.workflow_mode === 'authentic' && !next.paper_locked && film?.targetPrint) next.paper = film.targetPrint;"},
+      {"path": "web/app.js", "anchor": "$('paperField').hidden = positive;"},
+      {"path": "film_pipeline.py", "anchor": "# Coherent output-chain starting points. These are modeled recipes, not claims"},
+      {"path": "web/index.html", "anchor": "Lock paper when stock changes"}
+    ]
+  },
+  {
+    "id": "film-grain-and-format",
+    "title": "Adjust film grain and format",
+    "category": "Film",
+    "summary": "Control grain relative to the stock and choose the simulated film size.",
+    "keywords": ["grain", "size", "texture", "35mm", "medium format", "645", "6x6", "6x7", "4x5", "particle", "noise"],
+    "sections": [
+      {"title": "Set the format and grain", "paragraphs": ["Film format sets the physical long edge used by the simulation. The choices are 35 mm, 645, 6 × 6, 6 × 7, and 4 × 5; this setting is separate from cropping the photo.", "Grain size multiplies the chosen stock’s baseline particle area. The readout shows the resulting area in µm², so the same multiplier can show a different area after you change stocks."], "steps": ["In Film profile, choose Film format.", "Expand Physical film stages.", "Enable Grain size and adjust its slider, or clear its checkbox to disable grain.", "Inspect the image at 1:1 and wait for preview detail to finish before judging texture."]},
+      {"title": "What the number represents", "paragraphs": ["The per-stock grain baselines are derived from film speed as visual starting points. They are not laboratory granularity measurements for each emulsion.", "The Grain size setting belongs to the film simulation. Detail sharpening and noise reduction in Edit are separate adjustments."]}
+    ],
+    "related": ["film-getting-started", "performance-previews"],
+    "sources": [
+      {"path": "film_pipeline.py", "anchor": "# The simulation uses the physical long edge to derive micrometres per pixel."},
+      {"path": "film_pipeline.py", "anchor": "# field, so these are explicit speed-derived baselines rather than claims of"},
+      {"path": "film_pipeline.py", "anchor": "Resolve the stock baseline multiplied by the user's grain amount."},
+      {"path": "web/index.html", "anchor": "Judge sharpening and noise reduction at 1:1."},
+      {"path": "web/index.html", "anchor": "id=\"grain_on\" checked"}
+    ]
+  },
+  {
+    "id": "film-halation-diffusion-scan",
+    "title": "Adjust halation, diffusion, and scan character",
+    "category": "Film",
+    "summary": "Refine the film’s physical effects and the selected output recipe.",
+    "keywords": ["halation", "glow", "bloom", "diffusion", "couplers", "glare", "scan", "sharpness", "softness", "scanner", "preflash"],
+    "sections": [
+      {"title": "Physical film stages", "paragraphs": ["Open Film → Physical film stages while Film is enabled. Couplers, Halation, Grain size, and Print glare each have an enable checkbox and an amount control. Turning off a stage disables its amount slider.", "Capture diffusion changes the modeled camera stage. Print glare and Print preflash belong to the print stage and are unavailable for direct slide scans."], "steps": ["Choose the stock and Output recipe before refining the stage controls.", "Change one stage at a time and compare the result.", "Use each stage’s checkbox to compare its contribution without replacing the selected stock."]},
+      {"title": "Scan controls", "paragraphs": ["Scan softness adds lens blur to the selected output recipe. Scan sharpness scales that recipe’s sharpening; Scan sharpening enables or disables it.", "These are adjustments to modeled output recipes, not selections of measured scanner brands. Evaluate fine texture and sharpness with completed 1:1 preview detail."]}
+    ],
+    "related": ["film-negative-paper-and-slides", "film-grain-and-format", "performance-previews"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "These controls modify the selected output recipe. Scanner brand names are intentionally omitted until measured reference scans exist."},
+      {"path": "film_pipeline.py", "anchor": "\"lens_blur\": recipe[\"scanner_lens_blur\"] + p[\"scan_softness\"],"},
+      {"path": "web/app.js", "anchor": "$('halation_amount').disabled = !profileEnabled || !S.params.halation_on;"},
+      {"path": "web/app.js", "anchor": "$('scan_sharpness').disabled = !profileEnabled || !S.params.scan_sharpen;"},
+      {"path": "film_pipeline.py", "anchor": "\"active\": p[\"camera_diffusion_strength\"] > 0,"}
+    ]
+  },
+  {
+    "id": "film-reference-match",
+    "title": "Compare with a reference image",
+    "category": "Film",
+    "summary": "Align a scan or other reference, measure the difference, and apply a starting match.",
+    "keywords": ["reference", "match", "scan", "calibration", "overlay", "split", "opacity", "measure", "color match"],
+    "sections": [
+      {"title": "Load and align", "paragraphs": ["Reference Match is in the Film panel. Use a reference with corresponding image content so alignment and comparison are meaningful."], "steps": ["Expand Reference Match and choose a Reference image.", "Choose Overlay or Split, then set Opacity / split.", "Use Scale, Horizontal, and Vertical to align the reference with your photo.", "Click Measure to inspect the comparison, or Starting match to apply an initial adjustment."]},
+      {"title": "What Starting match changes", "paragraphs": ["Starting match turns off automatic scene metering and adjusts Camera EV. For RAW photos it also sets custom capture white balance; for processed photos it adjusts yellow and magenta print filtration.", "This is a starting adjustment based on measured image statistics, not a guarantee of an exact film or color match. Review the image after applying it and use Undo if needed. Clear removes the reference overlay."], "tips": ["The Calibration target button downloads an image you can use in a reference workflow."]}
+    ],
+    "related": ["film-exposure-and-processing", "film-negative-paper-and-slides"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Load a scan, align it, then measure."},
+      {"path": "web/index.html", "anchor": "Starting match adjusts physical capture exposure and capture WB for RAW, or print filtration for processed files."},
+      {"path": "web/app.js", "anchor": "$('startReferenceMatch').onclick = () => {"},
+      {"path": "web/app.js", "anchor": "S.params.auto_exposure = false;"},
+      {"path": "web/index.html", "anchor": "download=\"lighttable-calibration-target.png\""}
+    ]
+  },
+  {
+    "id": "export-photos",
+    "title": "Export selected photos",
+    "category": "Export",
+    "summary": "Choose exactly which photos to export, preview the output, and monitor progress.",
+    "keywords": ["export", "save", "jpeg", "jpg", "download", "selection", "picked", "rated", "batch", "cancel", "progress"],
+    "sections": [
+      {"title": "Make an export", "paragraphs": ["Export creates rendered output files from your photo edits. Use Selected photos when you want the export limited to a specific selection."], "steps": ["Select the photos you want, then click the Export photos button in the top bar. Command/Ctrl+Shift+E also opens Export.", "Check the Photos field. Choose Selected photos, Picked only, Rated 1+, or All except rejected.", "Choose an export preset or set file type, dimensions, quality, and color space.", "Set the destination and inspect Output preview for the filename, dimensions, and path.", "Click Export and follow the progress in the top bar."]},
+      {"title": "Check the scope and result", "paragraphs": ["Picked only, Rated 1+, and All except rejected select matching still photos from the active catalog, and can include photos outside the displayed collection or filter. Selected photos provides explicit control over the set.", "Use Cancel export to request a stop. Export details reports completed, skipped, and cancelled counts, plus warnings and errors; a warning can occur after a photo was successfully written. Video clips are not rendered by the still-photo export workflow."]}
+    ],
+    "related": ["export-format-color-space", "export-filenames-and-folders", "export-metadata-sidecars"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "aria-label=\"Export photos\""},
+      {"path": "server.py", "anchor": "def export_candidates() -> list[tuple[str, dict, str]]:"},
+      {"path": "server.py", "anchor": "for n, e, export_base_name in export_candidates():"},
+      {"path": "web/app.js", "anchor": "if (meta && e.shiftKey && e.key.toLowerCase() === 'e')"},
+      {"path": "web/app.js", "anchor": "$('exportDetails').onclick = () => {"},
+      {"path": "server.py", "anchor": "Photo exported, but its recipe sidecar could not be saved:"}
+    ]
+  },
+  {
+    "id": "export-format-color-space",
+    "title": "Choose export size, format, and color space",
+    "category": "Export",
+    "summary": "Use export presets and understand bit depth, resizing, and the current color-gamut limits.",
+    "keywords": ["jpeg", "jpg", "png", "heif", "heic", "tiff", "16 bit", "srgb", "p3", "prophoto", "icc", "quality", "full size", "resolution", "preset"],
+    "sections": [
+      {"title": "Formats and presets", "paragraphs": ["The export dialog offers JPEG, HEIF, PNG, and 16-bit TIFF. HEIF is an 8-bit output option on macOS. The quality slider applies to JPEG and HEIF.", "JPG (Large) uses full-size JPEG at quality 92 in sRGB. JPG (Small) uses a 2048-pixel long edge at quality 90 in sRGB. 16-bit TIFF uses full size and ProPhoto RGB. Changing these settings selects Custom."], "steps": ["Open Export and choose a preset across the top.", "Set Dimensions to Full size or a long-edge limit.", "Check Output preview: the exported size reflects rotation and crop, and a long-edge limit downsizes larger images without enlarging smaller ones."]},
+      {"title": "Color space limits", "paragraphs": ["Every export embeds the selected ICC profile. Choose sRGB, Display P3, or ProPhoto RGB in Colour space.", "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors. Encoding one of those results in P3 or ProPhoto does not restore colors already limited by rendering."]}
+    ],
+    "related": ["export-photos", "soft-proof", "external-editor"],
+    "sources": [
+      {"path": "web/app.js", "anchor": "const EXPORT_MODAL_PRESETS = {"},
+      {"path": "web/index.html", "anchor": "TIFF exports are 16-bit RGB. HEIF is high-efficiency 8-bit output on macOS. Every export embeds its selected ICC profile."},
+      {"path": "web/index.html", "anchor": "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors."},
+      {"path": "export_workflow.py", "anchor": "if long_edge and max(width, height) > int(long_edge):"},
+      {"path": "web/app.js", "anchor": "$('modalExQualityRow').style.display = ['jpeg', 'heif'].includes($('modalExFormat').value) ? '' : 'none';"}
+    ]
+  },
+  {
+    "id": "export-filenames-and-folders",
+    "title": "Set export folders and filenames",
+    "category": "Export",
+    "summary": "Choose a destination layout and decide what happens when a filename already exists.",
+    "keywords": ["destination", "folder", "path", "filename", "rename", "overwrite", "skip", "collision", "hierarchy", "sequence", "template"],
+    "sections": [
+      {"title": "Destination layout", "paragraphs": ["One destination folder sends exports to the chosen folder. Subfolder beside each original uses a relative subfolder name for each source photo. Keep source folder hierarchy preserves source-folder organization beneath the export destination."], "steps": ["Open Export and choose Destination layout.", "Use Choose… for a destination folder, or enter a subfolder name such as film-exports for Subfolder beside each original.", "Expand Advanced and edit Filename template.", "Check the filename and destination shown in Output preview before exporting."]},
+      {"title": "Names and existing files", "paragraphs": ["Filename templates support {filename}, {stock}, {date}, {rating}, and {sequence}. For example, {filename}_{stock} includes the source name and film stock.", "Keep both · add a number creates another filename, such as a name ending in -2. Skip existing leaves occupied names alone. Overwrite replaces existing output at the chosen path. Use the output preview to confirm the destination before choosing Overwrite."]}
+    ],
+    "related": ["export-photos", "export-metadata-sidecars"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Keep source folder hierarchy"},
+      {"path": "web/app.js", "anchor": "'Subfolder name, e.g. film-exports'"},
+      {"path": "web/index.html", "anchor": "Filename fields: {filename}, {stock}, {date}, {rating}, {sequence}."},
+      {"path": "export_workflow.py", "anchor": "def collision_path(path: Path, policy: str,"},
+      {"path": "export_workflow.py", "anchor": "candidate = path.with_name(f\"{path.stem}-{index}{path.suffix}\")"}
+    ]
+  },
+  {
+    "id": "export-metadata-sidecars",
+    "title": "Control export metadata, sidecars, and timestamps",
+    "category": "Export",
+    "summary": "Choose metadata privacy, optional recipe files, and capture-time handling.",
+    "keywords": ["metadata", "privacy", "gps", "location", "copyright", "sidecar", "recipe", "timestamp", "date", "timezone", "capture time"],
+    "sections": [
+      {"title": "Metadata and recipe files", "paragraphs": ["Export → Advanced offers All except location, All metadata, Copyright only, and No metadata. The initial metadata choice is All except location.", "Recipe sidecar controls whether LightTable writes a recipe beside the rendered export. This is separate from the portable edits and XMP sidecar preferences for originals in Settings → Files & Metadata."], "steps": ["Expand Advanced in Export.", "Choose the Metadata policy appropriate for the files you will share.", "Choose whether to write a Recipe sidecar beside each exported photo."]},
+      {"title": "File timestamps", "paragraphs": ["File timestamp can use the time of export or the original capture time. If capture timezone is missing, the default is to keep export time and report a warning. You can instead choose to interpret it in this computer’s local timezone.", "Missing or invalid capture time can also leave the export timestamp unchanged. Check Export details for the reported warning. A file’s filesystem timestamp is separate from the metadata policy selected above."]}
+    ],
+    "related": ["export-photos", "export-filenames-and-folders", "settings-and-defaults"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<span>Metadata</span><select id=\"modalExMetadata\">"},
+      {"path": "web/index.html", "anchor": "<span>Recipe sidecar</span><select id=\"modalExSidecar\">"},
+      {"path": "web/index.html", "anchor": "<span>File timestamp</span><select id=\"modalExPreserveCaptureTime\">"},
+      {"path": "export_workflow.py", "anchor": "Capture timezone is missing; kept the export file timestamp."},
+      {"path": "export_workflow.py", "anchor": "Capture time or timezone is invalid; kept the export file timestamp."},
+      {"path": "web/index.html", "anchor": "Keep portable LightTable edits beside originals"}
+    ]
+  },
+  {
+    "id": "soft-proof",
+    "title": "Preview an output with soft proofing",
+    "category": "Export",
+    "summary": "View a display or modeled paper preview without making it part of the exported photo.",
+    "keywords": ["soft proof", "proofing", "gamut", "paper", "ink", "matte", "gloss", "print", "p3", "srgb"],
+    "sections": [
+      {"title": "Turn on soft proof", "paragraphs": ["Soft-proof controls are in the viewer’s View options (•••). They let you inspect an output preview while editing."], "steps": ["Open View options (•••) below the viewer.", "Enable Preview output profile.", "Choose sRGB display, Display P3 display, Matte paper, or Gloss paper.", "For paper targets, choose whether to Simulate paper and ink. Toggle Show out-of-gamut warning as needed.", "Use the Soft Proof on button in the viewer toolbar to turn the preview off."]},
+      {"title": "Interpret the preview", "paragraphs": ["Matte and Gloss in this interface are modeled paper previews; they are not a selection of your printer’s measured ICC profile. Treat the preview as guidance when comparing contrast and color.", "Soft proof is a viewing state. Choose the file’s actual Colour space separately in Export."]}
+    ],
+    "related": ["export-format-color-space", "export-photos"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<strong>Soft proof</strong><div id=\"viewProofControls\"></div>"},
+      {"path": "web/index.html", "anchor": "<select id=\"softProofProfile\">"},
+      {"path": "soft_proof.py", "anchor": "\"matte\": (0.68, 0.032, 0.90),"},
+      {"path": "web/app.js", "anchor": "$('softProofPaper').disabled = !S.softProof.enabled || !printTarget;"},
+      {"path": "web/app.js", "anchor": "function exportModalOptions() {"}
+    ]
+  },
+  {
+    "id": "external-editor",
+    "title": "Edit a photo in another application",
+    "category": "Export",
+    "summary": "Send an adjusted TIFF to another editor and set the format and stacking defaults.",
+    "keywords": ["external", "editor", "photoshop", "affinity", "edit in", "tiff", "round trip", "derivative", "stack"],
+    "sections": [
+      {"title": "Open an external editor", "paragraphs": ["Use Edit in… to prepare photos for another pixel editor. The adjusted TIFF is written beside its original, and can be stacked with it in the catalog."], "steps": ["Select a photo and press Command/Ctrl+E to open Edit in another app.", "Choose Application.", "Choose TIFF with current adjustments, then set TIFF colour space and TIFF bit depth.", "Choose whether to Stack rendered file with original.", "Click Edit and wait for rendering to finish before working in the other app."]},
+      {"title": "RAW files and defaults", "paragraphs": ["RAW originals must be rendered as adjusted TIFFs. Processed original is unavailable if the selection contains a RAW file. For processed photos, that option opens the original rather than preparing an adjusted TIFF.", "Set the default application, color space, bit depth, and stacking behavior in Settings → External Editing. Adjusted TIFFs can use 16 or 8 bits and ProPhoto RGB, Display P3, or sRGB."]}
+    ],
+    "related": ["export-format-color-space", "settings-and-defaults"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "<strong id=\"externalEditTitle\">Edit in another app</strong>"},
+      {"path": "web/index.html", "anchor": "The adjusted TIFF is written beside its original."},
+      {"path": "web/app.js", "anchor": "$('externalEditMode').querySelector('[value=\"original\"]').disabled = hasRaw;"},
+      {"path": "web/app.js", "anchor": "if (meta && !e.shiftKey && e.key.toLowerCase() === 'e')"},
+      {"path": "web/index.html", "anchor": "Defaults for rendered files sent to another pixel editor."}
+    ]
+  },
+  {
+    "id": "settings-and-defaults",
+    "title": "Change preferences and new-photo defaults",
+    "category": "Settings",
+    "summary": "Adjust the interface, culling behavior, portable edits, and starting edits for new photos.",
+    "keywords": ["settings", "preferences", "defaults", "camera", "raw", "serial", "iso", "font", "background", "lights out", "notifications", "xmp", "portable"],
+    "sections": [
+      {"title": "Interface and behavior", "paragraphs": ["Settings changes save automatically. General controls Auto-advance after picking, rejecting, or rating, completion notifications, and update checks.", "Interface controls the viewer background, font scale, Lights Out, loupe information overlay, and crop guides. These preferences change the workspace appearance without changing exported pixels.", "Files & Metadata controls portable LightTable edits beside originals, automatic XMP writing, RAW/JPEG pairing, and keyword entry. Complete portable edits use .lighttable-state.json; XMP carries compatible edits and metadata."]},
+      {"title": "Defaults for unedited photos", "paragraphs": ["Develop Defaults apply only to photos that do not already have saved edits. They can start Film enabled, choose a workflow and neutral Develop profile, and apply a default preset."], "steps": ["Open Settings → Develop Defaults.", "Choose the starting Film, workflow, profile, and preset settings.", "To set camera-specific RAW defaults, open a RAW photo and adjust its RAW settings.", "Choose matching by camera model, serial number, or camera and ISO, then click Use current RAW settings.", "Use Reset in the Current camera area to remove that camera default."]}
+    ],
+    "related": ["keyboard-midi", "photo-index", "performance-previews", "catalog-health-recovery"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Changes save automatically."},
+      {"path": "web/index.html", "anchor": "Applied only to photos that do not already have saved edits."},
+      {"path": "web/index.html", "anchor": "Tune the editing canvas without changing exported pixels."},
+      {"path": "web/index.html", "anchor": "Complete edits travel in .lighttable-state.json when you copy the folder."},
+      {"path": "web/index.html", "anchor": "Match camera defaults by"},
+      {"path": "web/settings.js", "anchor": "byId('settingsSaveCameraDefault').disabled = !raw;"}
+    ]
+  },
+  {
+    "id": "keyboard-midi",
+    "title": "Use keyboard shortcuts and MIDI controls",
+    "category": "Settings",
+    "summary": "Find shortcuts, choose a keyboard scheme, and map a hardware controller where Web MIDI is available.",
+    "keywords": ["keyboard", "shortcut", "hotkey", "midi", "knob", "fader", "controller", "speed keys", "automation", "classic", "lighttable"],
+    "sections": [
+      {"title": "Keyboard preferences", "paragraphs": ["Settings → Shortcuts & Hardware contains the shortcut scheme and a keyboard reference under Keyboard and MIDI controls. The desktop Help menu also has Keyboard Shortcuts.", "Choose LightTable or Classic; the scheme applies after a reload. Hold-key slider control lets you hold a mapped key while scrolling or using arrow keys. Allow automation controls whether approved local tools can control the window with history and Undo."], "tips": ["Command/Ctrl+Shift+E opens Export; Command/Ctrl+E opens external editing. Text fields keep ordinary typing behavior, so leave a text field before using unmodified editing shortcuts."]},
+      {"title": "MIDI mapping", "paragraphs": ["MIDI support depends on the Web MIDI API in the current runtime. The status can show Unavailable, Off, No devices, or a connected device count. Unavailable means this runtime cannot use the MIDI controls."], "steps": ["Connect a MIDI controller that sends Control Change messages.", "When MIDI is available, open Keyboard and MIDI controls and choose MIDI Learn.", "Click the adjustment slider you want to map, then turn a knob or move a fader.", "Check the mapping message, then use the hardware control to adjust the slider.", "Use Reset MIDI to restore the default mappings."]}
+    ],
+    "related": ["settings-and-defaults", "export-photos", "external-editor"],
+    "sources": [
+      {"path": "web/app.js", "anchor": "toast('Shortcut scheme applies after a reload');"},
+      {"path": "web/index.html", "anchor": "Hold a mapped key and scroll or use arrow keys."},
+      {"path": "web/index.html", "anchor": "Let approved local tools control this window with visible history and Undo."},
+      {"path": "web/midi.js", "anchor": "pill.title = 'Web MIDI API not supported in this browser';"},
+      {"path": "web/midi.js", "anchor": "if (status !== 0xb0) return;"},
+      {"path": "web/midi.js", "anchor": "showMidiHud(`Turn any knob to map → ${target.label || target.control}`);"},
+      {"path": "app/main.swift", "anchor": "addEditorItem(helpMenu, title: \"Keyboard Shortcuts\","}
+    ]
+  },
+  {
+    "id": "photo-index",
+    "title": "Enable private photo-content search",
+    "category": "Settings",
+    "summary": "Build an on-device index of objects, scenes, visible text, and faces.",
+    "keywords": ["ai", "search", "index", "contents", "objects", "scenes", "ocr", "text", "faces", "privacy", "local", "description"],
+    "sections": [
+      {"title": "Build the index", "paragraphs": ["The Photo Index is off by default. Analysis stays on this Mac and does not modify photo folders. Apple Vision provides the core analysis; richer Foundation Models descriptions appear only when that capability is available."], "steps": ["Open Settings → Photo Index.", "Check the On-device capabilities status and turn on Photo contents index.", "Wait for indexing progress to complete. Photos can gain results as they are indexed.", "Use the library search field to search photo contents, visible text, or faces alongside filenames and keywords.", "Open Info → On-device description to inspect the current photo’s generated tags, visible text, and face count."]},
+      {"title": "Pause, rebuild, or delete", "paragraphs": ["Turning the index off pauses analysis and removes generated results from the active search view; existing index data remains local until deleted. Rebuild index reruns indexing when the feature is enabled.", "Delete index removes generated index data after confirmation. Originals and saved edits are unchanged. If Apple Vision says Build required, the current installation lacks the required local analyzer. Foundation Models may be unavailable while basic Vision indexing remains usable."]}
+    ],
+    "related": ["assisted-culling", "settings-and-defaults"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Analysis stays on this Mac and never modifies photo folders."},
+      {"path": "web/app.js", "anchor": "'Objects, scenes, visible text, and faces';"},
+      {"path": "web/app.js", "anchor": "'Search photos, contents, text, and faces'"},
+      {"path": "web/app.js", "anchor": "indexed ${S.ai.indexed === 1 ? 'photo remains' : 'photos remain'} local until deleted."},
+      {"path": "web/app.js", "anchor": "Delete the generated local photo index? Your originals and edits will not be changed."},
+      {"path": "film_lab_ai/providers.py", "anchor": "the local Vision analyzer has not been built"}
+    ]
+  },
+  {
+    "id": "assisted-culling",
+    "title": "Review assisted culling suggestions",
+    "category": "Settings",
+    "summary": "Review local analysis signals and apply pick or reject flags only when you choose.",
+    "keywords": ["cull", "culling", "ai", "selects", "rejects", "sharpness", "eyes", "misfire", "documents", "review", "flags"],
+    "sections": [
+      {"title": "Review signals", "paragraphs": ["Assisted culling uses the private Photo Index. It does not flag photos until you ask it to. A photo matches a group if any of your chosen criteria returns yes; not judged means that signal has no usable verdict."], "steps": ["Enable Photo Index in Settings and wait for photos to be scored.", "Expand Assisted culling in the library sidebar.", "Choose Select criteria such as Subject sharpness, Eye sharpness, or Eyes open, or Reject criteria such as Exposure issues, Misfires, or Documents.", "Use Selects, Rejects, or All to review the matching photos.", "Inspect the suggestions, then use Pick selects or Reject rejects if you want to apply those flags."]},
+      {"title": "Applying flags", "paragraphs": ["The confirmation shows the affected count and warns that existing flags on matching photos will be replaced. Linked RAW/JPEG metadata can also include the paired file when that preference is enabled.", "These are analysis signals for your review, not final judgments about which photographs to keep. Rejecting sets a flag; it does not itself move originals to Trash."]}
+    ],
+    "related": ["photo-index", "settings-and-defaults"],
+    "sources": [
+      {"path": "web/app.js", "anchor": "Nothing is flagged until you ask for it."},
+      {"path": "web/local-ai.js", "anchor": "True when any of the chosen criteria answered yes for this photo."},
+      {"path": "web/index.html", "anchor": "<summary>Assisted culling</summary>"},
+      {"path": "web/app.js", "anchor": "Existing flags on those photos are replaced."},
+      {"path": "web/app.js", "anchor": "const targets = linkedMetadataTargets(cullResults(group));"},
+      {"path": "web/app.js", "anchor": "for (const image of targets) enqueuePhotoPatch(image, { status });"}
+    ]
+  },
+  {
+    "id": "performance-previews",
+    "title": "Improve preview speed and check image detail",
+    "category": "Troubleshooting",
+    "summary": "Choose preview resolution, wait for real detail, and manage generated caches.",
+    "keywords": ["performance", "slow", "blurry", "pixelated", "preview", "resolution", "100%", "1:1", "gpu", "rust", "python", "cache", "purge"],
+    "sections": [
+      {"title": "Check what has finished rendering", "paragraphs": ["A 100% zoom setting does not guarantee that full image detail has arrived. The viewer may show Loading 100% detail…, Refining RAW detail…, or Updating preview detail… while it works. Wait for 100% detail ready when assessing fine detail.", "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."], "steps": ["Open Settings → Performance.", "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.", "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.", "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."]},
+      {"title": "Manage cache storage", "paragraphs": ["Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.", "Preview resolution is separate from the Dimensions setting used for exported files."]}
+    ],
+    "related": ["film-grain-and-format", "export-format-color-space", "catalog-health-recovery"],
+    "sources": [
+      {"path": "web/preview-detail.js", "anchor": "if (delivered >= source - 1) return '100% detail ready';"},
+      {"path": "web/preview-detail.js", "anchor": "if (refining) return 'Refining RAW detail…';"},
+      {"path": "web/view-performance.js", "anchor": "if (actualSize) return Math.max(64, Math.min(8000, source || 1100));"},
+      {"path": "web/index.html", "anchor": "Auto · fit display"},
+      {"path": "web/settings.js", "anchor": "Purge generated previews and render caches? Originals and edits are not affected."},
+      {"path": "web/app.js", "anchor": "pythonOption.disabled = rustOnly;"}
+    ]
+  },
+  {
+    "id": "catalog-health-recovery",
+    "title": "Back up the catalog and troubleshoot recovery",
+    "category": "Troubleshooting",
+    "summary": "Use verified catalog backups, Library Health, and desktop diagnostics when something goes wrong.",
+    "keywords": ["catalog", "backup", "restore", "recovery", "damaged", "corrupt", "crash", "missing", "safe mode", "diagnostics", "log", "repair"],
+    "sections": [
+      {"title": "Back up and inspect", "paragraphs": ["Settings → Catalog shows the catalog location and backup preferences. These backups cover the catalog database; keep a separate backup of your original photo files."], "steps": ["Choose an Automatic backup interval and Backup location.", "Click Back up now and check for a Verified backup result.", "Open Library Health… to check catalog structure, missing files, and recovery information.", "Use Check now to run the available catalog checks. Missing-file entries are kept with their edits."]},
+      {"title": "Understand recovery choices", "paragraphs": ["Restoring a backup returns catalog data to that backup’s state, so later edits are not in it. When a working catalog is restored, the current catalog is backed up first.", "For a damaged catalog, Library Health may offer salvage, restore, or a fresh catalog. Salvage copies readable rows but loses rows on damaged pages. Starting fresh does not carry over ratings, edits, collections, or history. The current damaged catalog file is preserved in Recovery."]},
+      {"title": "Desktop diagnostics", "paragraphs": ["On macOS, Help → Diagnostics offers Reload Interface, Restart Rendering Service, Show Server Log, Library Health…, and Restart in Safe Mode.", "Safe Mode turns off scanning, watched folders, local AI, and engine warm-up. Use Restart Rendering Service to return to normal operation. If an issue persists, include the visible error and relevant server-log details when reporting it."]}
+    ],
+    "related": ["settings-and-defaults", "performance-previews"],
+    "sources": [
+      {"path": "web/index.html", "anchor": "Verified backups of the current catalog database."},
+      {"path": "web/settings.js", "anchor": "? `Verified backup: ${result.archive}`"},
+      {"path": "web/recovery.js", "anchor": "Missing files: ${verify.missingFiles} (kept with their edits)"},
+      {"path": "web/recovery.js", "anchor": "Edits made after that backup are not in it."},
+      {"path": "web/recovery.js", "anchor": "The current catalog is backed up first, then replaced by this one."},
+      {"path": "web/recovery.js", "anchor": "backup; rows on damaged pages are lost."},
+      {"path": "web/recovery.js", "anchor": "Safe Mode: scanning, watched folders, local AI, and engine warm-up "},
+      {"path": "app/main.swift", "anchor": "diagnosticsMenu, title: \"Restart Rendering Service\","}
+    ]
+  }
+]

--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -15,6 +15,18 @@
     ],
     "sections": [
       {
+        "title": "Choose a starting point",
+        "paragraphs": [
+          "On a new library, setup offers a local folder, Lightroom migration, or Apple Photos. You can skip setup and add photos later.",
+          "Apple Photos whole-library import requires the macOS app and permission to read Photos. It copies original photos, including RAW files, into Pictures / LightTable Imports / Apple Photos. Your Photos library stays unchanged. iCloud originals download during import, so allow time and disk space. Albums, videos, and Photos edits are not transferred.",
+          "Stop import keeps completed copies. Running it again skips those copies and retries unfinished originals."
+        ],
+        "steps": [
+          "Choose a folder to browse originals in place, or select one of the migration options.",
+          "Review the import result, then continue into the library."
+        ]
+      },
+      {
         "title": "Open a local folder",
         "paragraphs": [
           "In the desktop app, Add Photos opens a picker for photos and folders. LightTable keeps the originals in their current location. Selecting an individual photo adds its containing folder, so other supported photos in that folder can appear too."
@@ -52,6 +64,18 @@
       {
         "path": "web/index.html",
         "anchor": "<button id=\"catalogRescan\" role=\"menuitem\">Rescan folders</button>"
+      },
+      {
+        "path": "web/first-run.js",
+        "anchor": "export function shouldShowSetup("
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "This imports photo originals, including RAW files. Albums, videos, and edits made in Photos aren’t transferred."
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "private final class PhotosLibraryImporter {"
       }
     ]
   },
@@ -303,7 +327,7 @@
       },
       {
         "path": "web/app.js",
-        "anchor": "if (S.viewMode !== 'detail') {"
+        "anchor": "function setViewMode(mode, persist = true) {"
       },
       {
         "path": "web/app.js",
@@ -1088,15 +1112,15 @@
       {
         "title": "Prepare and inspect",
         "paragraphs": [
-          "The importer reads a temporary copy of a Lightroom Classic .lrcat catalog. It matches photos already added to LightTable; it does not automatically add missing source folders or copy original photos."
+          "The importer reads a temporary copy of a Lightroom Classic .lrcat catalog. Add the photo folders used by this catalog lets the import register referenced originals and their containing folders. It leaves originals in place. Clear that option to match only photos already in LightTable.",
+          "Preview compatibility reports matches in the current library without changing it. Photos not yet added may show as unmatched in the preview; importing with Add the photo folders enabled registers available originals before matching again."
         ],
         "steps": [
-          "Add the folders containing the Lightroom originals to LightTable and let them scan.",
-          "Open Local ••• → Import catalog….",
-          "Choose the .lrcat file, or enter its path, then review the photo counts, folder roots, and warnings.",
-          "Choose which categories to import: metadata, keywords, collections, stacks, approximate develop settings, and optional edit history.",
-          "For photos with existing edits, choose Keep mine or Replace with imported.",
-          "Click Import and review the final matched, not found, and skipped counts."
+          "Open Local ••• → Import catalog…, or choose the Lightroom Classic catalog option in setup.",
+          "Choose the .lrcat file and review its counts and warnings.",
+          "Choose the categories to import, the policy for existing edits, and whether to add the referenced photo folders.",
+          "Click Preview compatibility and review mapped and skipped settings. Try 20 variants creates separate trial edits before a larger import.",
+          "Click Import after reviewing compatibility, then read the report and matched, not found, and skipped counts. LightTable creates a catalog backup before a trial or import."
         ]
       },
       {
@@ -1115,7 +1139,7 @@
     "sources": [
       {
         "path": "catalog_import.py",
-        "anchor": "The importer matches files a\n  scan has already added to the catalog."
+        "anchor": "def _register_catalog_originals("
       },
       {
         "path": "catalog_import.py",
@@ -1136,6 +1160,18 @@
       {
         "path": "web/catalog-ui.js",
         "anchor": "apply: { metadata: true, develop: false, crop: false },"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Add the photo folders used by this catalog"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "preview.onclick = () => begin('preview');"
+      },
+      {
+        "path": "server.py",
+        "anchor": "label=\"before-import\""
       }
     ]
   }

--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -1,0 +1,1142 @@
+[
+  {
+    "id": "add-photos",
+    "title": "Add photos and start browsing",
+    "category": "Getting started",
+    "summary": "Open photos or folders in place, then choose a folder and start reviewing.",
+    "keywords": [
+      "start",
+      "open",
+      "browse",
+      "add folder",
+      "originals",
+      "import",
+      "new library"
+    ],
+    "sections": [
+      {
+        "title": "Open a local folder",
+        "paragraphs": [
+          "In the desktop app, Add Photos opens a picker for photos and folders. LightTable keeps the originals in their current location. Selecting an individual photo adds its containing folder, so other supported photos in that folder can appear too."
+        ],
+        "steps": [
+          "Click Add Photos at the upper left and choose one or more photos or folders.",
+          "Choose the folder under Local in the left sidebar. Turn on Include subfolders to browse photos in its child folders.",
+          "Choose Photo Grid, Culling Grid, or Detail at the top. Click a photo to make it active."
+        ],
+        "tips": [
+          "If the sidebar is hidden, use Show or hide library at the upper left."
+        ]
+      },
+      {
+        "title": "Bring new files into an existing folder",
+        "paragraphs": [
+          "Use the Local ••• menu and Rescan folders after adding files outside LightTable. To copy photos from a card into a destination folder, use Import from card… in that menu."
+        ]
+      }
+    ],
+    "related": [
+      "browse-folders",
+      "import-from-card",
+      "views-and-selection"
+    ],
+    "sources": [
+      {
+        "path": "app/main.swift",
+        "anchor": "panel.message = \"Choose photos or folders. LightTable keeps originals in place.\""
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "isDir.boolValue ? url.path : url.deletingLastPathComponent().path"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<button id=\"catalogRescan\" role=\"menuitem\">Rescan folders</button>"
+      }
+    ]
+  },
+  {
+    "id": "import-from-card",
+    "title": "Import photos from a card",
+    "category": "Getting started",
+    "summary": "Copy selected photos into dated folders, with verification and an optional second copy.",
+    "keywords": [
+      "ingest",
+      "memory card",
+      "camera card",
+      "copy",
+      "backup",
+      "duplicates",
+      "import photos"
+    ],
+    "sections": [
+      {
+        "title": "Plan the copy",
+        "paragraphs": [
+          "Import from card copies files into the destination you choose. The card originals stay in place."
+        ],
+        "steps": [
+          "Open Local ••• → Import from card….",
+          "Choose the Source and Destination. Set Folder template and Rename to before scanning. The defaults keep filenames and organize copies as year/year-month-day.",
+          "Choose verification: Full hash, Size only, or None. Set Duplicates to Skip or Copy anyway, and optionally choose Second copy to.",
+          "Click Scan. Review the destination preview and the checked files, then click Import.",
+          "Wait for the copied count and check whether any files failed."
+        ],
+        "tips": [
+          "Template tokens include {filename}, {sequence}, {custom}, {camera}, {yyyy}, {mm}, and {dd}. Start at controls the four-digit sequence.",
+          "The selection list currently shows up to 200 files per scan. Only checked entries in that list are submitted. Check the completed count when working with a larger card.",
+          "If files are reported as cloud-only, download them locally and scan again."
+        ]
+      },
+      {
+        "title": "Refresh the plan when settings change",
+        "paragraphs": [
+          "Scan again after changing the destination or naming templates so you can review the updated paths before importing."
+        ]
+      }
+    ],
+    "related": [
+      "add-photos",
+      "rename-photos"
+    ],
+    "sources": [
+      {
+        "path": "web/index.html",
+        "anchor": "<strong id=\"ingestTitle\">Import from card</strong>"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "(ingestPlan.items || []).slice(0, 200)"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "items: ingestPlan.items.filter((item) => checked.has(item.source))"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "the originals on the card were not touched."
+      },
+      {
+        "path": "ingest_workflow.py",
+        "anchor": "TOKENS = {\"filename\", \"camera\", \"sequence\", \"custom\", *DATE_TOKENS}"
+      }
+    ]
+  },
+  {
+    "id": "browse-folders",
+    "title": "Browse folders and save favorites",
+    "category": "Library",
+    "summary": "Choose the folder scope, include subfolders, and keep frequent folders close at hand.",
+    "keywords": [
+      "favorites",
+      "local",
+      "folders",
+      "sidebar",
+      "missing photos",
+      "rescan",
+      "synchronize"
+    ],
+    "sections": [
+      {
+        "title": "Choose what is in view",
+        "paragraphs": [
+          "Local → Browse lists your added folders. Include subfolders controls whether a selected folder also shows its descendants. Other library filters still apply."
+        ],
+        "steps": [
+          "Click a folder under Local.",
+          "Turn Include subfolders on to include child folders, or off to view only that folder.",
+          "Click the star beside a folder, or open its ••• menu and choose Add as Favorite.",
+          "Use Local → Favorites to return to your saved folders."
+        ]
+      },
+      {
+        "title": "Folder actions",
+        "paragraphs": [
+          "A folder’s ••• menu includes Show in Finder on Mac or Show in File Explorer on Windows. For the current folder, Synchronize Folder refreshes the view. Local ••• → Rescan folders scans the catalog sources.",
+          "Remove from LightTable removes an added root from the app’s source list; it does not move the original files to the Trash. The action is offered when more than one source is available."
+        ]
+      }
+    ],
+    "related": [
+      "add-photos",
+      "search-filter-sort",
+      "trash-rejected"
+    ],
+    "sources": [
+      {
+        "path": "web/index.html",
+        "anchor": "<label class=\"include-subfolders\"><input type=\"checkbox\" id=\"includeSubfolders\">"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "favorite ? 'Remove from Favorites' : 'Add as Favorite'"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "items.push(menuButton('Synchronize Folder', () => location.reload()));"
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "sources.removeAll { $0.path == clean }"
+      }
+    ]
+  },
+  {
+    "id": "search-filter-sort",
+    "title": "Find photos with search, filters, and sorting",
+    "category": "Library",
+    "summary": "Narrow the current folder or collection by text, flags, stars, colour, and file kind.",
+    "keywords": [
+      "find",
+      "search",
+      "keywords",
+      "rating filter",
+      "sort",
+      "capture date",
+      "no results",
+      "unrated"
+    ],
+    "sections": [
+      {
+        "title": "Search the current view",
+        "paragraphs": [
+          "The search box matches text in filenames, display names, keywords, and available photo-index metadata. It searches within the current folder or collection and combines with the other active filters."
+        ],
+        "steps": [
+          "Click Search photos and keywords, or press / when you are not typing in a field.",
+          "Type a word or phrase from the filename or keywords.",
+          "Use All Photos, Unflagged, Picked, Rejected, or Rated in the sidebar to choose a flag or rating group.",
+          "Expand Filter for workflow state, minimum rating, colour label, and file kind.",
+          "Choose File name, Rating, Flag, Capture date, or Colour label in Sort."
+        ]
+      },
+      {
+        "title": "When a photo seems missing",
+        "paragraphs": [
+          "Clear the search text and reset Filter choices, then check the selected folder, Include subfolders, and any active collection. Paired-file preferences and collapsed stacks can also hide a companion or stack member.",
+          "Capture date sorts from earlier to later; Rating sorts higher ratings first."
+        ]
+      }
+    ],
+    "related": [
+      "browse-folders",
+      "smart-collections",
+      "raw-jpeg-pairs",
+      "virtual-copies-and-stacks"
+    ],
+    "sources": [
+      {
+        "path": "web/library.js",
+        "anchor": "const terms = [image.name, image.displayName, ...(image.keywords || []),"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "return matchesKind && photoMatchesQuery(im, search);"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<label for=\"labelFilter\">Colour label</label>"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "list = [...list].sort((a, b) => (b.rating || 0) - (a.rating || 0));"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "captureSortValue(a) - captureSortValue(b)"
+      }
+    ]
+  },
+  {
+    "id": "views-and-selection",
+    "title": "Switch views and select photos",
+    "category": "Getting started",
+    "summary": "Use the grids to choose a set and Detail to inspect an individual photo.",
+    "keywords": [
+      "grid",
+      "detail",
+      "filmstrip",
+      "select multiple",
+      "shift click",
+      "command click",
+      "control click",
+      "navigation",
+      "zoom"
+    ],
+    "sections": [
+      {
+        "title": "Move between views",
+        "paragraphs": [
+          "Photo Grid presents photos as a visual overview. Culling Grid adds room for selection and rating information. Detail opens the active photo for close inspection."
+        ],
+        "steps": [
+          "Use the three Photo view buttons at the top. In the LightTable shortcut scheme, G opens Photo Grid, Shift+G opens Culling Grid, and D opens Detail.",
+          "In a grid, use the Size slider to change thumbnail size.",
+          "Use the left and right arrow keys to move between photos. In Detail, Space toggles Fit and 1:1 when the photo area has focus."
+        ]
+      },
+      {
+        "title": "Build a selection",
+        "paragraphs": [
+          "Click selects a single active photo. Shift-click selects a contiguous range. Command-click on Mac or Control-click adds or removes individual photos.",
+          "In a grid, flag, rating, and colour-label actions apply to the selected set. In Detail, those marking actions apply to the active photo. In Survey, they apply to the active survey cell. Check the marking toolbar’s context before a batch action."
+        ]
+      }
+    ],
+    "related": [
+      "flags-and-ratings",
+      "survey-photos",
+      "shortcut-schemes"
+    ],
+    "sources": [
+      {
+        "path": "web/index.html",
+        "anchor": "aria-label=\"Photo view\""
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "const additive = event.metaKey || event.ctrlKey;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "for (const item of list.slice(first, last + 1)) S.msel.add(item.name);"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (S.viewMode !== 'detail') {"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (e.code === 'Space' && S.viewMode === 'detail' && cur() &&"
+      }
+    ]
+  },
+  {
+    "id": "flags-and-ratings",
+    "title": "Pick, reject, and rate photos",
+    "category": "Library",
+    "summary": "Mark keepers and rejects, give star ratings, and control automatic advance.",
+    "keywords": [
+      "cull",
+      "pick",
+      "reject",
+      "flag",
+      "unflag",
+      "stars",
+      "rating",
+      "auto advance",
+      "keeper"
+    ],
+    "sections": [
+      {
+        "title": "Mark the active photo or grid selection",
+        "paragraphs": [
+          "Flags and stars are separate: a photo can be Picked and have any star rating. Reject marks a photo for review; it does not delete it."
+        ],
+        "steps": [
+          "Use Pick, Reject, and Unflag in the marking toolbar or Info. The P, X, and U keys perform the same actions.",
+          "Click a star or press 1–5 to rate. Press 0 to clear the rating.",
+          "To clear an existing pick, reject, or rating, apply that same mark again.",
+          "Use the sidebar’s Picked, Rejected, and Rated views to review your decisions."
+        ]
+      },
+      {
+        "title": "Control what happens next",
+        "paragraphs": [
+          "Turn Auto-advance on to move to the next photo after picking, rejecting, or rating a single photo. Unflagging does not advance.",
+          "When multiple photos are selected in a grid, marks apply to that set without advancing. If Link pair metadata is on, marking also updates recognized RAW and JPEG companions."
+        ]
+      }
+    ],
+    "related": [
+      "views-and-selection",
+      "colour-labels",
+      "raw-jpeg-pairs",
+      "trash-rejected"
+    ],
+    "sources": [
+      {
+        "path": "web/app.js",
+        "anchor": "const next = st !== 'pending' && targets.every((image) => image.status === st)"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "const next = targets.every((image) => (image.rating || 0) === r) ? 0 : r;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (targets.length === 1 && next !== 'pending' && APP_PREFS.autoAdvance !== false)"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (targets.length === 1 && (advance || APP_PREFS.autoAdvance !== false))"
+      },
+      {
+        "path": "web/labels.js",
+        "anchor": "pick: ['p'], reject: ['x'], unflag: ['u'],"
+      }
+    ]
+  },
+  {
+    "id": "colour-labels",
+    "title": "Organize a workflow with colour labels",
+    "category": "Library",
+    "summary": "Use five colours independently of picks and star ratings.",
+    "keywords": [
+      "color",
+      "colour",
+      "labels",
+      "red",
+      "yellow",
+      "green",
+      "blue",
+      "purple",
+      "workflow"
+    ],
+    "sections": [
+      {
+        "title": "Apply and filter a label",
+        "paragraphs": [
+          "Colour labels are yours to assign meaning to—for example, red for retouching or green for delivery. They do not change star ratings or pick/reject status."
+        ],
+        "steps": [
+          "Select a photo, or a set in a grid, and open Info.",
+          "Under Colour label, choose Red, Yellow, Green, Blue, or Purple. Choose No label to clear it.",
+          "Use 6 for Red, 7 for Yellow, 8 for Green, and 9 for Blue. Purple is available from the colour controls.",
+          "Expand Filter in the library sidebar and use Colour label to find a particular colour, any colour, or unlabelled photos."
+        ],
+        "tips": [
+          "Applying the same label again clears it. Colour-label actions do not auto-advance."
+        ]
+      }
+    ],
+    "related": [
+      "flags-and-ratings",
+      "search-filter-sort",
+      "shortcut-schemes"
+    ],
+    "sources": [
+      {
+        "path": "web/labels.js",
+        "anchor": "export const LABELS = ['none', 'red', 'yellow', 'green', 'blue', 'purple'];"
+      },
+      {
+        "path": "web/labels.js",
+        "anchor": "export const LABEL_KEYS = { 6: 'red', 7: 'yellow', 8: 'green', 9: 'blue' };"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "const next = targets.every(image => cleanLabel(image.label) === labelValue) ? 'none' : labelValue;"
+      }
+    ]
+  },
+  {
+    "id": "shortcut-schemes",
+    "title": "Choose LightTable or Classic shortcuts",
+    "category": "Getting started",
+    "summary": "Choose the keyboard layout that fits your editing habits.",
+    "keywords": [
+      "keyboard",
+      "shortcuts",
+      "classic",
+      "Lightroom",
+      "crop key",
+      "detail key",
+      "before after"
+    ],
+    "sections": [
+      {
+        "title": "Choose a scheme",
+        "paragraphs": [
+          "Open Settings → Shortcuts & Hardware and choose Shortcut scheme. LightTable and Classic share most culling shortcuts, but differ for Detail, Crop, and before/after Compare."
+        ],
+        "steps": [
+          "Choose LightTable for D = Detail, C = Crop, and backslash (\\) = before/after Compare.",
+          "Choose Classic for E = Detail, R = Crop, and C = before/after Compare."
+        ],
+        "tips": [
+          "Both schemes use G for Photo Grid, Shift+G for Culling Grid, N for Survey, P/X/U for flags, and 0–5 for stars.",
+          "Hold B to show the original while inspecting an edit. Slash (/) focuses photo search.",
+          "Photo shortcuts are ignored while typing in text, number, or selection fields. Leave the field before using a photo command."
+        ]
+      }
+    ],
+    "related": [
+      "views-and-selection",
+      "flags-and-ratings",
+      "colour-labels",
+      "survey-photos"
+    ],
+    "sources": [
+      {
+        "path": "web/labels.js",
+        "anchor": "grid: 'g', squareGrid: 'G', detail: 'd', survey: 'n', compare: '\\\\',"
+      },
+      {
+        "path": "web/labels.js",
+        "anchor": "grid: 'g', squareGrid: 'G', detail: 'e', survey: 'n', compare: 'c',"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<h2>Shortcuts &amp; Hardware</h2>"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;"
+      }
+    ]
+  },
+  {
+    "id": "collections",
+    "title": "Group photos into collections",
+    "category": "Library",
+    "summary": "Create named groups without moving the original files.",
+    "keywords": [
+      "collection",
+      "album",
+      "organize",
+      "group",
+      "selected",
+      "delete collection"
+    ],
+    "sections": [
+      {
+        "title": "Create and add photos",
+        "paragraphs": [
+          "A regular collection stores a chosen set of photos. It is separate from the folder arrangement on disk."
+        ],
+        "steps": [
+          "Select the photos you want to group.",
+          "Click Create collection or the + beside Collections, enter a name, and save. The current selection is included.",
+          "Click a collection to view it. Clicking the active collection again leaves it.",
+          "With a regular collection active, choose photos to add and click Add selected to collection."
+        ]
+      },
+      {
+        "title": "Delete a collection",
+        "paragraphs": [
+          "The × beside a collection deletes the collection. This removes the grouping rather than moving original files to the Trash. Search and filters can further narrow the photos shown inside a collection."
+        ]
+      }
+    ],
+    "related": [
+      "smart-collections",
+      "views-and-selection",
+      "browse-folders"
+    ],
+    "sources": [
+      {
+        "path": "web/app.js",
+        "anchor": "const name = await askName('New collection');"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "action: 'create_collection', name,"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "S.activeCollection = S.activeCollection === collection.id ? '' : collection.id;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "await runLibraryAction({ action: 'delete_collection', id: collection.id });"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<button class=\"quiet full compact\" id=\"addToCollection\" disabled>Add selected to collection</button>"
+      }
+    ]
+  },
+  {
+    "id": "smart-collections",
+    "title": "Save a search as a smart collection",
+    "category": "Library",
+    "summary": "Keep a named group that updates from supported rules as photo metadata changes.",
+    "keywords": [
+      "smart collection",
+      "saved search",
+      "dynamic",
+      "filter rules",
+      "automatically",
+      "minimum rating"
+    ],
+    "sections": [
+      {
+        "title": "Save supported rules",
+        "paragraphs": [
+          "A smart collection finds photos that match its saved rules. Supported rules are pick/reject/unflag status, minimum star rating, file kind, and search text."
+        ],
+        "steps": [
+          "Set the search text, desired flag group, minimum rating, and file kind in the library.",
+          "Click the ✦ beside Collections, labelled Save filters as smart collection.",
+          "Name the collection and save.",
+          "Click its name to view matching photos. Changing a photo’s relevant metadata changes whether it matches."
+        ]
+      },
+      {
+        "title": "Know what is saved",
+        "paragraphs": [
+          "Colour-label filters, the selected folder, and Include subfolders are not saved in the smart collection rules. Edited and Unrated only are not supported smart-collection rules. Use supported flag and minimum-rating choices when creating one.",
+          "You cannot manually add photos with Add selected to collection while a smart collection is active. Current search and sidebar filters can still narrow the collection view."
+        ]
+      }
+    ],
+    "related": [
+      "collections",
+      "search-filter-sort",
+      "flags-and-ratings"
+    ],
+    "sources": [
+      {
+        "path": "web/app.js",
+        "anchor": "action: 'create_smart_collection', name,"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "kind: $('kindFilter').value, query: $('search').value },"
+      },
+      {
+        "path": "web/library.js",
+        "anchor": "export function photoMatchesRules(image, rules = {}, exif = null) {"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (!collection || collection.type !== 'regular') return;"
+      }
+    ]
+  },
+  {
+    "id": "survey-photos",
+    "title": "Compare several photos in Survey",
+    "category": "Library",
+    "summary": "Review a group together, mark the active frame, and narrow a set of candidates.",
+    "keywords": [
+      "survey",
+      "compare photos",
+      "compare frames",
+      "burst",
+      "side by side",
+      "keeper",
+      "make select"
+    ],
+    "sections": [
+      {
+        "title": "Review a group",
+        "paragraphs": [
+          "Survey displays original previews for choosing between photos. It shows up to 16 selected photos. If there is no explicit selection, it uses up to six nearby photos in the current view."
+        ],
+        "steps": [
+          "Select candidates in a grid and press N, or open Info → Survey selection.",
+          "Click a photo to make that survey cell active. Use left and right arrows to move between cells.",
+          "Use the marking toolbar or flag, rating, and label shortcuts on the active cell.",
+          "Click × on a cell to remove it from the survey without deleting or rejecting it. Double-click a cell to open that photo in Detail.",
+          "Click Close or press Escape to leave Survey."
+        ]
+      },
+      {
+        "title": "Choose one keeper",
+        "paragraphs": [
+          "Make select picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.",
+          "To judge an edit against its original, use before/after Compare in Detail; Survey is for choosing among different frames."
+        ]
+      }
+    ],
+    "related": [
+      "views-and-selection",
+      "flags-and-ratings",
+      "raw-jpeg-pairs",
+      "shortcut-schemes"
+    ],
+    "sources": [
+      {
+        "path": "web/survey.js",
+        "anchor": "return `/api/orig?name=${encodeURIComponent(image.name)}&w=800"
+      },
+      {
+        "path": "web/survey.js",
+        "anchor": "names = Array.from(new Set(list || [])).slice(0, 16);"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "chosen = list.slice(start, start + 6).map((image) => image.name);"
+      },
+      {
+        "path": "web/survey.js",
+        "anchor": "<button class=\"survey-remove\" title=\"Remove from survey\">×</button>"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "toast('Marked the select and rejected the rest');"
+      }
+    ]
+  },
+  {
+    "id": "virtual-copies-and-stacks",
+    "title": "Try virtual copies and group photos in stacks",
+    "category": "Library",
+    "summary": "Keep alternate edits of one original and collapse related photos in the grid.",
+    "keywords": [
+      "virtual copy",
+      "version",
+      "alternate edit",
+      "stack",
+      "unstack",
+      "duplicate",
+      "copy"
+    ],
+    "sections": [
+      {
+        "title": "Create an alternate edit",
+        "paragraphs": [
+          "A virtual copy refers to the same original file and keeps an independent edit state. It does not create a second original on disk."
+        ],
+        "steps": [
+          "Make the source photo active.",
+          "Open the Photo actions ••• menu beside Sort and Size, then choose Create virtual copy.",
+          "Name the copy and save. The new copy becomes active.",
+          "Edit the copy. Use Filter → Workflow state → Virtual copies to find copies later."
+        ],
+        "tips": [
+          "Delete virtual copy in Photo actions removes the active virtual copy. For a real second file on disk, export a rendered image."
+        ]
+      },
+      {
+        "title": "Collapse a group",
+        "paragraphs": [
+          "Select at least two photos, then choose Photo actions ••• → Stack selected photos and enter a name. The stack’s grid badge shows the member count; click it to expand or collapse. Unstack selected photos removes the grouping."
+        ]
+      }
+    ],
+    "related": [
+      "views-and-selection",
+      "search-filter-sort",
+      "collections"
+    ],
+    "sources": [
+      {
+        "path": "web/app.js",
+        "anchor": "action: 'create_virtual', name: source.name, displayName: displayNameValue,"
+      },
+      {
+        "path": "library_workflow.py",
+        "anchor": "return str(name).split(VIRTUAL_MARKER, 1)[0]"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "const result = await runLibraryAction({ action: 'delete_virtual', name: image.name });"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (members.length < 2) return toast('Select at least two photos to stack');"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "badge.title = stack.collapsed ? 'Expand stack' : 'Collapse stack';"
+      }
+    ]
+  },
+  {
+    "id": "raw-jpeg-pairs",
+    "title": "Work with RAW and JPEG pairs",
+    "category": "Library",
+    "summary": "Choose which companion to show and whether new metadata changes affect both.",
+    "keywords": [
+      "raw",
+      "jpeg",
+      "jpg",
+      "pair",
+      "companion",
+      "linked metadata",
+      "hidden jpeg"
+    ],
+    "sections": [
+      {
+        "title": "Choose the visible companion",
+        "paragraphs": [
+          "LightTable recognizes a pair when one RAW and one JPEG share the same base filename in the same source and folder. Each file keeps its own edits; virtual copies remain independent."
+        ],
+        "steps": [
+          "Open Settings → Files & Metadata and turn on Pair RAW and JPEG captures.",
+          "Set Show paired captures to Both files, Prefer RAW, or Prefer JPEG.",
+          "When viewing a paired photo, use RAW → JPEG or JPEG → RAW near the top to switch to its companion."
+        ]
+      },
+      {
+        "title": "Link new metadata changes",
+        "paragraphs": [
+          "Turn on Link pair metadata to link new ratings, flags, labels, and keyword changes. It does not combine the photo edits.",
+          "Exports and Trash use the files you choose or include in the current view. They do not automatically include a hidden companion. Choose Both files and review the selection when you need both originals. Capture-time correction has its own Include RAW + JPEG companions checkbox."
+        ]
+      }
+    ],
+    "related": [
+      "flags-and-ratings",
+      "metadata-and-keywords",
+      "capture-time",
+      "trash-rejected"
+    ],
+    "sources": [
+      {
+        "path": "web/photo-pairs.js",
+        "anchor": "/** RAW+JPEG pairs share a source and folder. Virtual copies remain independent. */"
+      },
+      {
+        "path": "web/photo-pairs.js",
+        "anchor": "if (members.length !== 2 || members.filter(image => image.raw).length !== 1) continue;"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<h2>Files &amp; Metadata</h2>"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Exports and Trash use only the files you choose."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "button.textContent = image.raw ? 'RAW → JPEG' : 'JPEG → RAW';"
+      }
+    ]
+  },
+  {
+    "id": "rename-photos",
+    "title": "Rename photos with a preview",
+    "category": "Library",
+    "summary": "Apply a consistent filename template to selected originals and their sidecars.",
+    "keywords": [
+      "rename",
+      "filename",
+      "sequence",
+      "batch",
+      "custom text",
+      "date tokens",
+      "sidecars"
+    ],
+    "sections": [
+      {
+        "title": "Preview and apply",
+        "paragraphs": [
+          "Rename changes filenames on disk and keeps the catalog records with the files. It also handles adjacent XMP sidecars. This is different from naming a virtual copy."
+        ],
+        "steps": [
+          "Select the photos to rename.",
+          "Open Info → Rename… (or Photo → Rename… in the Mac menu).",
+          "Enter a Template such as {custom}_{sequence}. Set Custom text and Start at as needed.",
+          "Review the before-and-after filenames in the preview.",
+          "Click Rename to apply."
+        ],
+        "tips": [
+          "Available tokens include {filename}, {camera}, {sequence}, {custom}, {yyyy}, {yy}, {mm}, {dd}, {hh}, {min}, and {ss}. Sequence numbers use four digits.",
+          "The original extension is retained. A naming collision receives a numeric suffix. Rename templates cannot create folders.",
+          "A virtual copy shares its source file: including one in a rename targets that original. The interface does not provide a dedicated rename-undo button."
+        ]
+      }
+    ],
+    "related": [
+      "import-from-card",
+      "virtual-copies-and-stacks",
+      "views-and-selection"
+    ],
+    "sources": [
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "function bindRename() {"
+      },
+      {
+        "path": "server.py",
+        "anchor": "def rename_photos(body: dict) -> dict:"
+      },
+      {
+        "path": "server.py",
+        "anchor": "continue  # a virtual copy shares its original's file"
+      },
+      {
+        "path": "server.py",
+        "anchor": "raise ValueError(\"a rename template cannot create folders\")"
+      },
+      {
+        "path": "server.py",
+        "anchor": "target = path.with_name(f\"{stem}-{suffix}{path.suffix}\")"
+      },
+      {
+        "path": "ingest_workflow.py",
+        "anchor": "SEQUENCE_DIGITS = 4"
+      }
+    ]
+  },
+  {
+    "id": "trash-rejected",
+    "title": "Move rejected photos to the Trash",
+    "category": "Library",
+    "summary": "Review the current view carefully before moving rejected originals and sidecars.",
+    "keywords": [
+      "delete",
+      "trash",
+      "rejected",
+      "restore",
+      "recover",
+      "remove originals",
+      "recycle bin"
+    ],
+    "sections": [
+      {
+        "title": "Review and move rejected files",
+        "paragraphs": [
+          "Rejecting a photo only changes its flag. Move Rejected Photos to Trash is a separate desktop action that affects rejected photos in the current view, not just the active photo."
+        ],
+        "steps": [
+          "Choose the folder or collection and filters that define the photos you want to review.",
+          "Inspect the rejected photos. Check paired-file settings and expand any stacks if you expect to include their other members.",
+          "On Mac, choose Photo → Move Rejected Photos to Trash…, or press Command+Delete.",
+          "Read the photo count in the confirmation and confirm only when it matches your intended set."
+        ],
+        "tips": [
+          "Adjacent XMP sidecars move with the originals. Hidden RAW or JPEG companions stay in the library; choose Both files in paired-capture settings to include them.",
+          "A virtual copy shares its original file. Deleting a virtual copy should use Photo actions → Delete virtual copy; moving its source to the Trash affects every edit that uses that original."
+        ]
+      },
+      {
+        "title": "Recover a mistaken removal on Mac",
+        "paragraphs": [
+          "Use Finder’s Trash to put the original and its sidecars back in their previous folder, then rescan the folder in LightTable. The app does not have an in-app Trash browser."
+        ]
+      }
+    ],
+    "related": [
+      "flags-and-ratings",
+      "raw-jpeg-pairs",
+      "browse-folders",
+      "virtual-copies-and-stacks"
+    ],
+    "sources": [
+      {
+        "path": "web/app.js",
+        "anchor": "const rejected = visible().filter((image) => image.status === 'skipped');"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "Paired files hidden from this view stay in the library."
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "title: \"Move Rejected Photos to Trash…\""
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "try FileManager.default.trashItem("
+      },
+      {
+        "path": "server.py",
+        "anchor": "for sidecar in (path.with_suffix(\".xmp\"), Path(str(path) + \".xmp\")):"
+      }
+    ]
+  },
+  {
+    "id": "metadata-and-keywords",
+    "title": "Add keywords, captions, and rights information",
+    "category": "Library",
+    "summary": "Make photos easier to find and prepare descriptive metadata for export.",
+    "keywords": [
+      "metadata",
+      "IPTC",
+      "EXIF",
+      "keywords",
+      "caption",
+      "title",
+      "copyright",
+      "creator",
+      "location",
+      "GPS"
+    ],
+    "sections": [
+      {
+        "title": "Add searchable keywords",
+        "paragraphs": [
+          "Open Info on the active photo. Enter keywords in Add keywords and click Add or press Enter. Commas separate keywords; Settings → Files & Metadata can also enable semicolon separators and catalog keyword suggestions.",
+          "Use a hierarchical path such as Places > Boston to keep related terms together. The Keyword tree lists catalog terms; click a term to search, or double-click it to rename that catalog keyword."
+        ],
+        "tips": [
+          "The keyword entry acts on the active photo, rather than every selected grid photo. Link pair metadata can also update its RAW or JPEG companion."
+        ]
+      },
+      {
+        "title": "Describe the photo",
+        "paragraphs": [
+          "In Info, expand Description for title, caption, and headline; Rights for creator, copyright, and credit; or Place for location and coordinates. Changes save to the catalog as you type.",
+          "Apply to selection copies the current metadata form to selected photos, including its blank fields. Review the whole form first. Metadata is included in exports according to the export recipe; editing these fields does not rewrite the original image file."
+        ]
+      }
+    ],
+    "related": [
+      "search-filter-sort",
+      "raw-jpeg-pairs",
+      "capture-time"
+    ],
+    "sources": [
+      {
+        "path": "web/app.js",
+        "anchor": "const separator = APP_PREFS.keywordSeparators === 'comma-semicolon'"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "function addKeyword() {\n  const im = cur();"
+      },
+      {
+        "path": "web/metadata-panel.js",
+        "anchor": "pendingSave = { name: currentName, fields: collect() };"
+      },
+      {
+        "path": "web/metadata-panel.js",
+        "anchor": "{ names, fields: collect() });"
+      },
+      {
+        "path": "web/metadata-panel.js",
+        "anchor": "fields[key] = input.value.trim() || null;"
+      },
+      {
+        "path": "web/metadata-panel.js",
+        "anchor": "const name = await ctx.askName('Rename keyword',"
+      },
+      {
+        "path": "web/metadata-panel.js",
+        "anchor": "files when the recipe asks for them; originals are never modified."
+      }
+    ]
+  },
+  {
+    "id": "capture-time",
+    "title": "Correct a camera clock or time zone",
+    "category": "Library",
+    "summary": "Preview a shared clock correction while preserving the intervals between photos.",
+    "keywords": [
+      "capture time",
+      "date",
+      "camera clock",
+      "time zone",
+      "timezone",
+      "daylight saving",
+      "sort date",
+      "timestamp"
+    ],
+    "sections": [
+      {
+        "title": "Preview the correction",
+        "paragraphs": [
+          "Capture-time corrections change catalog dates used for capture-date sorting and exported metadata. Original image files and filesystem dates stay unchanged."
+        ],
+        "steps": [
+          "Select the affected photos and open Info → Correct capture time.",
+          "Enter Shift clock by hours, such as -1 or 5.5.",
+          "Optionally enter Assign time zone as an offset such as -04:00 or +05:30. Leave it blank to keep the existing zone, or enter remove to clear it.",
+          "Choose whether to Include RAW + JPEG companions.",
+          "Click Preview selection and review the before-and-after times and any skipped photos.",
+          "Click Apply previewed changes. If you change the selection or correction controls, preview again first."
+        ]
+      },
+      {
+        "title": "Restore a correction",
+        "paragraphs": [
+          "Assigning a time zone does not also shift the camera clock. Use the shift field when the displayed time itself is wrong.",
+          "Undo last correction reverses the most recent correction held in this window. Restore camera times… previews removing catalog corrections; review the preview and apply it to restore original camera times. Capture-time steps are also available in History."
+        ]
+      }
+    ],
+    "related": [
+      "search-filter-sort",
+      "metadata-and-keywords",
+      "raw-jpeg-pairs"
+    ],
+    "sources": [
+      {
+        "path": "web/index.html",
+        "anchor": "These catalog corrections affect capture-date sorting and exported metadata; original files and filesystem dates stay unchanged."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Assigning a zone does not also shift the clock."
+      },
+      {
+        "path": "web/capture-time.js",
+        "anchor": "el('captureTimeReset').onclick=()=>preview(true);"
+      },
+      {
+        "path": "web/capture-time.js",
+        "anchor": "return {selectionChanged:invalidate};"
+      },
+      {
+        "path": "web/capture-time.js",
+        "anchor": "You can also restore capture-time steps in History."
+      }
+    ]
+  },
+  {
+    "id": "import-lightroom-catalog",
+    "title": "Bring a Lightroom Classic catalog into LightTable",
+    "category": "Getting started",
+    "summary": "Import supported metadata and approximate edits, then review the conversion report.",
+    "keywords": [
+      "Lightroom",
+      "Lightroom Classic",
+      "migrate",
+      "migration",
+      "catalog import",
+      "lrcat",
+      "sidecars",
+      "XMP"
+    ],
+    "sections": [
+      {
+        "title": "Prepare and inspect",
+        "paragraphs": [
+          "The importer reads a temporary copy of a Lightroom Classic .lrcat catalog. It matches photos already added to LightTable; it does not automatically add missing source folders or copy original photos."
+        ],
+        "steps": [
+          "Add the folders containing the Lightroom originals to LightTable and let them scan.",
+          "Open Local ••• → Import catalog….",
+          "Choose the .lrcat file, or enter its path, then review the photo counts, folder roots, and warnings.",
+          "Choose which categories to import: metadata, keywords, collections, stacks, approximate develop settings, and optional edit history.",
+          "For photos with existing edits, choose Keep mine or Replace with imported.",
+          "Click Import and review the final matched, not found, and skipped counts."
+        ]
+      },
+      {
+        "title": "Review translated edits",
+        "paragraphs": [
+          "Develop settings are approximate and cannot promise Lightroom’s rendered appearance. Unsupported local masks, camera profiles, .lrcat-data AI masks or LUT payloads, and unsupported smart-collection rules are reported as skipped. Imported develop settings turn Film off.",
+          "Local ••• → Import sidecars… is a separate action for reading supported metadata from adjacent sidecars. That action does not apply develop settings or crop."
+        ]
+      }
+    ],
+    "related": [
+      "add-photos",
+      "collections",
+      "metadata-and-keywords"
+    ],
+    "sources": [
+      {
+        "path": "catalog_import.py",
+        "anchor": "The importer matches files a\n  scan has already added to the catalog."
+      },
+      {
+        "path": "catalog_import.py",
+        "anchor": "Every read here happens against a throwaway\n  copy of the catalog"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Develop settings (approximate)"
+      },
+      {
+        "path": "catalog_import.py",
+        "anchor": "\"filmOff\": True,"
+      },
+      {
+        "path": "catalog_import.py",
+        "anchor": "masks and imported LUT payloads, local masks, camera profiles, and any\nsmart-collection rule the catalog cannot express."
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "apply: { metadata: true, develop: false, crop: false },"
+      }
+    ]
+  }
+]

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -285,7 +285,7 @@
       "content": "5a0553049a8b55ee9243df162f16abbc78e3e1cd05ae464a8404b19e2c00f680",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "web/catalog-ui.js": "485110df7b9caebe4b4a8be9897fe5e7e61b6c61e7dbcb4fdd5b3562c93af282",
+        "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
         "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
@@ -294,7 +294,7 @@
       "sources": {
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
-        "web/catalog-ui.js": "485110df7b9caebe4b4a8be9897fe5e7e61b6c61e7dbcb4fdd5b3562c93af282",
+        "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
         "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
@@ -345,7 +345,7 @@
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
-        "web/catalog-ui.js": "485110df7b9caebe4b4a8be9897fe5e7e61b6c61e7dbcb4fdd5b3562c93af282"
+        "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba"
       }
     },
     "search-filter-sort": {

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -1,0 +1,418 @@
+{
+  "articles": {
+    "add-photos": {
+      "content": "3fc6505380b2c95d8d20c5d7fc313a655730e3a9a9dd636221dfa1eeae094a5d",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "assisted-culling": {
+      "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
+      }
+    },
+    "browse-folders": {
+      "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "capture-time": {
+      "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
+      "sources": {
+        "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "catalog-health-recovery": {
+      "content": "f6b565f14fbeb65476ffe10b0664a5f21d61b7241605808fe0326c8750d4abec",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
+        "web/settings.js": "42ff15607ec83cae3e73322e96309670571d69a1a8b9de709c51edbabc6112d3"
+      }
+    },
+    "collections": {
+      "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "colour-labels": {
+      "content": "2c5b7d4b0df298ecfb0ddc7e025366294fd42d2036114e43c9d87a70e98b48f4",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
+      }
+    },
+    "editing-color-grading": {
+      "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
+      "sources": {
+        "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-color-mixer-point-color": {
+      "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-copy-paste-match-exposure": {
+      "content": "ea587a5f680591f686563eed6326436e6413f5da512086974be55c4603bebe85",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
+      }
+    },
+    "editing-crop-geometry": {
+      "content": "6319d9249dfba3ab26caa7c6e8d5cb0ec6306da2b993ada340152373c888c60a",
+      "sources": {
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-curves": {
+      "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-detail-effects-enhance": {
+      "content": "eceac49eddd311832852e28fbff3fab0be536cabf1220d3fc81c5087bb62c0ed",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-effects": {
+      "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
+      "sources": {
+        "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-history-snapshots": {
+      "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-lens-corrections": {
+      "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-masks-ai": {
+      "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
+      "sources": {
+        "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-masks-brush-gradients": {
+      "content": "7702f31a22aca801cec4d6985a696f77e4d038fb86613ba1953b2590cd855434",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-masks-ranges-refinements": {
+      "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-photo-merge": {
+      "content": "79288ea8afc3621d945d5e55ca0716c8b4f4ae064c4d9007b7d686d6b9553895",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
+        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-presets": {
+      "content": "53107c055d29749d94f8708d4e18b5e246db2eb67b1b68948659c3f46fc65026",
+      "sources": {
+        "preset_io.py": "16aafa7edd016912ba7538ae223b1b532c3214b507763c22575ba2d0da25c2ea",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-remove-heal": {
+      "content": "41b396a3d13fa3364bd68d63aec838869e50787b3e2a7ab68a5cf4530af3fbf7",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-save-recovery": {
+      "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
+      }
+    },
+    "editing-tone": {
+      "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "editing-white-balance": {
+      "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "export-filenames-and-folders": {
+      "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
+      "sources": {
+        "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "export-format-color-space": {
+      "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
+      "sources": {
+        "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "export-metadata-sidecars": {
+      "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
+      "sources": {
+        "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "export-photos": {
+      "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
+      "sources": {
+        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "external-editor": {
+      "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "film-exposure-and-processing": {
+      "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "film-getting-started": {
+      "content": "40ee07cc67a0c1adc8399b5637ce2013db09cb112ceb00513b673006e42bddf8",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "film-grain-and-format": {
+      "content": "9a1053af3c49d0067e62943d4ab3f7a8ca8162b2205e4a815d392fb32d980234",
+      "sources": {
+        "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "film-halation-diffusion-scan": {
+      "content": "f02ee05d45129d688db98d5b9f91ecb520904e7a508b12926168955ba9bb120d",
+      "sources": {
+        "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "film-negative-paper-and-slides": {
+      "content": "58fd1a72df074b9eba7c45f90e5d34f9d817c60977dfbd42a93ef0ada8fe02bb",
+      "sources": {
+        "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "film-reference-match": {
+      "content": "1be79ec76df974f733a333725c268d6f7314ee6f96216593dc2c0c128786e3ed",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "flags-and-ratings": {
+      "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
+      }
+    },
+    "import-from-card": {
+      "content": "5a0553049a8b55ee9243df162f16abbc78e3e1cd05ae464a8404b19e2c00f680",
+      "sources": {
+        "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
+        "web/catalog-ui.js": "a722be6e3de124d28d5de5728d0e9560194d0b970e83eacfc5472929ad28d8a1",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "import-lightroom-catalog": {
+      "content": "55dbffbe81dfa0505e387996b18f3e0b603d679b34e400866d57006b9d0e3cb3",
+      "sources": {
+        "catalog_import.py": "ee13bce7fb5c016d6f3a223ee2fb0f0855a3d9cb2007daa1e81626d2a15338ae",
+        "web/catalog-ui.js": "a722be6e3de124d28d5de5728d0e9560194d0b970e83eacfc5472929ad28d8a1",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "keyboard-midi": {
+      "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
+      }
+    },
+    "metadata-and-keywords": {
+      "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
+      }
+    },
+    "performance-previews": {
+      "content": "7310080ae9b9d7bfedfa16f4cc37b14892aa4390165db7e2c8ae9c3be52c14ea",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
+        "web/settings.js": "42ff15607ec83cae3e73322e96309670571d69a1a8b9de709c51edbabc6112d3",
+        "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
+      }
+    },
+    "photo-index": {
+      "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
+      "sources": {
+        "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "raw-jpeg-pairs": {
+      "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
+      }
+    },
+    "rename-photos": {
+      "content": "66a50e18b2e2dee4d8a35ea3c59b09e45f609b5dddea804b663e9744a456617d",
+      "sources": {
+        "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
+        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
+        "web/catalog-ui.js": "a722be6e3de124d28d5de5728d0e9560194d0b970e83eacfc5472929ad28d8a1"
+      }
+    },
+    "search-filter-sort": {
+      "content": "ff18bb946e9c68623d3d2f104a2a22025ea0c5d74c3a232c12bf0915ec9730ea",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/library.js": "f34f4221773427bb7372af094babf01a0283b4c9e1b4052c26f9b758c5a619f2"
+      }
+    },
+    "settings-and-defaults": {
+      "content": "c924f166996e97b4da2d038d431ef735d757dc5cc12fba6e959f5fc39450f006",
+      "sources": {
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/settings.js": "42ff15607ec83cae3e73322e96309670571d69a1a8b9de709c51edbabc6112d3"
+      }
+    },
+    "shortcut-schemes": {
+      "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
+      }
+    },
+    "smart-collections": {
+      "content": "2f91873697f5787c3aa826af3e449ff1487e15ab7f2f57bdcc89d19d92095035",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/library.js": "f34f4221773427bb7372af094babf01a0283b4c9e1b4052c26f9b758c5a619f2"
+      }
+    },
+    "soft-proof": {
+      "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
+      "sources": {
+        "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "survey-photos": {
+      "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
+      }
+    },
+    "trash-rejected": {
+      "content": "85731343eefbc085ca0eff4b39db0d043c537b6cc69f3b77c8722ec01725acb9",
+      "sources": {
+        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96"
+      }
+    },
+    "views-and-selection": {
+      "content": "6cab8261d08ae6516fc3032f710226f99ffb3ed395e0b1dd0b81f15c7fb0c18e",
+      "sources": {
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+      }
+    },
+    "virtual-copies-and-stacks": {
+      "content": "48e2beb283a16a46d8174bac5f9a0511c623a5665591f02deac6badd33ba3692",
+      "sources": {
+        "library_workflow.py": "ac36ded31b6b62e88c8a8624004d769942d060db1a910afda0077092dd31274c",
+        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96"
+      }
+    }
+  },
+  "version": 1
+}

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -1,55 +1,56 @@
 {
   "articles": {
     "add-photos": {
-      "content": "3fc6505380b2c95d8d20c5d7fc313a655730e3a9a9dd636221dfa1eeae094a5d",
+      "content": "78282b14cc31bbf1590b392567e0fe5837406ff0cc71045134480816ea9f491e",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
+        "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
     },
     "browse-folders": {
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "capture-time": {
       "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
       "sources": {
         "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "catalog-health-recovery": {
-      "content": "f6b565f14fbeb65476ffe10b0664a5f21d61b7241605808fe0326c8750d4abec",
+      "content": "41e3f81ef36412cf1ec4ce0f431988f484834120a750a45d31a1fef66365c718",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
-        "web/settings.js": "42ff15607ec83cae3e73322e96309670571d69a1a8b9de709c51edbabc6112d3"
+        "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82"
       }
     },
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "colour-labels": {
       "content": "2c5b7d4b0df298ecfb0ddc7e025366294fd42d2036114e43c9d87a70e98b48f4",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -57,226 +58,226 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-copy-paste-match-exposure": {
       "content": "ea587a5f680591f686563eed6326436e6413f5da512086974be55c4603bebe85",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
-        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
+        "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
     "editing-crop-geometry": {
-      "content": "6319d9249dfba3ab26caa7c6e8d5cb0ec6306da2b993ada340152373c888c60a",
+      "content": "847f666d8a355cae0104998f95f855baf7de6490a8445d2603e67e681623393c",
       "sources": {
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-curves": {
       "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-detail-effects-enhance": {
       "content": "eceac49eddd311832852e28fbff3fab0be536cabf1220d3fc81c5087bb62c0ed",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-effects": {
       "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-masks-ai": {
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "7702f31a22aca801cec4d6985a696f77e4d038fb86613ba1953b2590cd855434",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-photo-merge": {
       "content": "79288ea8afc3621d945d5e55ca0716c8b4f4ae064c4d9007b7d686d6b9553895",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
-        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-presets": {
       "content": "53107c055d29749d94f8708d4e18b5e246db2eb67b1b68948659c3f46fc65026",
       "sources": {
         "preset_io.py": "16aafa7edd016912ba7538ae223b1b532c3214b507763c22575ba2d0da25c2ea",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-remove-heal": {
       "content": "41b396a3d13fa3364bd68d63aec838869e50787b3e2a7ab68a5cf4530af3fbf7",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "export-filenames-and-folders": {
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "export-format-color-space": {
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "export-metadata-sidecars": {
       "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "export-photos": {
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
-        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "film-getting-started": {
       "content": "40ee07cc67a0c1adc8399b5637ce2013db09cb112ceb00513b673006e42bddf8",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "film-grain-and-format": {
       "content": "9a1053af3c49d0067e62943d4ab3f7a8ca8162b2205e4a815d392fb32d980234",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "film-halation-diffusion-scan": {
       "content": "f02ee05d45129d688db98d5b9f91ecb520904e7a508b12926168955ba9bb120d",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "film-negative-paper-and-slides": {
       "content": "58fd1a72df074b9eba7c45f90e5d34f9d817c60977dfbd42a93ef0ada8fe02bb",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "film-reference-match": {
       "content": "1be79ec76df974f733a333725c268d6f7314ee6f96216593dc2c0c128786e3ed",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -284,41 +285,42 @@
       "content": "5a0553049a8b55ee9243df162f16abbc78e3e1cd05ae464a8404b19e2c00f680",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "web/catalog-ui.js": "a722be6e3de124d28d5de5728d0e9560194d0b970e83eacfc5472929ad28d8a1",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/catalog-ui.js": "485110df7b9caebe4b4a8be9897fe5e7e61b6c61e7dbcb4fdd5b3562c93af282",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "import-lightroom-catalog": {
-      "content": "55dbffbe81dfa0505e387996b18f3e0b603d679b34e400866d57006b9d0e3cb3",
+      "content": "431fb5fc10894d56e863219e9661ab2995d81996b9f8816abf7f3c7b9f4485ce",
       "sources": {
-        "catalog_import.py": "ee13bce7fb5c016d6f3a223ee2fb0f0855a3d9cb2007daa1e81626d2a15338ae",
-        "web/catalog-ui.js": "a722be6e3de124d28d5de5728d0e9560194d0b970e83eacfc5472929ad28d8a1",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
+        "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
+        "web/catalog-ui.js": "485110df7b9caebe4b4a8be9897fe5e7e61b6c61e7dbcb4fdd5b3562c93af282",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "keyboard-midi": {
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
     },
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
       "content": "7310080ae9b9d7bfedfa16f4cc37b14892aa4390165db7e2c8ae9c3be52c14ea",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
-        "web/settings.js": "42ff15607ec83cae3e73322e96309670571d69a1a8b9de709c51edbabc6112d3",
+        "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
       }
     },
@@ -326,15 +328,15 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -342,37 +344,37 @@
       "content": "66a50e18b2e2dee4d8a35ea3c59b09e45f609b5dddea804b663e9744a456617d",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
-        "web/catalog-ui.js": "a722be6e3de124d28d5de5728d0e9560194d0b970e83eacfc5472929ad28d8a1"
+        "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
+        "web/catalog-ui.js": "485110df7b9caebe4b4a8be9897fe5e7e61b6c61e7dbcb4fdd5b3562c93af282"
       }
     },
     "search-filter-sort": {
       "content": "ff18bb946e9c68623d3d2f104a2a22025ea0c5d74c3a232c12bf0915ec9730ea",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/library.js": "f34f4221773427bb7372af094babf01a0283b4c9e1b4052c26f9b758c5a619f2"
       }
     },
     "settings-and-defaults": {
       "content": "c924f166996e97b4da2d038d431ef735d757dc5cc12fba6e959f5fc39450f006",
       "sources": {
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
-        "web/settings.js": "42ff15607ec83cae3e73322e96309670571d69a1a8b9de709c51edbabc6112d3"
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82"
       }
     },
     "shortcut-schemes": {
       "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
     "smart-collections": {
       "content": "2f91873697f5787c3aa826af3e449ff1487e15ab7f2f57bdcc89d19d92095035",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/library.js": "f34f4221773427bb7372af094babf01a0283b4c9e1b4052c26f9b758c5a619f2"
       }
     },
@@ -380,37 +382,37 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
         "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
       }
     },
     "trash-rejected": {
       "content": "85731343eefbc085ca0eff4b39db0d043c537b6cc69f3b77c8722ec01725acb9",
       "sources": {
-        "app/main.swift": "699c60b95a6425512f52bb0e1c03ae2be98f566169428120bf99980d8023045b",
-        "server.py": "3338c25a300ab1445e82f8fa71d3d4c43922f4f605d82b6e3eb3aa78ca9d18a7",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96"
+        "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
+        "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b"
       }
     },
     "views-and-selection": {
-      "content": "6cab8261d08ae6516fc3032f710226f99ffb3ed395e0b1dd0b81f15c7fb0c18e",
+      "content": "7412cdc7f39cc344f7b438ad008a5661ec18d13009da7cbbe2a405bf6a5e710b",
       "sources": {
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96",
-        "web/index.html": "9b492083f4a8483edfcc0cebfe493971340b4125daae928be342f1a140d6c2c9"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
       }
     },
     "virtual-copies-and-stacks": {
       "content": "48e2beb283a16a46d8174bac5f9a0511c623a5665591f02deac6badd33ba3692",
       "sources": {
         "library_workflow.py": "ac36ded31b6b62e88c8a8624004d769942d060db1a910afda0077092dd31274c",
-        "web/app.js": "7830afb84b9afaf7956e7840ab0a5a33ed78f489592a6e3a2e5ed887dd426c96"
+        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b"
       }
     }
   },

--- a/durable_io.py
+++ b/durable_io.py
@@ -222,3 +222,30 @@ def move_file_no_replace(source: Path | str, destination: Path | str) -> Path:
         raise
     _flush_directory(source.parent)
     return destination
+
+
+def publish_cache(staged: Path | str, destination: Path | str) -> Path:
+    """Atomically publish disposable, validated cache data without fsync.
+
+    Only reproducible cache entries may use this path. Catalog state, originals,
+    user exports and sidecars must continue using the durable publishers.
+    """
+    destination = Path(destination)
+    os.replace(staged, destination)
+    return destination
+
+
+def cache_write_bytes(path: Path | str, payload: bytes) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    staged = temporary_path(path, "cache")
+    try:
+        staged.write_bytes(payload)
+        return publish_cache(staged, path)
+    finally:
+        staged.unlink(missing_ok=True)
+
+
+def cache_write_json(path: Path | str, value: Any, *,
+                     indent: int | None = None) -> Path:
+    return cache_write_bytes(path, json.dumps(value, indent=indent).encode("utf-8"))

--- a/lighttable_cli/__main__.py
+++ b/lighttable_cli/__main__.py
@@ -102,6 +102,54 @@ def merge_mapping(base: dict, patch: dict) -> dict:
     return result
 
 
+# The window's lens defaults. A preset carrying exactly these values has no
+# lens edit to apply, so they are not layered onto a photo.
+OPTICS_DEFAULTS = {
+    "profileEnabled": False, "profileDistortion": True, "profileVignette": True,
+    "flipHorizontal": False, "flipVertical": False, "distortion": 0.0,
+    "vignette": 0.0, "vertical": 0.0, "horizontal": 0.0, "rotate": 0.0,
+    "scale": 1.0,
+}
+PRESET_LAYERED = ("masks", "heals")
+
+
+def preset_state(preset: dict) -> dict:
+    """The groups a preset carries, following the window's layering rules.
+
+    A saved preset stores every group, so a grade-only preset still holds an
+    empty film recipe, empty mask and heal lists, and default lens values.
+    Sending those would reset the photo's own film, local corrections, and
+    geometry; only the groups the preset actually contains are applied.
+    """
+    entry: dict = {}
+    grade = preset.get("grade") if isinstance(preset.get("grade"), dict) else {}
+    included = preset.get("includedGrade")
+    if not isinstance(included, list):
+        included = list(grade)
+    chosen = {key: grade[key] for key in included if key in grade}
+    if chosen:
+        entry["grade"] = chosen
+    params = preset.get("params")
+    if preset.get("includeFilm", True) and isinstance(params, dict) and params:
+        entry["params"] = params
+    for key in PRESET_LAYERED:
+        if isinstance(preset.get(key), list) and preset[key]:
+            entry[key] = preset[key]
+    optics = preset.get("optics") if isinstance(preset.get("optics"), dict) else {}
+    changed = {key: value for key, value in optics.items()
+               if key not in OPTICS_DEFAULTS or value != OPTICS_DEFAULTS[key]}
+    if changed:
+        entry["optics"] = changed
+    return entry
+
+
+def fresh_identities(items: list, group: str) -> list:
+    """Copy layered masks or heals with identities that cannot collide."""
+    prefix = group[:-1]
+    return [{**item, "id": f"{prefix}-{uuid.uuid4().hex}"}
+            if isinstance(item, dict) else item for item in items]
+
+
 def add_selector_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("refs", nargs="*", help="qualified names, paths, #ids, @current, or @selection")
     parser.add_argument("--where", action="append", default=[], metavar="FIELD=VALUE")
@@ -184,7 +232,8 @@ def build_parser() -> argparse.ArgumentParser:
     edit.add_argument("--include", default="film,grade,crop,masks,heals,optics")
     edit.add_argument("--preset", help="apply a named preset")
     edit.add_argument("--layer", action="store_true",
-                      help="merge a tool preset over existing settings")
+                      help="accepted for compatibility; presets always layer"
+                           " over existing settings")
     edit.add_argument("--group", choices=["film", "grade", "crop", "masks", "heals", "optics", "all"], default="all")
     edit.add_argument("--history-label", "--label", default="Command-line edit")
 
@@ -424,8 +473,13 @@ def state_update(client: Client, names: list[str], entry: dict, args,
 
 
 def state_merge_update(client: Client, names: list[str], entry: dict, args,
-                       history_label: str) -> dict:
-    """Apply a patch without replacing each photo's unsupplied nested fields."""
+                       history_label: str, *,
+                       append: tuple[str, ...] = ()) -> dict:
+    """Apply a patch without replacing each photo's unsupplied nested fields.
+
+    Groups named in ``append`` are lists layered after the photo's own items
+    with fresh identities, the way the window applies a preset's masks.
+    """
     results = []
     for name in names:
         current = client.get(query("/api/state", name=name))
@@ -433,6 +487,9 @@ def state_merge_update(client: Client, names: list[str], entry: dict, args,
         for key, incoming in entry.items():
             if key in {"grade", "params", "optics"} and isinstance(incoming, dict):
                 merged[key] = merge_mapping(current.get(key) or {}, incoming)
+            elif key in append and isinstance(incoming, list):
+                merged[key] = [*(current.get(key) or []),
+                               *fresh_identities(incoming, key)]
             else:
                 merged[key] = incoming
         results.append(client.post("/api/state", {
@@ -598,12 +655,7 @@ def dispatch(client: Client, args):
                            if item.get("name") == args.preset), None)
             if preset is None:
                 raise ValueError("preset not found")
-            preset_entry = {key: preset[key] for key in
-                            ("params", "grade", "masks", "heals", "optics")
-                            if key in preset}
-            if not preset.get("includeFilm", True):
-                preset_entry.pop("params", None)
-            entry = merge_mapping(entry, preset_entry)
+            entry = merge_mapping(entry, preset_state(preset))
         grade_patch = assignments(args.grade)
         grade_patch.update(curve_assignments(args.curve))
         if args.hsl:
@@ -625,7 +677,8 @@ def dispatch(client: Client, args):
             entry = merge_mapping(entry, patch)
         if not entry: raise ValueError("no edit fields were supplied")
         return state_merge_update(client, names, entry, args,
-                                  args.history_label)
+                                  args.history_label,
+                                  append=PRESET_LAYERED if args.preset else ())
     if command in {"render", "analyze", "compare"}:
         names = resolve_reference(client, args.ref)
         if not names: raise ValueError("photo was not found")
@@ -728,8 +781,8 @@ def dispatch(client: Client, args):
             return client.post("/api/presets", {"action": "save", "name": args.name, **state})
         if not preset: raise ValueError("preset not found")
         names = selected_names(client, args)
-        entry = {key: preset[key] for key in ("params", "grade", "masks", "heals", "optics") if key in preset}
-        return state_update(client, names, entry, args, f"Preset {args.name}")
+        return state_merge_update(client, names, preset_state(preset), args,
+                                  f"Preset {args.name}", append=PRESET_LAYERED)
     if command == "versions":
         names = resolve_reference(client, args.ref)
         if not names: raise ValueError("photo was not found")
@@ -908,8 +961,9 @@ def dispatch_domain(client: Client, args):
 
     if args.command == "merge":
         if action == "status": return client.get("/api/merge/status")
+        supplied = body.pop("names", [])
         return client.post("/api/merge", {"mode": action,
-            "names": names or body.pop("names", []), **body})
+            "names": names or supplied, **body})
 
     if args.command == "denoise":
         if action == "status": return client.get("/api/denoise/status")

--- a/lighttable_cli/__main__.py
+++ b/lighttable_cli/__main__.py
@@ -105,7 +105,8 @@ def merge_mapping(base: dict, patch: dict) -> dict:
 # The window's lens defaults. A preset carrying exactly these values has no
 # lens edit to apply, so they are not layered onto a photo.
 OPTICS_DEFAULTS = {
-    "profileEnabled": False, "profileDistortion": True, "profileVignette": True,
+    "profileEnabled": False, "profileOverride": None,
+    "profileDistortion": True, "profileVignette": True,
     "flipHorizontal": False, "flipVertical": False, "distortion": 0.0,
     "vignette": 0.0, "vertical": 0.0, "horizontal": 0.0, "rotate": 0.0,
     "scale": 1.0,

--- a/packaging/README-rawpy.md
+++ b/packaging/README-rawpy.md
@@ -1,0 +1,53 @@
+# macOS RAW runtime
+
+`scripts/build-release.sh` installs the runtime lock, then adds
+`scripts/build-rawpy-openmp.sh`'s `rawpy_openmp` package alongside standard rawpy.
+`raw_decode_runtime.py` selects the decoder from a header-only sensor check.
+The personal updater checks the actual runtime's OpenMP support and library
+dependencies, so an old
+base app must first receive a full release build.
+
+The rawpy/LibRaw/CMake source commits are pinned in that script. Native library
+source URLs and SHA-256 digests live in `scripts/build-rawpy-native.sh`; build
+Python dependencies live in `packaging/rawpy-build.lock`. No Homebrew library
+is linked into the finished wheel. Source builds retain macOS 13 compatibility;
+using recent Homebrew bottles would accidentally raise the minimum OS to the
+build machine's version. `delocate` bundles native libraries and their license
+texts are copied into the app. `scripts/verify-rawpy-openmp.py` checks OpenMP,
+bundled dependencies, and each binary's deployment target after installation.
+
+## X-Trans correctness guard
+
+LibRaw 0.22's X-Trans tile loop reads the same image buffer that adjacent
+parallel tiles overwrite. On a real 40 MP X100VI RAF, eight threads produced
+different output between runs and against one thread. The observed maximum
+error was 1119 in a 16-bit channel. This is not a floating-point tolerance test.
+
+`packaging/libraw-xtrans-determinism.patch` keeps that particular loop serial
+as a defense in depth. The new serial build was slower than the existing wheel
+on X-Trans, so application dispatch retains stock rawpy for those sensors.
+Bayer files use the OpenMP extension. Do not remove this
+guard solely because a faster decode completes successfully. The large
+X-Trans parallel demosaic speedup remains unavailable until the upstream
+algorithm provides independent tile inputs or another deterministic schedule.
+
+Run the candidate interpreter with real X-Trans and Bayer sources before
+changing the dependency pins or guard:
+
+```sh
+candidate-python scripts/benchmark-rawpy-openmp.py \
+  --baseline-python stock-wheel-python photo.RAF photo.DNG
+```
+
+The harness starts fresh processes with one and eight threads, repeats both,
+reports phase timings and SHA-256 hashes, and fails on any pixel change. It
+reads originals only and never opens a catalog.
+
+## RAW grid thumbnails
+
+`scripts/benchmark-raw-thumbnails.py` compares ImageIO and rawpy embedded
+thumbnail extraction on supplied RAW files. The initial NEF/CR2 measurements
+favoured rawpy, so RAW thumbnail decoding keeps the existing draft JPEG path.
+Scan callbacks enqueue bounded background work after catalog transactions
+commit. On-demand grid thumbnails remain the fallback when the queue is full,
+rendering is busy, or a source cannot be decoded.

--- a/packaging/libraw-xtrans-determinism.patch
+++ b/packaging/libraw-xtrans-determinism.patch
@@ -1,0 +1,13 @@
+diff --git a/src/demosaic/xtrans_demosaic.cpp b/src/demosaic/xtrans_demosaic.cpp
+index 6d9f999..a1e07f1 100644
+--- a/src/demosaic/xtrans_demosaic.cpp
++++ b/src/demosaic/xtrans_demosaic.cpp
+@@ -168,3 +168,8 @@ void LibRaw::xtrans_interpolate(int passes)
++// LightTable: this in-place tile loop reads neighbouring strips while other
++// threads overwrite them. Keep X-Trans deterministic until upstream provides
++// independent tile input. Other LibRaw translation units retain OpenMP.
++#undef LIBRAW_USE_OPENMP
++
+ #if defined(LIBRAW_USE_OPENMP)
+   int buffer_count = omp_get_max_threads();
+ #else

--- a/packaging/rawpy-build.lock
+++ b/packaging/rawpy-build.lock
@@ -1,0 +1,10 @@
+# Build tools only: excluded from the application runtime.
+altgraph==0.17.5
+Cython==3.2.4
+delocate==0.13.0
+macholib==1.16.4
+numpy==2.5.2
+packaging==26.3
+setuptools==82.0.0
+typing-extensions==4.16.0
+wheel==0.46.3

--- a/platform_image.py
+++ b/platform_image.py
@@ -117,7 +117,8 @@ def _cf_symbol(library, name: str) -> int:
 
 def _build_thumbnail_imageio(source: Path, destination: Path,
                              max_pixel: int = 240,
-                             quality: float = 0.8) -> None:
+                             quality: float = 0.8, *, output_type: str = "public.jpeg",
+                             from_full_image: bool = False) -> None:
     """Decode an oriented thumbnail in-process through macOS ImageIO.
 
     ``CGImageSourceCreateThumbnailAtIndex`` asks ImageIO for the bounded draft
@@ -147,6 +148,7 @@ def _build_thumbnail_imageio(source: Path, destination: Path,
             None, 3, ctypes.byref(maximum)), "thumbnail size")
         keys = (ctypes.c_void_p * 3)(
             _cf_symbol(imageio,
+                       "kCGImageSourceCreateThumbnailFromImageAlways" if from_full_image else
                        "kCGImageSourceCreateThumbnailFromImageIfAbsent"),
             _cf_symbol(imageio, "kCGImageSourceCreateThumbnailWithTransform"),
             _cf_symbol(imageio, "kCGImageSourceThumbnailMaxPixelSize"),
@@ -158,7 +160,7 @@ def _build_thumbnail_imageio(source: Path, destination: Path,
         thumbnail = own(imageio.CGImageSourceCreateThumbnailAtIndex(
             source_ref, 0, options), "thumbnail")
         jpeg_type = own(core.CFStringCreateWithCString(
-            None, b"public.jpeg", 0x08000100), "JPEG type")
+            None, output_type.encode("ascii"), 0x08000100), "JPEG type")
         output = own(imageio.CGImageDestinationCreateWithURL(
             file_url(destination), jpeg_type, 1, None), "image destination")
         compression = ctypes.c_float(max(0.0, min(1.0, float(quality))))
@@ -394,6 +396,39 @@ def convert_processed_to_tiff(
     image, profile = _convert_profile(image, embedded, app_root, output_space)
     options = {"icc_profile": profile} if profile else {}
     image.save(destination, "TIFF", compression="tiff_lzw", **options)
+
+
+def processed_preview(source: Path, max_width: int, *, app_root: Path,
+                      output_space: str = "prophoto") -> np.ndarray:
+    """Decode/convert at preview size; keep full-precision TIFFs for export."""
+    source = Path(source)
+    max_width = max(1, int(max_width))
+    try:
+        with Image.open(source) as opened:
+            embedded = opened.info.get("icc_profile")
+            orientation = opened.getexif().get(274, 1)
+            oriented_width = opened.height if orientation in (5, 6, 7, 8) else opened.width
+            ratio = min(1.0, max_width / max(1, oriented_width))
+            opened.draft("RGB", (max(1, round(opened.width * ratio)),
+                                 max(1, round(opened.height * ratio))))
+            image = ImageOps.exif_transpose(opened).convert("RGB")
+    except (OSError, ValueError):
+        if sys.platform == "darwin":
+            import tempfile
+            with tempfile.TemporaryDirectory(prefix="lighttable-preview-") as directory:
+                draft = Path(directory) / "preview.tif"
+                # ImageIO handles HEIC with bounded native decode. A lossless
+                # temporary retains its ICC profile without a JPEG round-trip.
+                _build_thumbnail_imageio(source, draft, max_pixel=max_width,
+                                         output_type="public.tiff", from_full_image=True)
+                image, embedded = _open_portable(draft)
+        else:
+            image, embedded = _open_portable(source)
+    if image.width > max_width:
+        image = image.resize((max_width, max(1, round(
+            image.height * max_width / image.width))), Image.Resampling.LANCZOS)
+    image, _ = _convert_profile(image, embedded, app_root, output_space)
+    return np.asarray(image, dtype=np.float32) / 255.0
 
 
 def build_thumbnail(

--- a/raw_decode_runtime.py
+++ b/raw_decode_runtime.py
@@ -1,0 +1,38 @@
+"""Use the bundled parallel decoder without regressing X-Trans development."""
+from contextlib import contextmanager
+from enum import Enum
+import importlib
+
+
+@contextmanager
+def open_raw(path):
+    stock = importlib.import_module("rawpy")
+    try:
+        decoder = importlib.import_module("rawpy_openmp")
+    except ImportError:
+        decoder = stock
+    raw = None
+    try:
+        raw = decoder.imread(str(path))
+        if decoder is not stock and raw.is_xtrans:
+            # is_xtrans reads only the already-open header; it never unpacks
+            # sensor pixels. Bayer takes one header open; X-Trans adds one
+            # cheap header read before retaining the stock decoder's speed.
+            raw.close()
+            raw = None
+            decoder = stock
+            raw = stock.imread(str(path))
+        with raw:
+            yield raw, decoder
+    except Exception as error:
+        if decoder is not stock and isinstance(error, decoder.LibRawError):
+            error_type = getattr(stock, type(error).__name__, stock.LibRawError)
+            raise error_type(str(error)) from error
+        raise
+
+
+def native_options(options, decoder):
+    """The two extension modules have distinct enum classes with equal values."""
+    return {key: getattr(decoder, type(value).__name__)(value.value)
+            if isinstance(value, Enum) else value
+            for key, value in options.items()}

--- a/render_cli.py
+++ b/render_cli.py
@@ -24,6 +24,13 @@ import platform_image
 APP = Path(__file__).resolve().parent
 
 
+def _creation_flags() -> dict:
+    """Keep the console-subsystem engine hidden under a console-less parent."""
+    if os.name != "nt":
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
 def render_rust(src: str, params: dict) -> np.ndarray:
     """Run the Rust engine for full-resolution export."""
     cp = fp.clean_params(params)
@@ -50,7 +57,7 @@ def render_rust(src: str, params: dict) -> np.ndarray:
         else:
             command += ["--paper", cp["paper"]]
         result = subprocess.run(command, capture_output=True, text=True,
-                                timeout=1800)
+                                timeout=1800, **_creation_flags())
         if result.returncode != 0 or not output_path.is_file():
             detail = (result.stderr or result.stdout).strip()[-500:]
             raise RuntimeError(f"Rust film render failed: {detail}")

--- a/requirements-runtime.lock
+++ b/requirements-runtime.lock
@@ -21,6 +21,7 @@ pillow==12.3.0
 pyfftw==0.15.1
 pyparsing==3.3.2
 python-dateutil==2.9.0.post0
+# macOS additionally installs rawpy_openmp; stock rawpy handles X-Trans.
 rawpy==0.26.1
 scikit-image==0.26.0
 scipy==1.18.1

--- a/rust-engine/bench_native_surface.py
+++ b/rust-engine/bench_native_surface.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Prove GPU packing, rotated viewport crops, and shared transport against float RGB."""
+import argparse
+import ctypes
+import json
+import mmap
+import os
+from pathlib import Path
+import statistics
+import struct
+import subprocess
+import tempfile
+
+from bench_resident_cache import fixture, invoke
+from bench_viewport import read_float_tiff
+
+
+def read_surface(path):
+    data = path.read_bytes()
+    magic, width, height, row = struct.unpack('<4sIII', data[:16])
+    assert magic == b'FLRA' and row == width * 4
+    return width, height, data[16:]
+
+
+def read_shared(surface):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.shm_open.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_uint]
+    libc.shm_open.restype = ctypes.c_int
+    name = surface['name'].encode()
+    fd = libc.shm_open(name, os.O_RDONLY, 0)
+    assert fd >= 0, ctypes.get_errno()
+    try:
+        with mmap.mmap(fd, surface['length'], access=mmap.ACCESS_READ) as data:
+            row = surface['rowBytes']
+            return b''.join(data[y*row:y*row+surface['width']*4] for y in range(surface['height']))
+    finally:
+        os.close(fd)
+        assert libc.shm_unlink(name) == 0
+
+
+def expected_rgba(samples):
+    # The worker quantizes f32, so preserve the f32 multiply before Python round.
+    out = bytearray()
+    for i, value in enumerate(samples):
+        scaled = struct.unpack('f', struct.pack('f', min(1.0, max(0.0, value))*255.0))[0]
+        out.append(round(scaled))
+        if i % 3 == 2:
+            out.append(255)
+    return bytes(out)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=Path(__file__).parent/'target/release/lighttable-engine')
+    parser.add_argument('--data', type=Path, required=True)
+    parser.add_argument('--width', type=int, default=1100)
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    results = []
+    with tempfile.TemporaryDirectory(prefix='lighttable-native-pack-') as tmp:
+        root = Path(tmp)
+        source = root/'input.tiff'
+        fixture(source, args.width, args.width*2//3)
+        with (root/'engine.log').open('w') as log:
+            process = subprocess.Popen([str(args.binary.resolve())], text=True, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=log, env=dict(os.environ, SPEKTRAFILM_BACKEND='wgpu'))
+            try:
+                for rotation in range(4):
+                    for viewport in [None, dict(x=71, y=37, width=180, height=120)]:
+                        request = dict(id=len(results)+1, command='render', input=str(source),
+                            input_cache_key='pack-fixture', data_dir=str(args.data.resolve()),
+                            film='kodak_portra_400', paper='kodak_endura_premier',
+                            params={'io': {'input_color_space':'ProPhoto RGB', 'input_cctf_decoding':False}},
+                            bit_depth=32, rotate_quarters_ccw=rotation)
+                        if viewport: request['viewport'] = viewport
+                        rgb_path = root/'float.tiff'
+                        baseline = invoke(process, dict(request, output=str(rgb_path)))
+                        assert 'wgpu' in baseline['backend'].lower(), baseline
+                        width, height, samples = read_float_tiff(rgb_path)
+                        expected = expected_rgba(samples)
+                        for shared in (False, True):
+                            output = root/f'native-{rotation}-{bool(viewport)}-{shared}.rgba'
+                            result = invoke(process, dict(request, native_output=str(output), native_shared=shared))
+                            assert result['native_gpu_packed'], result
+                            assert (result['width'],result['height']) == (width,height), result
+                            if shared:
+                                assert not output.exists(), 'shared transport still wrote the frame to disk'
+                                actual = read_shared(result['native_shared'])
+                            else:
+                                w,h,actual = read_surface(output)
+                                assert (w,h)==(width,height)
+                            assert actual == expected, (rotation, viewport, shared,
+                                sum(a!=b for a,b in zip(actual,expected)))
+                            reference_mean = sum(samples)/len(samples)
+                            assert abs(result['mean']-reference_mean) < 1e-6, (result['mean'],reference_mean)
+                            result.update(rotation=rotation, viewport=viewport, shared=shared, byte_identical=True)
+                            results.append(result)
+            finally:
+                process.stdin.close()
+                try: process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill(); process.wait()
+    summary = dict(cases=len(results), byte_identical=True, shared_only_cases=sum(r['shared'] for r in results),
+        native_encode_ms=statistics.median(r['encode_ms'] for r in results))
+    print(json.dumps(summary, indent=2))
+    if args.output: args.output.write_text(json.dumps(dict(summary=summary, results=results), indent=2)+'\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/rust-engine/bench_resident_cache.py
+++ b/rust-engine/bench_resident_cache.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare uncached and cached resident film outputs and print-exposure timings.
+"""Compare uncached and cached resident film outputs and downstream-slider timings.
 
 Uses only Python's standard library. Build release first; provide the installed
 engine/data directory. Every output is a float32 TIFF and must match byte for byte.
@@ -56,9 +56,9 @@ def invoke(proc, request):
     return result
 
 
-def run(binary, data, directory, enabled, requests, input_cache_bytes):
+def run(binary, data, directory, enabled, requests, input_cache_bytes, fresh_pipeline=False):
     env = dict(os.environ, LIGHTTABLE_RESIDENT_STAGE_CACHE=str(int(enabled)),
-               LIGHTTABLE_RESIDENT_PIPELINE_CACHE_ENTRIES='1',
+               LIGHTTABLE_RESIDENT_PIPELINE_CACHE_ENTRIES='0' if fresh_pipeline else '1',
                LIGHTTABLE_RESIDENT_INPUT_CACHE_BYTES=str(input_cache_bytes))
     results = []
     with (directory / f'engine-{enabled}.log').open('w') as log:
@@ -90,6 +90,7 @@ def main():
     parser.add_argument('--data', type=Path, required=True)
     parser.add_argument('--width', type=int, default=1100)
     parser.add_argument('--input-cache-bytes', type=int, default=256 * 1024 * 1024)
+    parser.add_argument('--fresh-pipeline-check', action='store_true', help='also compare against independently rebuilt spectral pipelines')
     parser.add_argument('--budget-check', action='store_true', help='four-case large-image cache bypass check')
     parser.add_argument('--output', type=Path)
     args = parser.parse_args()
@@ -109,6 +110,30 @@ def main():
             params = copy.deepcopy(base)
             params['enlarger'] = {'print_exposure': 0.65 + index * 0.075}
             add('print_drag', params)
+        downstream_labels = []
+        for label, group, field, value in [
+            ('yellow_filter', 'enlarger', 'y_filter_shift', 3.0),
+            ('magenta_filter', 'enlarger', 'm_filter_shift', -3.0),
+            ('preflash', 'enlarger', 'preflash_exposure', 0.05),
+            ('preflash_yellow', 'enlarger', 'preflash_y_filter_shift', 7.0),
+            ('illuminant', 'enlarger', 'illuminant', 'D50'),
+            ('paper_gamma', 'print_render', 'density_curve_gamma', 1.1),
+            ('paper_glare', 'print_render', 'glare', {'active': True, 'percent': 3.0, 'roughness': 0.0}),
+            ('scanner_blur', 'scanner', 'lens_blur', 1.2),
+            ('scanner_sharpen', 'scanner', 'unsharp_mask', [1.2, 0.8]),
+            ('print_reference', 'scanner', 'white_correction', True),
+            ('output_space', 'io', 'output_color_space', 'ProPhoto RGB'),
+            ('output_encoding', 'io', 'output_cctf_encoding', False),
+        ]:
+            params = copy.deepcopy(base)
+            params.setdefault(group, {})[field] = value
+            label = 'downstream_' + label
+            add(label, params)
+            downstream_labels.append(label)
+        add('paper_switch', base, paper='fujifilm_crystal_archive_typeii')
+        downstream_labels.append('paper_switch')
+        add('paper_return', base)
+        downstream_labels.append('paper_return')
         for label, group, field, value in [
             ('camera_ev', 'camera', 'exposure_compensation_ev', 0.3),
             ('meter_method', 'camera', 'auto_exposure_method', 'average'),
@@ -131,14 +156,25 @@ def main():
         add('other_stock', base, a, 'kodak_gold_200')
         add('rebuilt_pipeline', base, a)
         add('slide_scan', base, a, 'kodak_ektachrome_100', scan=True)
+        scan_params = copy.deepcopy(base)
+        scan_params['scanner'] = {'lens_blur': 1.2}
+        add('slide_scanner_blur', scan_params, a, 'kodak_ektachrome_100', scan=True)
+        scan_params['scanner']['white_correction'] = True
+        add('slide_reference', scan_params, a, 'kodak_ektachrome_100', scan=True)
         add('return_from_scan', base, a)
         if args.budget_check:
-            requests = [requests[0], requests[1], requests[-6], requests[-5]]
+            requests = [next(r for r in requests if r[0] == label) for label in
+                        ('warmup', 'print_drag', 'different_dimensions', 'return_dimensions')]
         baseline = run((args.baseline_binary or args.binary).resolve(), args.data.resolve(), directory, False, requests, args.input_cache_bytes)
         cached = run(args.binary.resolve(), args.data.resolve(), directory, True, requests, args.input_cache_bytes)
         assert 0.001 < cached[0]['mean'] < 0.999, 'fixture must produce nonblank pixels'
         assert len({r['sha256'] for r in cached if r['case'] == 'print_drag'}) == sum(r['case'] == 'print_drag' for r in cached), 'print exposure must alter output'
         mismatches = [a['case'] for a, b in zip(baseline, cached) if a['sha256'] != b['sha256']]
+        if args.fresh_pipeline_check:
+            fresh = run(args.binary.resolve(), args.data.resolve(), directory, False,
+                        requests, args.input_cache_bytes, fresh_pipeline=True)
+            mismatches.extend('fresh:' + a['case'] for a, b in zip(fresh, cached)
+                              if a['sha256'] != b['sha256'])
         if 'wgpu' in cached[0]['backend'].lower():
             expected_checkpoint = args.width * (args.width * 2 // 3) * 12 <= 96 * 1024 * 1024
             assert all(r['film_stage_cache_hit'] == expected_checkpoint for r in cached if r['case'] == 'print_drag')
@@ -149,9 +185,14 @@ def main():
                 assert all(r['resident_cache_bytes'] <= 32 * 1024 * 1024 and not r['gpu_buffers_reused']
                            for r in cached if r['width'] == args.width)
             assert all(not r['film_stage_cache_hit'] for r in cached if r['case'] in
-                       ('camera_ev', 'different_input', 'different_dimensions', 'rebuilt_pipeline', 'slide_scan'))
+                       ('camera_ev', 'different_input', 'different_dimensions', 'rebuilt_pipeline', 'slide_scan', 'slide_reference'))
+            unexpected_misses = [r['case'] for r in cached if
+                (r['case'] in downstream_labels or r['case'] == 'slide_scanner_blur')
+                and (r['film_stage_cache_hit'] != expected_checkpoint or not r['pipeline_cache_hit'])]
+            assert not unexpected_misses, unexpected_misses
         summary = {'width': args.width, 'cases': len(requests), 'backend': cached[0]['backend'],
-                   'bit_identical': not mismatches, 'mismatches': mismatches}
+                   'bit_identical': not mismatches, 'mismatches': mismatches,
+                   'fresh_pipeline_checked': args.fresh_pipeline_check}
         for metric in ('render_ms', 'total_ms'):
             before = [r[metric] for r in baseline if r['case'] == 'print_drag']
             after = [r[metric] for r in cached if r['case'] == 'print_drag']

--- a/rust-engine/bench_viewport.py
+++ b/rust-engine/bench_viewport.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Verify every viewport float against the same full-frame GPU render.
+
+Covers panning, frame boundaries, every quarter rotation, film/grain pitch,
+scanner kernels, stochastic glare, and the exact full-frame diffusion fallback.
+"""
+import argparse
+import array
+import copy
+import json
+import os
+from pathlib import Path
+import statistics
+import struct
+import subprocess
+import tempfile
+
+from bench_resident_cache import fixture, invoke
+
+
+def read_float_tiff(path):
+    data = path.read_bytes()
+    endian = '<' if data[:2] == b'II' else '>'
+    assert struct.unpack_from(endian+'H', data, 2)[0] == 42
+    offset = struct.unpack_from(endian+'I', data, 4)[0]
+    count = struct.unpack_from(endian+'H', data, offset)[0]
+    tags = {}
+    for i in range(count):
+        at = offset+2+i*12
+        tag, kind, n, location = struct.unpack_from(endian+'HHII', data, at)
+        if kind not in (3, 4):
+            continue
+        size, code = (2, 'H') if kind == 3 else (4, 'I')
+        start = at+8 if n*size <= 4 else location
+        tags[tag] = struct.unpack_from(endian+code*n, data, start)
+    assert tags[259] == (1,), 'benchmark needs uncompressed TIFF'
+    assert tags[258] == (32, 32, 32)
+    assert tags[339] == (3, 3, 3)
+    raw = b''.join(data[start:start+n] for start, n in zip(tags[273], tags[279]))
+    values = array.array('f')
+    values.frombytes(raw)
+    if (endian == '<') != (struct.pack('=I', 1) == struct.pack('<I', 1)):
+        values.byteswap()
+    return tags[256][0], tags[257][0], values
+
+
+def crop(values, width, rect):
+    out = array.array('f')
+    for y in range(rect['y'], rect['y']+rect['height']):
+        start = (y*width+rect['x'])*3
+        out.extend(values[start:start+rect['width']*3])
+    return out
+
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary',type=Path,default=Path(__file__).parent/'target/release/lighttable-engine')
+    parser.add_argument('--data',type=Path,required=True)
+    parser.add_argument('--width',type=int,default=1100)
+    parser.add_argument('--output',type=Path)
+    args=parser.parse_args()
+    records=[]
+    with tempfile.TemporaryDirectory(prefix='lighttable-viewport-') as tmp:
+        directory=Path(tmp)
+        source=directory/'input.tiff'
+        fixture(source,args.width,args.width*2//3)
+        with (directory/'engine.log').open('w') as log:
+            process=subprocess.Popen([str(args.binary.resolve())],text=True,stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,stderr=log,env=dict(os.environ,SPEKTRAFILM_BACKEND='wgpu'))
+            try:
+                base={'io':{'input_color_space':'ProPhoto RGB','input_cctf_decoding':False},
+                      'film_render':{'grain':{'active':True},'halation':{'active':True}}}
+                cases=[('default',base)]
+                spatial=copy.deepcopy(base)
+                spatial.update(camera={'lens_blur_um':8.0},scanner={'lens_blur':1.3,'unsharp_mask':[2.1,0.8]},
+                               print_render={'glare':{'active':True,'percent':2.0,'roughness':0.2,'blur':3.0}})
+                cases.append(('spatial',spatial))
+                diffusion=copy.deepcopy(spatial)
+                diffusion['camera']['diffusion_filter']={'active':True,'strength':0.5}
+                cases.append(('diffusion_fallback',diffusion))
+                for case,params in cases:
+                    for rotation in range(4):
+                        request=dict(id=len(records)+1,command='render',input=str(source),
+                            input_cache_key='viewport-fixture',data_dir=str(args.data.resolve()),
+                            film='kodak_portra_400',paper='kodak_endura_premier',params=params,
+                            bit_depth=32,rotate_quarters_ccw=rotation)
+                        full=directory/'full.tiff'
+                        baseline=invoke(process,dict(request,output=str(full)))
+                        if 'wgpu' not in baseline['backend'].lower():
+                            raise RuntimeError('GPU path NOT DONE: '+baseline['backend'])
+                        width,height,pixels=read_float_tiff(full)
+                        tw,th=min(240,width//3),min(160,height//3)
+                        rects=[dict(x=width//3,y=height//3,width=tw,height=th),
+                               dict(x=0,y=0,width=tw,height=th),
+                               dict(x=width-tw,y=height-th,width=tw,height=th),
+                               dict(x=width//3+17,y=height//3+11,width=tw,height=th)]
+                        for rect in rects:
+                            output=directory/'viewport.tiff'
+                            result=invoke(process,dict(request,viewport=rect,output=str(output)))
+                            w,h,actual=read_float_tiff(output)
+                            expected=crop(pixels,width,rect)
+                            assert (w,h)==(tw,th),result
+                            assert (result['full_width'],result['full_height'])==(width,height),result
+                            assert actual==expected, (case,rotation,rect,
+                                max(abs(a-b) for a,b in zip(actual,expected)))
+                            assert result['viewport_accelerated']==(case!='diffusion_fallback'), result
+                            result.update(case=case,rotation=rotation,viewport=rect,bit_identical=True,
+                                          full_render_ms=baseline['render_ms'])
+                            records.append(result)
+            finally:
+                process.stdin.close()
+                try: process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill();process.wait()
+    accelerated=[r for r in records if r['viewport_accelerated']]
+    summary=dict(cases=len(records),bit_identical=True,
+                 accelerated_cases=len(accelerated),
+                 full_render_ms=statistics.median(r['full_render_ms'] for r in accelerated),
+                 viewport_render_ms=statistics.median(r['render_ms'] for r in accelerated))
+    report=dict(summary=summary,results=records)
+    print(json.dumps(summary,indent=2))
+    if args.output: args.output.write_text(json.dumps(report,indent=2)+'\n')
+
+
+if __name__=='__main__': main()

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -17,6 +17,8 @@ use spektrafilm_gpu::ComputeBackend;
 use spektrafilm_math::{image::ImageBuf, precision};
 
 mod export;
+mod region;
+mod native_surface;
 
 #[derive(Debug, Deserialize)]
 struct Request {
@@ -29,6 +31,9 @@ struct Request {
     input_cache_key: Option<String>,
     output: Option<PathBuf>,
     native_output: Option<PathBuf>,
+    #[serde(default)]
+    native_shared: bool,
+    viewport: Option<region::Rect>,
     data_dir: Option<PathBuf>,
     film: Option<String>,
     paper: Option<String>,
@@ -66,8 +71,14 @@ struct Response {
     backend: String,
     width: Option<u32>,
     height: Option<u32>,
+    full_width: Option<u32>,
+    full_height: Option<u32>,
     mean: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_shared: Option<native_surface::SharedSurface>,
     input_cache_hit: bool,
+    viewport_accelerated: bool,
+    native_gpu_packed: bool,
     film_stage_cache_hit: bool,
     gpu_buffers_reused: bool,
     resident_cache_bytes: usize,
@@ -88,8 +99,13 @@ impl Response {
             backend: backend.to_owned(),
             width: None,
             height: None,
+            full_width: None,
+            full_height: None,
             mean: None,
+            native_shared: None,
             input_cache_hit: false,
+            viewport_accelerated: false,
+            native_gpu_packed: false,
             film_stage_cache_hit: false,
             gpu_buffers_reused: false,
             resident_cache_bytes: 0,
@@ -127,6 +143,7 @@ struct Engine {
     inputs: VecDeque<CachedInput>,
     input_cache_max_bytes: usize,
     pipelines: VecDeque<(String, Pipeline, u64)>,
+    print_profiles: VecDeque<(String, profile::Profile)>,
     pipeline_cache_max_entries: usize,
     next_input_generation: u64,
     next_pipeline_generation: u64,
@@ -147,6 +164,7 @@ impl Engine {
                 .and_then(|value| value.parse().ok())
                 .unwrap_or(256 * 1024 * 1024),
             pipelines: VecDeque::new(),
+            print_profiles: VecDeque::new(),
             pipeline_cache_max_entries: std::env::var("LIGHTTABLE_RESIDENT_PIPELINE_CACHE_ENTRIES")
                 .ok()
                 .and_then(|value| value.parse().ok())
@@ -156,16 +174,34 @@ impl Engine {
 
     fn handle(&mut self, request: Request) -> Result<Response> {
         let started = Instant::now();
-        if request.command == "ping" {
+        if request.command == "ping" || request.command == "probe_input" {
+            let cached_input = if request.command == "probe_input" {
+                let key = request.input_cache_key.as_ref().context("missing input_cache_key")?;
+                self.inputs.iter().position(|cached| {
+                    cached.identity == InputIdentity::Shared(key.clone())
+                }).map(|position| {
+                    let cached = self.inputs.remove(position).expect("cached input position");
+                    let dimensions = (cached.image.width, cached.image.height);
+                    self.inputs.push_back(cached);
+                    dimensions
+                })
+            } else {
+                None
+            };
             return Ok(Response {
                 id: request.id,
                 ok: true,
                 backend: self.backend.name().to_owned(),
-                width: None,
-                height: None,
+                width: cached_input.map(|size| size.0),
+                height: cached_input.map(|size| size.1),
+                full_width: None,
+                full_height: None,
                 mean: None,
-                input_cache_hit: false,
-                film_stage_cache_hit: false,
+            native_shared: None,
+                input_cache_hit: cached_input.is_some(),
+                viewport_accelerated: false,
+            native_gpu_packed: false,
+            film_stage_cache_hit: false,
                 gpu_buffers_reused: false,
                 resident_cache_bytes: 0,
                 pipeline_cache_hit: false,
@@ -246,7 +282,7 @@ impl Engine {
         let key = format!(
             "{}:{}",
             profile_root.display(),
-            pipeline_cache_key(film_name, print_name, &params)
+            pipeline_cache_key(film_name, &params)
         );
         let active_input = self.inputs.back_mut().expect("active cached input");
         let reuse_film_stages = self.reuse_film_stages && self.backend.is_gpu();
@@ -282,6 +318,20 @@ impl Engine {
             None
         };
         let pipeline_started = Instant::now();
+        let print_key = format!("{}:{print_name}", profile_root.display());
+        let print_profile = if let Some(position) = self.print_profiles.iter()
+            .position(|(key, _)| key == &print_key) {
+            let cached = self.print_profiles.remove(position).expect("cached print position");
+            let print = cached.1.clone();
+            self.print_profiles.push_back(cached);
+            print
+        } else {
+            let print = profile::load_profile_by_name(data_dir, print_name)
+                .map_err(|error| anyhow!("print profile '{print_name}': {error}"))?;
+            self.print_profiles.push_back((print_key, print.clone()));
+            while self.print_profiles.len() > 16 { self.print_profiles.pop_front(); }
+            print
+        };
         let cached_position = self
             .pipelines
             .iter()
@@ -292,21 +342,19 @@ impl Engine {
                 .pipelines
                 .remove(position)
                 .expect("cached pipeline position");
-            let active = cached.1.clone().with_params(params);
+            let active = cached.1.clone().with_print_params(print_profile, params);
             let generation = cached.2;
             self.pipelines.push_back(cached);
             (active, generation)
         } else {
             let film = profile::load_profile_by_name(data_dir, film_name)
                 .map_err(|error| anyhow!("film profile '{film_name}': {error}"))?;
-            let print = profile::load_profile_by_name(data_dir, print_name)
-                .map_err(|error| anyhow!("print profile '{print_name}': {error}"))?;
-            let built = Pipeline::new_with_spectral(film, print, params, data_dir)
+            let built = Pipeline::new_with_spectral(film, print_profile, params, data_dir)
                 .map_err(|error| anyhow!("pipeline build: {error}"))?;
             self.next_pipeline_generation += 1;
             self.pipelines
                 .push_back((key, built.clone(), self.next_pipeline_generation));
-            while self.pipelines.len() > self.pipeline_cache_max_entries.max(1) {
+            while self.pipelines.len() > self.pipeline_cache_max_entries {
                 self.pipelines.pop_front();
             }
             (built, self.next_pipeline_generation)
@@ -314,16 +362,53 @@ impl Engine {
         let film_key = film_key.map(|key| format!("{pipeline_generation}:{key}"));
         let pipeline_ms = millis(pipeline_started.elapsed());
 
+        if request.viewport.is_some() && (request.grade.is_some() || request.masks.is_some()
+            || request.crop.is_some() || request.long_edge.is_some()) {
+            bail!("viewport rendering requires an unbaked native preview");
+        }
+        let plan = request.viewport.map(|viewport| region::plan(viewport, image.width, image.height,
+            request.rotate_quarters_ccw, &pipeline.params,
+            self.backend.name().to_lowercase().contains("wgpu"))).transpose()?;
+        let accelerated = plan.as_ref().is_some_and(|plan| plan.accelerated);
+        // Meter the original before the spatial crop, even with checkpoint reuse disabled.
+        let metered_ev = if accelerated && metered_ev.is_none() && pipeline.params.camera.auto_exposure {
+            let matrix = spektrafilm_core::stages::filming::input_colorspace_to_xyz(
+                &pipeline.params.io.input_color_space);
+            Some(spektrafilm_core::stages::filming::measure_autoexposure_ev(&image, &matrix,
+                &pipeline.params.camera.auto_exposure_method))
+        } else { metered_ev };
+        let region_image = plan.as_ref().filter(|plan| plan.accelerated)
+            .map(|plan| region::crop_image(&image, plan.render));
+        let render_image = region_image.as_ref().unwrap_or(image.as_ref());
+        let pipeline = if let Some(plan) = plan.as_ref().filter(|plan| plan.accelerated) {
+            pipeline.with_image_region(plan.render.x, plan.render.y, image.width, image.height)
+        } else { pipeline };
+        let film_key = film_key.map(|key| if let Some(plan) = plan.as_ref() {
+            format!("{key}:region:{:?}", plan.render.array())
+        } else { key });
         let render_started = Instant::now();
-        let resident_rendered = pipeline.process_resident_cached(
-            image.as_ref(),
-            self.backend.as_ref(),
-            film_key.as_deref(),
-            metered_ev,
-        );
-        let used_resident = resident_rendered.is_some();
-        let rendered = resident_rendered
-            .unwrap_or_else(|| pipeline.process((*image).clone(), self.backend.as_ref()));
+        let native_only = native_output.is_some() && output.is_none()
+            && request.grade.is_none() && request.masks.is_none()
+            && request.crop.is_none() && request.long_edge.is_none();
+        let packed = if native_only {
+            pipeline.process_resident_native(render_image, self.backend.as_ref(),
+                film_key.as_deref(), metered_ev,
+                spektrafilm_gpu::NativeOutputSpec {
+                    quarters_ccw: request.rotate_quarters_ccw, crop: plan.as_ref().map(|plan| plan.trim.array()),
+                })
+        } else { None };
+        let resident_rendered = if packed.is_none() {
+            pipeline.process_resident_cached(render_image, self.backend.as_ref(),
+                film_key.as_deref(), metered_ev)
+        } else { None };
+        if accelerated && packed.is_none() && resident_rendered.is_none() {
+            bail!("GPU viewport path unavailable; retry a full-frame render");
+        }
+        let used_resident = packed.is_some() || resident_rendered.is_some();
+        let rendered = if packed.is_none() {
+            Some(resident_rendered.unwrap_or_else(||
+                pipeline.process((*image).clone(), self.backend.as_ref())))
+        } else { None };
         let mut cache_status = self.backend.resident_cache_status();
         if !used_resident {
             cache_status.0 = false;
@@ -332,8 +417,13 @@ impl Engine {
         let render_ms = millis(render_started.elapsed());
 
         let encode_started = Instant::now();
-        let (mut width, mut height, mut samples) =
-            rotate_samples(&rendered, request.rotate_quarters_ccw);
+        let (mut width, mut height, mut samples) = if let Some(packed) = packed.as_ref() {
+            (packed.width, packed.height, Vec::new())
+        } else {
+            let rendered = rendered.as_ref().expect("RGB render");
+            let trimmed = plan.as_ref().map(|plan| region::crop_image(rendered, plan.trim));
+            rotate_samples(trimmed.as_ref().unwrap_or(rendered), request.rotate_quarters_ccw)
+        };
         if request.grade.is_some()
             || request.masks.is_some()
             || request.crop.is_some()
@@ -352,11 +442,9 @@ impl Engine {
             height = processed.height;
             samples = processed.samples;
         }
-        let mean = samples
-            .par_iter()
-            .map(|&value| f64::from(value))
-            .sum::<f64>()
-            / samples.len() as f64;
+        let mean = packed.as_ref().map_or_else(|| samples.par_iter()
+            .map(|&value| f64::from(value)).sum::<f64>() / samples.len() as f64,
+            |packed| packed.mean);
         if let Some(output) = output {
             save_output(
                 output,
@@ -367,8 +455,28 @@ impl Engine {
                 request.bit_depth,
             )?;
         }
-        if let Some(native_output) = native_output {
-            save_native_surface(native_output, width, height, &samples)?;
+        let native_shared = if request.native_shared && native_output.is_some() {
+            let publish = if let Some(packed) = packed.as_ref() {
+                native_surface::publish_packed(width, height, packed.row_bytes, &packed.pixels)
+            } else {
+                native_surface::publish_rgb(width, height, &samples)
+            };
+            match publish {
+                Ok(surface) => Some(surface),
+                Err(error) => {
+                    eprintln!("native shared transport unavailable: {error:#}");
+                    None
+                }
+            }
+        } else { None };
+        if native_shared.is_none() {
+            if let Some(native_output) = native_output {
+                if let Some(packed) = packed.as_ref() {
+                    save_packed_native_surface(native_output, packed)?;
+                } else {
+                    save_native_surface(native_output, width, height, &samples)?;
+                }
+            }
         }
         let encode_ms = millis(encode_started.elapsed());
 
@@ -378,8 +486,13 @@ impl Engine {
             backend: self.backend.name().to_owned(),
             width: Some(width),
             height: Some(height),
+            full_width: request.viewport.map(|_| if request.rotate_quarters_ccw % 2 == 0 { image.width } else { image.height }),
+            full_height: request.viewport.map(|_| if request.rotate_quarters_ccw % 2 == 0 { image.height } else { image.width }),
             mean: Some(mean),
+            native_shared,
             input_cache_hit,
+            viewport_accelerated: accelerated,
+            native_gpu_packed: packed.is_some(),
             film_stage_cache_hit: cache_status.0,
             gpu_buffers_reused: cache_status.1,
             resident_cache_bytes: cache_status.2,
@@ -646,59 +759,42 @@ fn load_tiff(path: &Path) -> Result<ImageBuf> {
     Ok(ImageBuf::from_data(width, height, data))
 }
 
-/// Conservative dependency key: normalize only print exposure, whose first use
-/// is after the developed-film checkpoint. Everything else invalidates reuse.
-/// Input generations never alias, including after byte-budget eviction/reload.
+/// Key the developed-film checkpoint on physical filming dependencies only.
+/// Scanner reference settings are downstream here; Pipeline appends the actual
+/// filming exposure correction for positive scans before handing the GPU its key.
+/// Input and spectral pipeline generations prevent aliasing after cache eviction.
 fn film_stage_key(input_generation: u64, pipeline_key: &str, params: &RuntimeParams) -> String {
     let mut dependencies = params.clone();
-    if !dependencies.io.scan_film {
-        dependencies.enlarger.print_exposure = 1.0;
-    }
+    let defaults = RuntimeParams::default();
+    dependencies.enlarger = defaults.enlarger;
+    dependencies.print_render = defaults.print_render;
+    dependencies.film_render.glare = defaults.film_render.glare;
+    dependencies.scanner = defaults.scanner;
+    dependencies.io.scan_film = defaults.io.scan_film;
+    dependencies.io.output_color_space = defaults.io.output_color_space;
+    dependencies.io.output_cctf_encoding = defaults.io.output_cctf_encoding;
+    dependencies.io.output_gamut_compress = defaults.io.output_gamut_compress;
+    dependencies.settings.neutral_print_filters_from_database = defaults.settings.neutral_print_filters_from_database;
+    dependencies.settings.use_enlarger_lut = defaults.settings.use_enlarger_lut;
+    dependencies.settings.use_scanner_lut = defaults.settings.use_scanner_lut;
     serde_json::to_string(&(input_generation, pipeline_key, dependencies))
         .expect("finite runtime parameters")
 }
 
-fn pipeline_cache_key(film: &str, print: &str, params: &RuntimeParams) -> String {
+/// Only dependencies baked into the expensive film spectral calibration.
+/// Print profiles, enlarger calibration and output conversion are refreshed
+/// separately, without rebuilding or copying the shared film TC LUT.
+fn pipeline_cache_key(film: &str, params: &RuntimeParams) -> String {
     serde_json::json!({
         "film": film,
-        "print": print,
         "film_dev": params.film_render.development_time,
-        "print_dev": params.print_render.development_time,
-        "scan_film": params.io.scan_film,
-        "input_color_space": params.io.input_color_space,
-        "input_cctf_decoding": params.io.input_cctf_decoding,
         "input_gamut": params.io.input_gamut_compress,
-        "output_color_space": params.io.output_color_space,
-        "output_gamut": params.io.output_gamut_compress,
-        "settings": {
-            "rgb_to_raw_method": params.settings.rgb_to_raw_method,
-            "apply_hanatos2025_adaptation_window": params.settings.apply_hanatos2025_adaptation_window,
-            "apply_hanatos2025_adaptation_surface": params.settings.apply_hanatos2025_adaptation_surface,
-            "spectral_gaussian_blur": params.settings.spectral_gaussian_blur,
-            "lut_resolution": params.settings.lut_resolution,
-            "neutral_print_filters_from_database": params.settings.neutral_print_filters_from_database,
-            "use_cat16": params.settings.use_cat16,
-        },
-        "enlarger": {
-            "illuminant": params.enlarger.illuminant,
-            "c_filter_neutral": params.enlarger.c_filter_neutral,
-            "m_filter_neutral": params.enlarger.m_filter_neutral,
-            "y_filter_neutral": params.enlarger.y_filter_neutral,
-            "m_filter_shift": params.enlarger.m_filter_shift,
-            "y_filter_shift": params.enlarger.y_filter_shift,
-            "preflash_exposure": params.enlarger.preflash_exposure,
-            "preflash_m_filter_shift": params.enlarger.preflash_m_filter_shift,
-            "preflash_y_filter_shift": params.enlarger.preflash_y_filter_shift,
-            "normalize_print_exposure": params.enlarger.normalize_print_exposure,
-            "print_exposure_compensation": params.enlarger.print_exposure_compensation,
-        },
-        "exposure_compensation_ev": if params.enlarger.print_exposure_compensation {
-            params.camera.exposure_compensation_ev
-        } else {
-            0.0
-        },
-    })
-    .to_string()
+        "rgb_to_raw_method": params.settings.rgb_to_raw_method,
+        "apply_hanatos2025_adaptation_window": params.settings.apply_hanatos2025_adaptation_window,
+        "apply_hanatos2025_adaptation_surface": params.settings.apply_hanatos2025_adaptation_surface,
+        "spectral_gaussian_blur": params.settings.spectral_gaussian_blur,
+        "lut_resolution": params.settings.lut_resolution,
+    }).to_string()
 }
 
 fn rotate_samples(image: &ImageBuf, quarters_ccw: u8) -> (u32, u32, Vec<f32>) {
@@ -850,6 +946,20 @@ fn quantize_u8(samples: &[f32]) -> Vec<u8> {
 /// followed by tightly packed RGBA pixels. The native AppKit shell uploads
 /// this directly into a Metal texture, avoiding JPEG encoding/decoding and a
 /// second high-resolution WebGL texture upload.
+fn save_packed_native_surface(path: &Path, packed: &spektrafilm_gpu::NativePackedSurface) -> Result<()> {
+    if let Some(parent) = path.parent() { fs::create_dir_all(parent)?; }
+    let mut writer = BufWriter::new(fs::File::create(path)?);
+    writer.write_all(b"FLRA")?;
+    writer.write_all(&packed.width.to_le_bytes())?;
+    writer.write_all(&packed.height.to_le_bytes())?;
+    writer.write_all(&(packed.width * 4).to_le_bytes())?;
+    for row in packed.pixels.chunks(packed.row_bytes) {
+        writer.write_all(&row[..packed.width as usize * 4])?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
 fn save_native_surface(path: &Path, width: u32, height: u32, samples: &[f32]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -1126,29 +1236,85 @@ mod windows_shared_input_tests {
 mod resident_cache_tests {
     use super::*;
 
+    fn changed(group: &str, patch: serde_json::Value) -> RuntimeParams {
+        let mut value = serde_json::to_value(RuntimeParams::default()).unwrap();
+        for (field, replacement) in patch.as_object().unwrap() {
+            value[group][field] = replacement.clone();
+        }
+        serde_json::from_value(value).unwrap()
+    }
+
     #[test]
-    fn only_print_exposure_can_reuse_film_density() {
-        let mut params = RuntimeParams::default();
-        let key = film_stage_key(1, "profile-a", &params);
-        params.enlarger.print_exposure = 1.4;
-        assert_eq!(key, film_stage_key(1, "profile-a", &params));
-        params.camera.exposure_compensation_ev = 0.2;
-        assert_ne!(key, film_stage_key(1, "profile-a", &params));
-        params = RuntimeParams::default();
-        params.film_render.development_time = Some(1.1);
-        assert_ne!(key, film_stage_key(1, "profile-a", &params));
-        assert_ne!(
-            key,
-            film_stage_key(2, "profile-a", &RuntimeParams::default())
-        );
-        assert_ne!(
-            key,
-            film_stage_key(1, "profile-b", &RuntimeParams::default())
-        );
-        params = RuntimeParams::default();
-        params.io.scan_film = true;
-        let scan_key = film_stage_key(1, "profile-a", &params);
-        params.enlarger.print_exposure = 1.4;
-        assert_ne!(scan_key, film_stage_key(1, "profile-a", &params));
+    fn downstream_changes_reuse_film_and_spectral_calibration() {
+        let base = RuntimeParams::default();
+        let key = film_stage_key(1, "profile-a", &base);
+        let pipeline = pipeline_cache_key("film-a", &base);
+        for (group, patch) in [
+            ("enlarger", serde_json::json!({"print_exposure":1.4,"y_filter_shift":3.0,"m_filter_shift":-4.0,"preflash_exposure":0.1,"illuminant":"D50","normalize_print_exposure":false})),
+            ("print_render", serde_json::json!({"density_curve_gamma":1.2,"development_time":1.3,"glare":{"active":true,"percent":4.0}})),
+            ("scanner", serde_json::json!({"lens_blur":2.0,"unsharp_mask":[1.0,1.2],"white_correction":true,"black_level":0.02})),
+            ("io", serde_json::json!({"output_color_space":"ProPhoto RGB","output_cctf_encoding":false,"output_gamut_compress":{"algorithm":"off"}})),
+            ("film_render", serde_json::json!({"glare":{"active":true,"percent":4.0}})),
+            ("settings", serde_json::json!({"neutral_print_filters_from_database":false,"use_enlarger_lut":true,"use_scanner_lut":true})),
+        ] {
+            let params = changed(group, patch);
+            assert_eq!(key, film_stage_key(1,"profile-a",&params), "{group}");
+            assert_eq!(pipeline, pipeline_cache_key("film-a",&params), "{group}");
+        }
+    }
+
+    #[test]
+    fn upstream_changes_and_generations_invalidate_film() {
+        let base = RuntimeParams::default();
+        let key = film_stage_key(1, "profile-a", &base);
+        for (group, patch) in [
+            ("camera", serde_json::json!({"exposure_compensation_ev":0.2})),
+            ("camera", serde_json::json!({"lens_blur_um":2.0})),
+            ("film_render", serde_json::json!({"development_time":1.1})),
+            ("film_render", serde_json::json!({"grain":{"active":false}})),
+            ("io", serde_json::json!({"input_color_space":"sRGB"})),
+        ] {
+            assert_ne!(key, film_stage_key(1,"profile-a",&changed(group,patch)), "{group}");
+        }
+        assert_ne!(key, film_stage_key(2,"profile-a",&base));
+        assert_ne!(key, film_stage_key(1,"profile-b",&base));
+        let mut scan = base.clone();
+        scan.io.scan_film = true;
+        let scan_key = film_stage_key(1,"profile-a",&scan);
+        scan.scanner.lens_blur = 2.0;
+        assert_eq!(scan_key, film_stage_key(1,"profile-a",&scan));
+        scan.scanner.white_correction = true;
+        assert_eq!(scan_key, film_stage_key(1,"profile-a",&scan));
+    }
+
+    #[test]
+    fn input_probe_reports_miss_hit_and_refreshes_lru_without_loading() {
+        let mut engine = Engine {
+            backend: Box::new(spektrafilm_gpu::cpu_backend::CpuBackend),
+            inputs: VecDeque::new(), input_cache_max_bytes: 1024,
+            pipelines: VecDeque::new(), print_profiles: VecDeque::new(),
+            pipeline_cache_max_entries: 4, next_input_generation: 0,
+            next_pipeline_generation: 0, reuse_film_stages: true,
+        };
+        let request = || serde_json::from_value(serde_json::json!({
+            "id":1,"command":"probe_input","input_cache_key":"input-a"
+        })).unwrap();
+        let missing = engine.handle(request()).unwrap();
+        assert!(missing.ok);
+        assert!(!missing.input_cache_hit);
+        assert_eq!(missing.width, None);
+        for key in ["input-a", "input-b"] {
+            engine.inputs.push_back(CachedInput {
+                identity: InputIdentity::Shared(key.into()),
+                image: Arc::new(ImageBuf::from_data(2,1,vec![precision::from_f32(0.5);6])),
+                bytes: 24, generation: 1, metering: VecDeque::new(),
+            });
+        }
+        let found = engine.handle(request()).unwrap();
+        assert!(found.input_cache_hit);
+        assert_eq!((found.width, found.height), (Some(2),Some(1)));
+        assert_eq!(engine.inputs.back().unwrap().identity, InputIdentity::Shared("input-a".into()));
+        engine.inputs.clear();
+        assert!(!engine.handle(request()).unwrap().input_cache_hit);
     }
 }

--- a/rust-engine/src/main.rs
+++ b/rust-engine/src/main.rs
@@ -506,7 +506,127 @@ fn load_shared_input(name: &str, length: usize) -> Result<ImageBuf> {
     result
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn load_shared_input(name: &str, length: usize) -> Result<ImageBuf> {
+    use std::os::windows::ffi::OsStrExt;
+
+    if !(RAW_SHARED_HEADER_BYTES..=2 * 1024 * 1024 * 1024).contains(&length) {
+        bail!("invalid shared RAW length {length}");
+    }
+    // Python's multiprocessing.shared_memory names Windows segments
+    // `wnsm_<hex>`; anything outside that alphabet is not a segment the
+    // server created for this request.
+    if name.is_empty()
+        || name.len() > 128
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        bail!("invalid shared-memory name");
+    }
+    let wide: Vec<u16> = std::ffi::OsStr::new(name)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // The Python owner keeps its own mapping handle open until this
+    // synchronous request returns, so the pagefile-backed object outlives
+    // the copy below even though Windows has no unlink step.
+    let mapping = unsafe {
+        windows_shared::OpenFileMappingW(windows_shared::FILE_MAP_READ, 0, wide.as_ptr())
+    };
+    if mapping.is_null() {
+        return Err(io::Error::last_os_error())
+            .with_context(|| format!("opening shared RAW {name}"));
+    }
+    // Asking for exactly the protocol length makes the view fail rather
+    // than silently shorten when the object is smaller than advertised.
+    let address = unsafe {
+        windows_shared::MapViewOfFile(mapping, windows_shared::FILE_MAP_READ, 0, 0, length)
+    };
+    let map_error = io::Error::last_os_error();
+    unsafe {
+        windows_shared::CloseHandle(mapping);
+    }
+    if address.is_null() {
+        return Err(map_error).with_context(|| format!("mapping shared RAW {name}"));
+    }
+    let result = windows_shared::view_length(address).and_then(|available| {
+        if available < length {
+            bail!("shared RAW is truncated: request {length}, view {available}");
+        }
+        let bytes = unsafe { std::slice::from_raw_parts(address.cast::<u8>(), length) };
+        parse_shared_input(bytes)
+    });
+    unsafe {
+        windows_shared::UnmapViewOfFile(address);
+    }
+    result
+}
+
+/// The handful of kernel32 entry points needed to read a named file mapping.
+/// Declared by hand so the engine gains no Windows-only crate dependency.
+#[cfg(windows)]
+mod windows_shared {
+    use std::ffi::c_void;
+
+    use anyhow::{Context, Result};
+
+    pub const FILE_MAP_READ: u32 = 0x0004;
+
+    /// `MEMORY_BASIC_INFORMATION` from the Windows SDK, including the
+    /// `PartitionId` field that pads `RegionSize` to pointer alignment.
+    #[repr(C)]
+    pub struct MemoryBasicInformation {
+        pub base_address: *mut c_void,
+        pub allocation_base: *mut c_void,
+        pub allocation_protect: u32,
+        pub partition_id: u16,
+        pub region_size: usize,
+        pub state: u32,
+        pub protect: u32,
+        pub kind: u32,
+    }
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        pub fn OpenFileMappingW(desired_access: u32, inherit_handle: i32, name: *const u16)
+        -> *mut c_void;
+        pub fn MapViewOfFile(
+            mapping: *mut c_void,
+            desired_access: u32,
+            offset_high: u32,
+            offset_low: u32,
+            bytes: usize,
+        ) -> *mut c_void;
+        pub fn UnmapViewOfFile(address: *const c_void) -> i32;
+        pub fn CloseHandle(handle: *mut c_void) -> i32;
+        pub fn VirtualQuery(
+            address: *const c_void,
+            buffer: *mut MemoryBasicInformation,
+            length: usize,
+        ) -> usize;
+    }
+
+    /// Bytes readable from `address` to the end of its mapped region.
+    pub fn view_length(address: *const c_void) -> Result<usize> {
+        let mut information = std::mem::MaybeUninit::<MemoryBasicInformation>::uninit();
+        let written = unsafe {
+            VirtualQuery(
+                address,
+                information.as_mut_ptr(),
+                std::mem::size_of::<MemoryBasicInformation>(),
+            )
+        };
+        if written == 0 {
+            return Err(std::io::Error::last_os_error()).context("sizing shared RAW view");
+        }
+        let information = unsafe { information.assume_init() };
+        let offset = address as usize - information.base_address as usize;
+        Ok(information.region_size.saturating_sub(offset))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 fn load_shared_input(_name: &str, _length: usize) -> Result<ImageBuf> {
     bail!("shared RAW input is unavailable on this platform")
 }
@@ -883,6 +1003,122 @@ mod tests {
         assert_eq!(u32::from_le_bytes(bytes[8..12].try_into().unwrap()), 1);
         assert_eq!(u32::from_le_bytes(bytes[12..16].try_into().unwrap()), 8);
         assert_eq!(&bytes[16..], &[0, 128, 255, 255, 255, 64, 0, 255]);
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_shared_input_tests {
+    use super::*;
+    use std::os::windows::ffi::OsStrExt;
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn CreateFileMappingW(
+            file: *mut std::ffi::c_void,
+            attributes: *mut std::ffi::c_void,
+            protect: u32,
+            maximum_size_high: u32,
+            maximum_size_low: u32,
+            name: *const u16,
+        ) -> *mut std::ffi::c_void;
+    }
+
+    const PAGE_READWRITE: u32 = 0x04;
+    const FILE_MAP_WRITE: u32 = 0x0002;
+
+    struct Segment {
+        name: String,
+        mapping: *mut std::ffi::c_void,
+        view: *mut std::ffi::c_void,
+        length: usize,
+    }
+
+    impl Segment {
+        /// Mirror `multiprocessing.shared_memory.SharedMemory(create=True)`:
+        /// a pagefile-backed mapping whose handle stays open for the test.
+        fn create(length: usize) -> Self {
+            let name = format!("wnsm_lighttable_test_{}_{length}", std::process::id());
+            let wide: Vec<u16> = std::ffi::OsStr::new(&name)
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect();
+            let mapping = unsafe {
+                CreateFileMappingW(
+                    usize::MAX as *mut std::ffi::c_void,
+                    std::ptr::null_mut(),
+                    PAGE_READWRITE,
+                    0,
+                    length as u32,
+                    wide.as_ptr(),
+                )
+            };
+            assert!(!mapping.is_null(), "{}", io::Error::last_os_error());
+            let view = unsafe { windows_shared::MapViewOfFile(mapping, FILE_MAP_WRITE, 0, 0, 0) };
+            assert!(!view.is_null(), "{}", io::Error::last_os_error());
+            Self {
+                name,
+                mapping,
+                view,
+                length,
+            }
+        }
+
+        fn write(&self, bytes: &[u8]) {
+            assert!(bytes.len() <= self.length);
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), self.view.cast::<u8>(), bytes.len());
+            }
+        }
+    }
+
+    impl Drop for Segment {
+        fn drop(&mut self) {
+            unsafe {
+                windows_shared::UnmapViewOfFile(self.view);
+                windows_shared::CloseHandle(self.mapping);
+            }
+        }
+    }
+
+    fn packed_rgb16(width: u32, height: u32, samples: &[u16]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(RAW_SHARED_MAGIC);
+        bytes.extend_from_slice(&width.to_le_bytes());
+        bytes.extend_from_slice(&height.to_le_bytes());
+        bytes.extend_from_slice(&(width * 6).to_le_bytes());
+        for sample in samples {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn named_file_mapping_delivers_packed_rgb16_pixels() {
+        let payload = packed_rgb16(2, 1, &[0, 32768, 65535, 7, 8, 9]);
+        let segment = Segment::create(payload.len());
+        segment.write(&payload);
+        let image = load_shared_input(&segment.name, payload.len()).unwrap();
+        assert_eq!((image.width, image.height), (2, 1));
+        let values: Vec<f32> = image
+            .data
+            .iter()
+            .map(|&value| precision::to_f32(value))
+            .collect();
+        assert_eq!(values[0], 0.0);
+        assert!((values[1] - 32768.0 / 65535.0).abs() < 1e-6);
+        assert_eq!(values[2], 1.0);
+    }
+
+    #[test]
+    fn short_or_missing_mappings_are_refused_instead_of_read_past() {
+        let payload = packed_rgb16(2, 1, &[1, 2, 3, 4, 5, 6]);
+        let segment = Segment::create(payload.len());
+        segment.write(&payload);
+        // A request one page beyond the object must fail to map, never
+        // return a view that reads unmapped memory.
+        assert!(load_shared_input(&segment.name, payload.len() + 4096).is_err());
+        assert!(load_shared_input("wnsm_lighttable_missing", payload.len()).is_err());
+        assert!(load_shared_input("bad name", payload.len()).is_err());
     }
 }
 

--- a/rust-engine/src/native_surface.rs
+++ b/rust-engine/src/native_surface.rs
@@ -1,0 +1,102 @@
+//! Immutable native preview transport. The server adopts each successful name
+//! and unlinks it on LRU eviction; mmap users retain their pixels after unlink.
+use std::sync::atomic::{AtomicU64, Ordering};
+use anyhow::{Context, Result, bail};
+use rayon::prelude::*;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct SharedSurface {
+    pub name: String,
+    pub length: usize,
+    pub offset: usize,
+    pub width: u32,
+    pub height: u32,
+    #[serde(rename = "rowBytes")]
+    pub row_bytes: usize,
+}
+
+pub fn publish_rgb(width: u32, height: u32, samples: &[f32]) -> Result<SharedSurface> {
+    let row_bytes = (width as usize).checked_mul(4).context("surface row overflow")?
+        .checked_add(255).context("surface alignment overflow")? & !255;
+    let pixels = (width as usize).checked_mul(height as usize).context("surface size overflow")?;
+    if width == 0 || height == 0 || samples.len() != pixels * 3 {
+        bail!("native surface sample count mismatch");
+    }
+    let mut packed = vec![0_u8; row_bytes.checked_mul(height as usize).context("surface size overflow")?];
+    packed.par_chunks_mut(row_bytes).zip(samples.par_chunks(width as usize * 3))
+        .for_each(|(row, source)| {
+            for (pixel, rgb) in row.chunks_mut(4).zip(source.chunks(3)) {
+                for channel in 0..3 {
+                    pixel[channel] = (rgb[channel].clamp(0.0, 1.0) * 255.0).round_ties_even() as u8;
+                }
+                pixel[3] = 255;
+            }
+        });
+    publish_packed(width, height, row_bytes, &packed)
+}
+
+#[cfg(unix)]
+pub fn publish_packed(width: u32, height: u32, row_bytes: usize, packed: &[u8]) -> Result<SharedSurface> {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    if width == 0 || height == 0 || row_bytes < width as usize * 4 || row_bytes % 256 != 0
+        || packed.len() != row_bytes.checked_mul(height as usize).context("surface size overflow")? {
+        bail!("invalid packed surface");
+    }
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+    let length = packed.len().checked_add(page - 1).context("surface mapping overflow")? / page * page;
+    if length > 256 * 1024 * 1024 { bail!("shared native surface exceeds byte budget"); }
+    let name = format!("/lt-{:x}-{:x}", std::process::id(), NEXT.fetch_add(1, Ordering::Relaxed));
+    let c_name = std::ffi::CString::new(name.clone())?;
+    let fd = unsafe { libc::shm_open(c_name.as_ptr(), libc::O_RDWR | libc::O_CREAT | libc::O_EXCL, 0o600) };
+    if fd < 0 { return Err(std::io::Error::last_os_error()).context("creating native shared memory"); }
+    let result = (|| {
+        if unsafe { libc::ftruncate(fd, length as libc::off_t) } != 0 {
+            return Err(std::io::Error::last_os_error()).context("sizing native shared memory");
+        }
+        let address = unsafe { libc::mmap(std::ptr::null_mut(), length, libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED, fd, 0) };
+        if address == libc::MAP_FAILED {
+            return Err(std::io::Error::last_os_error()).context("mapping native shared memory");
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(packed.as_ptr(), address.cast::<u8>(), packed.len());
+            libc::munmap(address, length);
+        }
+        Ok(SharedSurface { name, length, offset: 0, width, height, row_bytes })
+    })();
+    unsafe {
+        libc::close(fd);
+        if result.is_err() { libc::shm_unlink(c_name.as_ptr()); }
+    }
+    result
+}
+
+#[cfg(not(unix))]
+pub fn publish_packed(_width: u32, _height: u32, _row_bytes: usize, _packed: &[u8]) -> Result<SharedSurface> {
+    bail!("shared native transport is unavailable on this platform")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    #[test]
+    fn mapping_preserves_padded_rows_and_survives_unlink() {
+        let surface = publish_rgb(2, 2, &[0.0, 0.5, 1.0, 1.0, 0.0, 0.25,
+            0.25, 0.5, 0.75, 0.0, 0.0, 0.0]).unwrap();
+        let name = std::ffi::CString::new(surface.name).unwrap();
+        unsafe {
+            let fd = libc::shm_open(name.as_ptr(), libc::O_RDONLY, 0);
+            assert!(fd >= 0);
+            let address = libc::mmap(std::ptr::null_mut(), surface.length, libc::PROT_READ,
+                libc::MAP_SHARED, fd, 0);
+            assert_ne!(address, libc::MAP_FAILED);
+            libc::close(fd);
+            assert_eq!(libc::shm_unlink(name.as_ptr()), 0);
+            let bytes = std::slice::from_raw_parts(address.cast::<u8>(), surface.length);
+            assert_eq!(&bytes[..8], &[0, 128, 255, 255, 255, 0, 64, 255]);
+            assert_eq!(&bytes[256..264], &[64, 128, 191, 255, 0, 0, 0, 255]);
+            libc::munmap(address, surface.length);
+        }
+    }
+}

--- a/rust-engine/src/region.rs
+++ b/rust-engine/src/region.rs
@@ -1,0 +1,316 @@
+//! Exact viewport planning for the finite-support WGPU film chain.
+//!
+//! Input and metering remain full frame. Only the image sent through the pixel
+//! stages is cropped, with the sum of the sequential kernels' support. Noise
+//! uses absolute source coordinates. Diffusion's resampling lattice currently
+//! requires the full frame; that path returns the same requested output crop.
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+use spektrafilm_core::params::RuntimeParams;
+use spektrafilm_math::image::ImageBuf;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Rect {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Rect {
+    pub fn array(self) -> [u32; 4] {
+        [self.x, self.y, self.width, self.height]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RegionPlan {
+    /// Expanded input-axis rectangle sent to the pixel stages.
+    pub render: Rect,
+    /// Input-axis final crop relative to the expanded render, before rotation.
+    pub trim: Rect,
+    pub accelerated: bool,
+}
+
+pub fn plan(
+    viewport: Rect,
+    width: u32,
+    height: u32,
+    quarters_ccw: u8,
+    params: &RuntimeParams,
+    wgpu: bool,
+) -> Result<RegionPlan> {
+    let (out_width, out_height) = if quarters_ccw % 2 == 0 {
+        (width, height)
+    } else {
+        (height, width)
+    };
+    if viewport.width == 0
+        || viewport.height == 0
+        || viewport
+            .x
+            .checked_add(viewport.width)
+            .is_none_or(|end| end > out_width)
+        || viewport
+            .y
+            .checked_add(viewport.height)
+            .is_none_or(|end| end > out_height)
+    {
+        bail!("viewport must be a nonempty rectangle inside {out_width}x{out_height}");
+    }
+    let v = viewport;
+    let source = match quarters_ccw % 4 {
+        0 => v,
+        1 => Rect {
+            x: width - v.y - v.height,
+            y: v.x,
+            width: v.height,
+            height: v.width,
+        },
+        2 => Rect {
+            x: width - v.x - v.width,
+            y: height - v.y - v.height,
+            width: v.width,
+            height: v.height,
+        },
+        _ => Rect {
+            x: v.y,
+            y: height - v.x - v.width,
+            width: v.height,
+            height: v.width,
+        },
+    };
+    let padding = wgpu.then(|| kernel_margin(params, width, height)).flatten();
+    let render = if let Some(pad) = padding {
+        let x = source.x.saturating_sub(pad);
+        let y = source.y.saturating_sub(pad);
+        let right = (source.x + source.width).saturating_add(pad).min(width);
+        let bottom = (source.y + source.height).saturating_add(pad).min(height);
+        Rect {
+            x,
+            y,
+            width: right - x,
+            height: bottom - y,
+        }
+    } else {
+        Rect {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }
+    };
+    Ok(RegionPlan {
+        render,
+        trim: Rect {
+            x: source.x - render.x,
+            y: source.y - render.y,
+            width: source.width,
+            height: source.height,
+        },
+        accelerated: render.width < width || render.height < height,
+    })
+}
+
+/// Match the WGPU separable FIR support exactly (including its safety cap).
+fn blur_radius(sigma: f32) -> u32 {
+    (3.0 * sigma.max(0.01)).ceil().min(256.0) as u32
+}
+
+fn kernel_margin(p: &RuntimeParams, width: u32, height: u32) -> Option<u32> {
+    // Downsample/interpolate in diffusion currently depends on full-frame grid
+    // dimensions, so a padded crop alone cannot preserve the sampling lattice.
+    if p.camera.diffusion_filter.active
+        || (!p.io.scan_film && p.enlarger.diffusion_filter.active)
+        || (p.io.upscale_factor - 1.0).abs() > 1e-6
+        || p.io.crop
+    {
+        return None;
+    }
+    let pixel_um =
+        spektrafilm_core::stages::filming::pixel_size_um(p.camera.film_format_mm, width, height);
+    let mut margin = 0;
+    if p.camera.lens_blur_um > 0.0 {
+        margin += blur_radius(p.camera.lens_blur_um / pixel_um);
+    }
+    let h = &p.film_render.halation;
+    if h.active {
+        let avg = |a: [f64; 3]| (a[0] + a[1] + a[2]) / 3.0;
+        // Scatter branches are parallel; the bounce blurs read their combined
+        // result in parallel. Add each stage's largest radius, not every branch.
+        let scatter = (avg(h.scatter_core_um).max(avg(h.scatter_tail_um)) * h.scatter_spatial_scale
+            / pixel_um as f64) as f32;
+        margin += blur_radius(scatter);
+        if h.halation_n_bounces > 0 {
+            let first = (avg(h.halation_first_sigma_um) * h.halation_spatial_scale
+                / pixel_um as f64) as f32;
+            margin += blur_radius(first * (h.halation_n_bounces as f32).sqrt());
+        }
+    }
+    let dir = &p.film_render.dir_couplers;
+    if dir.active {
+        margin += blur_radius(
+            (dir.diffusion_size_um.max(dir.diffusion_tail_um) / pixel_um as f64) as f32,
+        );
+    }
+    let grain = &p.film_render.grain;
+    if grain.active && grain.blur > 0.0 {
+        margin += blur_radius(grain.blur);
+    }
+    let glare = if p.io.scan_film {
+        &p.film_render.glare
+    } else {
+        &p.print_render.glare
+    };
+    // Glare noise is independent of image pixels, but its own blur needs the
+    // same absolute-coordinate halo. Adding it is conservative and bounded.
+    if glare.active && glare.percent > 0.0 && glare.blur > 0.0 {
+        margin += blur_radius(glare.blur);
+    }
+    if p.scanner.lens_blur > 0.0 {
+        margin += blur_radius(p.scanner.lens_blur);
+    }
+    let [sigma, amount] = p.scanner.unsharp_mask;
+    if sigma > 0.0 && amount > 0.0 {
+        margin += blur_radius(sigma);
+    }
+    Some(margin)
+}
+
+pub fn crop_image(image: &ImageBuf, rect: Rect) -> ImageBuf {
+    assert!(rect.x + rect.width <= image.width && rect.y + rect.height <= image.height);
+    let mut data = Vec::with_capacity(rect.width as usize * rect.height as usize * 3);
+    for y in rect.y..rect.y + rect.height {
+        let start = (y as usize * image.width as usize + rect.x as usize) * 3;
+        data.extend_from_slice(&image.data[start..start + rect.width as usize * 3]);
+    }
+    ImageBuf::from_data(rect.width, rect.height, data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn pointwise() -> RuntimeParams {
+        let mut p = RuntimeParams::default();
+        p.film_render.halation.active = false;
+        p.film_render.dir_couplers.active = false;
+        p.film_render.grain.active = false;
+        p.print_render.glare.active = false;
+        p.film_render.glare.active = false;
+        p.scanner.unsharp_mask = [0.0, 0.0];
+        p
+    }
+    #[test]
+    fn inverse_rotated_viewports_select_the_same_source_pixels() {
+        let image = ImageBuf::from_data(6, 4, (0..72).map(|v| v as f32 / 72.0).collect());
+        for q in 0..4 {
+            let viewport = Rect {
+                x: 1,
+                y: 1,
+                width: 2,
+                height: 3,
+            };
+            let region = plan(viewport, 6, 4, q, &pointwise(), true).unwrap();
+            let cropped = crop_image(&image, region.render);
+            let (w, _, actual) = crate::rotate_samples(&cropped, q);
+            let (full_w, _, full) = crate::rotate_samples(&image, q);
+            assert_eq!(w, viewport.width);
+            let mut expected = Vec::new();
+            for y in viewport.y..viewport.y + viewport.height {
+                let start = ((y * full_w + viewport.x) * 3) as usize;
+                expected.extend_from_slice(&full[start..start + (viewport.width * 3) as usize]);
+            }
+            assert_eq!(actual, expected, "rotation {q}");
+        }
+    }
+    #[test]
+    fn margin_sums_sequential_kernels_and_clamps_at_frame_edges() {
+        let mut p = pointwise();
+        p.scanner.lens_blur = 2.0;
+        p.scanner.unsharp_mask = [3.0, 1.0];
+        let region = plan(
+            Rect {
+                x: 10,
+                y: 20,
+                width: 50,
+                height: 60,
+            },
+            200,
+            150,
+            0,
+            &p,
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            region.render,
+            Rect {
+                x: 0,
+                y: 5,
+                width: 75,
+                height: 90
+            }
+        );
+        assert_eq!(
+            region.trim,
+            Rect {
+                x: 10,
+                y: 15,
+                width: 50,
+                height: 60
+            }
+        );
+        assert!(region.accelerated);
+    }
+    #[test]
+    fn unsupported_resampling_and_cpu_use_full_frame_without_changing_crop() {
+        let mut p = pointwise();
+        let viewport = Rect {
+            x: 10,
+            y: 20,
+            width: 50,
+            height: 60,
+        };
+        for gpu in [false, true] {
+            p.camera.diffusion_filter.active = gpu;
+            let region = plan(viewport, 200, 150, 0, &p, gpu).unwrap();
+            assert!(!region.accelerated);
+            assert_eq!(
+                region.render,
+                Rect {
+                    x: 0,
+                    y: 0,
+                    width: 200,
+                    height: 150
+                }
+            );
+            assert_eq!(region.trim, viewport);
+        }
+    }
+    #[test]
+    fn invalid_and_overflowing_viewports_fail_before_allocating() {
+        for viewport in [
+            Rect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 10,
+            },
+            Rect {
+                x: u32::MAX,
+                y: 0,
+                width: 2,
+                height: 1,
+            },
+            Rect {
+                x: 10,
+                y: 10,
+                width: 191,
+                height: 2,
+            },
+        ] {
+            assert!(plan(viewport, 200, 150, 0, &pointwise(), true).is_err());
+        }
+    }
+}

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/pipeline.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/pipeline.rs
@@ -6,6 +6,7 @@
 ///   3. Compute print exposure normalization factor from midgray spectral density
 ///   4. Pass all calibration data to the pipeline stages
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use spektrafilm_gpu::ComputeBackend;
@@ -98,7 +99,9 @@ pub struct Pipeline {
     pub film: Profile,
     pub print: Profile,
     pub params: RuntimeParams,
-    tc_lut: Option<TcLut>,
+    image_region: Option<[u32; 4]>,
+    tc_lut: Option<Arc<TcLut>>,
+    neutral_filters: Option<Arc<crate::neutral_filters::NeutralFilters>>,
     /// Mallett2019 reflectance-basis core matrix (linear-sRGB → raw), when that
     /// upsampler is selected instead of the hanatos2025 tc LUT. Mutually
     /// exclusive with `tc_lut`.
@@ -119,9 +122,21 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
+    /// Preserve the original sensor pitch and absolute noise coordinates when
+    /// the input is an expanded viewport cut out of the full decoded image.
+    pub fn with_image_region(mut self, x: u32, y: u32, full_width: u32, full_height: u32) -> Self {
+        self.image_region = Some([x, y, full_width, full_height]);
+        self
+    }
+
+    fn pixel_size_um(&self, image: &ImageBuf) -> f32 {
+        let [_, _, width, height] = self.image_region.unwrap_or([0, 0, image.width, image.height]);
+        stages::filming::pixel_size_um(self.params.camera.film_format_mm, width, height)
+    }
+
     /// Accessor for the pre-computed TC LUT (used by parity tests).
     pub fn tc_lut(&self) -> Option<&TcLut> {
-        self.tc_lut.as_ref()
+        self.tc_lut.as_deref()
     }
     /// Accessor for the print exposure factor (parity tests).
     pub fn print_exposure_factor(&self) -> f64 {
@@ -174,7 +189,9 @@ impl Pipeline {
             film,
             print,
             params,
+            image_region: None,
             tc_lut: None,
+            neutral_filters: None,
             mallett_core: None,
             front_illuminant,
             print_exposure_factor: 1.0,
@@ -195,7 +212,6 @@ impl Pipeline {
         // time and broadcast the single channel onto the 3-channel engine
         // layout. Must happen before anything reads the profile data.
         let film = crate::profile::resolve_for_render(film, params.film_render.development_time);
-        let print = crate::profile::resolve_for_render(print, params.print_render.development_time);
 
         // Python parity: mirror `_apply_film_specifics` in
         // `spektrafilm/runtime/params_builder.py`. Python applies these
@@ -204,31 +220,6 @@ impl Pipeline {
         // Python uses. The DIR-coupler gammas in particular differ
         // between positive and negative films.
         apply_film_specific_params(&film, &mut params);
-
-        // Python parity: look up per-(print, illuminant, film) neutral filter values from
-        // the JSON database — matches `apply_database_neutral_print_filters`. Defaults to
-        // params.enlarger.{c,m,y}_filter_neutral when the combo isn't in the database.
-        // Keep the f64 lookup values around (params is f32) — narrowing to
-        // f32 here costs ~4e-8 precision through the `10^(-cc/100)` step.
-        let mut neutral_cmy_f64: Option<[f64; 3]> = None;
-        if params.settings.neutral_print_filters_from_database {
-            let db = crate::neutral_filters::NeutralFilters::load(data_dir);
-            let print_stock = print.info.stock.as_deref().unwrap_or("");
-            let film_stock = film.info.stock.as_deref().unwrap_or("");
-            if let Some([c, m, y]) = db.lookup(print_stock, &params.enlarger.illuminant, film_stock)
-            {
-                params.enlarger.c_filter_neutral = c as f32;
-                params.enlarger.m_filter_neutral = m as f32;
-                params.enlarger.y_filter_neutral = y as f32;
-                neutral_cmy_f64 = Some([c, m, y]);
-            }
-        }
-        let cmy_f64 = neutral_cmy_f64.unwrap_or([
-            params.enlarger.c_filter_neutral as f64,
-            params.enlarger.m_filter_neutral as f64,
-            params.enlarger.y_filter_neutral as f64,
-        ]);
-        let (c_neutral_f64, m_neutral_f64, y_neutral_f64) = (cmy_f64[0], cmy_f64[1], cmy_f64[2]);
 
         // Film sensitivity: Python `sensitivity = np.nan_to_num(10 ** log_sensitivity)` — f64.
         let log_sens = film.log_sensitivity_f64();
@@ -322,6 +313,60 @@ impl Pipeline {
         // Python parity: sensitivities are pre-balanced in the profile so midgray ≈ 1.0.
         // The TC LUT is used unnormalized — Python's `rgb_to_raw_hanatos2025` does NOT scale it.
         // See `spektrafilm/utils/spectral_upsampling.py:rgb_to_raw_hanatos2025` (comment line 373).
+
+        let pipeline = Self {
+            film,
+            print: print.clone(),
+            params: params.clone(),
+            image_region: None,
+            tc_lut: tc_lut.map(Arc::new),
+            neutral_filters: Some(Arc::new(crate::neutral_filters::NeutralFilters::load(data_dir))),
+            mallett_core,
+            front_illuminant,
+            print_exposure_factor: 1.0,
+            print_illuminant: Vec::new(),
+            preflash_raw: [0.0; 3],
+            output_gamut: crate::gamut_compression::OutputGamutCompress::build(
+                &params.io.output_gamut_compress, &params.io.output_color_space),
+        };
+        Ok(pipeline.with_print_params(print, params))
+    }
+
+    /// Recalibrate only the print/output side, preserving the film spectral LUT.
+    /// `print` must be an unresolved source profile so development changes never
+    /// interpolate a profile that was already collapsed to a previous time.
+    /// The caller must keep film stock, film development and LUT inputs fixed.
+    pub fn with_print_params(mut self, print: Profile, mut params: RuntimeParams) -> Self {
+        let film = &self.film;
+        let print = crate::profile::resolve_for_render(print, params.print_render.development_time);
+        apply_film_specific_params(film, &mut params);
+        let tc_lut = &self.tc_lut;
+        let mallett_core = &self.mallett_core;
+        let front_illuminant = &self.front_illuminant;
+        // Python parity: look up per-(print, illuminant, film) neutral filter values from
+        // the JSON database — matches `apply_database_neutral_print_filters`. Defaults to
+        // params.enlarger.{c,m,y}_filter_neutral when the combo isn't in the database.
+        // Keep the f64 lookup values around (params is f32) — narrowing to
+        // f32 here costs ~4e-8 precision through the `10^(-cc/100)` step.
+        let mut neutral_cmy_f64: Option<[f64; 3]> = None;
+        if params.settings.neutral_print_filters_from_database {
+            let db = self.neutral_filters.as_ref().expect("spectral neutral database");
+            let print_stock = print.info.stock.as_deref().unwrap_or("");
+            let film_stock = film.info.stock.as_deref().unwrap_or("");
+            if let Some([c, m, y]) = db.lookup(print_stock, &params.enlarger.illuminant, film_stock)
+            {
+                params.enlarger.c_filter_neutral = c as f32;
+                params.enlarger.m_filter_neutral = m as f32;
+                params.enlarger.y_filter_neutral = y as f32;
+                neutral_cmy_f64 = Some([c, m, y]);
+            }
+        }
+        let cmy_f64 = neutral_cmy_f64.unwrap_or([
+            params.enlarger.c_filter_neutral as f64,
+            params.enlarger.m_filter_neutral as f64,
+            params.enlarger.y_filter_neutral as f64,
+        ]);
+        let (c_neutral_f64, m_neutral_f64, y_neutral_f64) = (cmy_f64[0], cmy_f64[1], cmy_f64[2]);
 
         // Compute enlarger illuminant with dichroic filters — f64 for Python parity.
         // c/m/y come from the f64 lookup, shift values are f32 in params.
@@ -445,18 +490,13 @@ impl Pipeline {
             &params.io.output_gamut_compress,
             &params.io.output_color_space,
         );
-        Ok(Self {
-            film,
-            print,
-            params,
-            tc_lut,
-            mallett_core,
-            front_illuminant,
-            print_exposure_factor,
-            print_illuminant,
-            preflash_raw,
-            output_gamut,
-        })
+        self.print = print;
+        self.params = params;
+        self.print_exposure_factor = print_exposure_factor;
+        self.print_illuminant = print_illuminant;
+        self.preflash_raw = preflash_raw;
+        self.output_gamut = output_gamut;
+        self
     }
 
     pub fn process(&self, image: ImageBuf, backend: &dyn ComputeBackend) -> ImageBuf {
@@ -506,7 +546,7 @@ impl Pipeline {
             &self.film,
             &self.params,
             backend,
-            self.tc_lut.as_ref(),
+            self.tc_lut.as_deref(),
             self.mallett_core.as_ref(),
             select_illuminant(&self.front_illuminant),
             color_ref.filming_exposure_correction,
@@ -599,11 +639,35 @@ impl Pipeline {
             &self.print_illuminant,
             self.print_exposure_factor,
         );
-        let out = self.try_gpu_resident(image, backend, &color_ref, film_cache_key, metered_ev)?;
+        // Direct positive-film scanner correction changes filming exposure.
+        // Key its actual derived value so print-only reference settings can
+        // still reuse the checkpoint, without incorrectly reusing slide density.
+        let film_cache_key = film_cache_key.map(|key| {
+            format!("{key}:{}", color_ref.filming_exposure_correction.to_bits())
+        });
+        let out = self.try_gpu_resident(image, backend, &color_ref, film_cache_key.as_deref(), metered_ev)?;
         if backend.resident_chain_applies_post_scan() {
             Some(out)
         } else {
             Some(self.apply_post_scan(out))
+        }
+    }
+
+    /// Native previews avoid full float RGB readback, CPU rotation and packing.
+    pub fn process_resident_native(
+        &self, image: &ImageBuf, backend: &dyn ComputeBackend,
+        film_cache_key: Option<&str>, metered_ev: Option<f32>, output: spektrafilm_gpu::NativeOutputSpec,
+    ) -> Option<spektrafilm_gpu::NativePackedSurface> {
+        if self.tc_lut.is_none() && self.mallett_core.is_none() { return None; }
+        let color_ref = crate::color_reference::ColorReference::compute(
+            &self.film, &self.print, &self.params, &self.print_illuminant,
+            self.print_exposure_factor);
+        let key = film_cache_key.map(|key|
+            format!("{key}:{}", color_ref.filming_exposure_correction.to_bits()));
+        match self.try_gpu_resident_output(image, backend, &color_ref,
+            key.as_deref(), metered_ev, Some(output))? {
+            spektrafilm_gpu::FilmChainOutput::Native(surface) => Some(surface),
+            spektrafilm_gpu::FilmChainOutput::Rgb(_) => None,
         }
     }
 
@@ -648,6 +712,18 @@ impl Pipeline {
         film_cache_key: Option<&str>,
         metered_ev: Option<f32>,
     ) -> Option<ImageBuf> {
+        match self.try_gpu_resident_output(image, backend, color_ref,
+            film_cache_key, metered_ev, None)? {
+            spektrafilm_gpu::FilmChainOutput::Rgb(image) => Some(image),
+            spektrafilm_gpu::FilmChainOutput::Native(_) => None,
+        }
+    }
+
+    fn try_gpu_resident_output(
+        &self, image: &ImageBuf, backend: &dyn ComputeBackend,
+        color_ref: &crate::color_reference::ColorReference,
+        film_cache_key: Option<&str>, metered_ev: Option<f32>, native_rotation: Option<spektrafilm_gpu::NativeOutputSpec>,
+    ) -> Option<spektrafilm_gpu::FilmChainOutput> {
         // Bake the exposure scale (auto-exposure × manual EV compensation)
         // into the front-pass matrix. Both upsamplers (hanatos and mallett)
         // are homogeneous in the input RGB, so scaling the matrix is
@@ -839,11 +915,7 @@ impl Pipeline {
             }
         }
 
-        let pix_um = stages::filming::pixel_size_um(
-            self.params.camera.film_format_mm,
-            image.width,
-            image.height,
-        );
+        let pix_um = self.pixel_size_um(image);
 
         // print_exposure_factor × print_exposure, with the B&W printing
         // exposure correction folded in (CPU applies it as a further raw
@@ -858,11 +930,7 @@ impl Pipeline {
         // per-channel µm sigmas, converts to pixel space, and passes the
         // resulting scalars to the shaders.
         let halation = if self.params.film_render.halation.active {
-            let pix_um = stages::filming::pixel_size_um(
-                self.params.camera.film_format_mm,
-                image.width,
-                image.height,
-            );
+            let pix_um = self.pixel_size_um(image);
             let h = &self.params.film_render.halation;
             // GPU shaders take f32 — narrow at the boundary.
             let avg_f64 = |a: [f64; 3]| (a[0] + a[1] + a[2]) / 3.0;
@@ -904,11 +972,7 @@ impl Pipeline {
         // Held in this binding so `&density_curves_0_f64` outlives the
         // backend call.
         let dir_inputs = if self.params.film_render.dir_couplers.active {
-            let pix_um = stages::filming::pixel_size_um(
-                self.params.camera.film_format_mm,
-                image.width,
-                image.height,
-            );
+            let pix_um = self.pixel_size_um(image);
             let dir = &self.params.film_render.dir_couplers;
             let matrix = spektrafilm_model::couplers::compute_dir_couplers_matrix(
                 dir.gamma_samelayer_rgb,
@@ -997,11 +1061,7 @@ impl Pipeline {
         // sampling; CPU does the same whenever λ > 30 / var > 9, which is
         // the typical regime for ≥ 1 MP images.
         let grain = if self.params.film_render.grain.active {
-            let pix_um = stages::filming::pixel_size_um(
-                self.params.camera.film_format_mm,
-                image.width,
-                image.height,
-            );
+            let pix_um = self.pixel_size_um(image);
             let g = &self.params.film_render.grain;
             let pixel_area = pix_um * pix_um;
             let n_sub = g.n_sub_layers.max(1);
@@ -1034,6 +1094,8 @@ impl Pipeline {
                 ],
                 n_sub_layers: n_sub,
                 base_seed: 0,
+                pixel_origin: self.image_region.map_or([0, 0], |r| [r[0], r[1]]),
+                full_width: self.image_region.map_or(image.width, |r| r[2]),
                 grain_blur: g.blur,
                 monochrome: g.monochrome,
             })
@@ -1080,6 +1142,8 @@ impl Pipeline {
                 sigma: sigma as f32,
                 blur_px: g.blur,
                 base_seed: 42,
+                pixel_origin: self.image_region.map_or([0, 0], |r| [r[0], r[1]]),
+                full_width: self.image_region.map_or(image.width, |r| r[2]),
                 rgb_offset: offset_rgb,
             })
         } else {
@@ -1182,7 +1246,12 @@ impl Pipeline {
             print_exposure_scale,
             output_cctf_encoding: self.params.io.output_cctf_encoding,
         };
-        backend.try_run_film_chain(&params)
+        if let Some(rotation) = native_rotation {
+            backend.try_run_film_chain_native(&params, rotation)
+                .map(spektrafilm_gpu::FilmChainOutput::Native)
+        } else {
+            backend.try_run_film_chain(&params).map(spektrafilm_gpu::FilmChainOutput::Rgb)
+        }
     }
 
     /// After the GPU fast path returns linear RGB, apply sRGB encoding + clip

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-gpu/src/lib.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-gpu/src/lib.rs
@@ -134,6 +134,10 @@ pub trait ComputeBackend: Send + Sync {
         None
     }
 
+    /// Display-only resident output, packed and rotated before GPU readback.
+    fn try_run_film_chain_native(&self, _params: &FilmChainParams<'_>,
+        _output: NativeOutputSpec) -> Option<NativePackedSurface> { None }
+
     /// True when `try_run_film_chain` returns the same post-scan output that
     /// `Pipeline::apply_post_scan` would produce (final clamp and optional
     /// sRGB encoding). Backends default to returning linear RGB and letting
@@ -153,6 +157,27 @@ pub trait ComputeBackend: Send + Sync {
     fn resident_cache_status(&self) -> (bool, bool, usize) { (false, false, 0) }
 
     fn name(&self) -> &str;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeOutputSpec {
+    pub quarters_ccw: u8,
+    /// Rectangle within the resident input, cropped before rotation.
+    pub crop: Option<[u32; 4]>,
+}
+
+/// Display-referred RGBA with Metal-compatible 256-byte row alignment.
+pub struct NativePackedSurface {
+    pub width: u32,
+    pub height: u32,
+    pub row_bytes: usize,
+    pub pixels: Vec<u8>,
+    pub mean: f64,
+}
+
+pub enum FilmChainOutput {
+    Rgb(ImageBuf),
+    Native(NativePackedSurface),
 }
 
 /// All inputs to the GPU-resident film chain. Bundled into a struct so the
@@ -319,6 +344,9 @@ pub struct GrainGpuParams {
     pub grain_uniformity: [f32; 3],
     pub n_sub_layers: u32,
     pub base_seed: u32,
+    /// Absolute source coordinates keep noise unchanged while panning.
+    pub pixel_origin: [u32; 2],
+    pub full_width: u32,
     pub grain_blur: f32,
     /// One shared noise field across all channels (B&W single emulsion)
     /// instead of independent per-channel RNG streams.
@@ -367,6 +395,9 @@ pub struct GlareGpuParams {
     pub sigma: f32,
     pub blur_px: f32,
     pub base_seed: u32,
+    /// Absolute source coordinates keep noise unchanged while panning.
+    pub pixel_origin: [u32; 2],
+    pub full_width: u32,
     /// `(XYZ→RGB) * illuminant_xyz`, pre-divided by 100. The shader
     /// just multiplies the lognormal scalar by this per-channel offset.
     pub rgb_offset: [f32; 3],

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-gpu/src/wgpu_backend.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-gpu/src/wgpu_backend.rs
@@ -814,6 +814,14 @@ impl WgpuBackend {
     /// and unsharp as a single command buffer with ping-pong image storage.
     /// Only one upload at the start and one readback at the end.
     pub fn run_film_chain(&self, p: &crate::FilmChainParams<'_>) -> ImageBuf {
+        match self.run_film_chain_output(p, None) {
+            crate::FilmChainOutput::Rgb(image) => image,
+            crate::FilmChainOutput::Native(_) => unreachable!("RGB output requested"),
+        }
+    }
+
+    fn run_film_chain_output(&self, p: &crate::FilmChainParams<'_>,
+        native_rotation: Option<crate::NativeOutputSpec>) -> crate::FilmChainOutput {
         use wgpu::util::DeviceExt;
         let t_start = std::time::Instant::now();
         // Pull all references into locals so the existing body below
@@ -1405,7 +1413,7 @@ impl WgpuBackend {
         // Readback buffer (for the final image only) — only needed when we
         // can't map buf_b directly. Skipping it on the mappable path also
         // avoids allocating a second full-image buffer per frame.
-        let readback = (!mappable).then(|| {
+        let readback = (!mappable && native_rotation.is_none()).then(|| {
             self.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("readback"),
                 size: img_bytes as u64,
@@ -1715,6 +1723,11 @@ impl WgpuBackend {
         // display-ready pixels without a CPU full-frame post pass.
         post_scan_state.encode_passes(&mut encoder, n_pixels);
 
+        let native_pack = native_rotation.map(|rotation| {
+            self.encode_native_pack(&mut encoder, &buf_b, image.width, image.height,
+                rotation, mappable)
+        });
+
         // Zero-copy path: when buf_b is mappable, skip the blit and map it
         // directly below. Otherwise stage it into the MAP_READ readback buffer.
         if let Some(rb) = readback.as_ref() {
@@ -1727,7 +1740,8 @@ impl WgpuBackend {
 
         // Single sync point at the end. Map buf_b directly on the zero-copy
         // path, or the staging buffer otherwise.
-        let map_target = readback.as_ref().unwrap_or(&buf_b);
+        let map_target = native_pack.as_ref().map(|pack| &pack.0)
+            .or(readback.as_ref()).unwrap_or(&buf_b);
         let slice = map_target.slice(..);
         let (tx, rx) = std::sync::mpsc::channel();
         slice.map_async(wgpu::MapMode::Read, move |r| {
@@ -1737,6 +1751,18 @@ impl WgpuBackend {
         rx.recv().unwrap().unwrap();
         let gpu_wait_ms = t_start.elapsed().as_secs_f32() * 1000.0 - cpu_setup_ms;
         let data = slice.get_mapped_range();
+        if let Some((_, width, height, row_bytes)) = native_pack.as_ref() {
+            let pixel_bytes = row_bytes * *height as usize;
+            let pixels = data[..pixel_bytes].to_vec();
+            let partials: &[f32] = bytemuck::cast_slice(&data[pixel_bytes..]);
+            let mean = partials.iter().map(|&value| f64::from(value)).sum::<f64>()
+                / (*width as f64 * *height as f64 * 3.0);
+            drop(data);
+            map_target.unmap();
+            return crate::FilmChainOutput::Native(crate::NativePackedSurface {
+                width: *width, height: *height, row_bytes: *row_bytes, pixels, mean,
+            });
+        }
         let out_f32: Vec<f32> = bytemuck::cast_slice(&data).to_vec();
         drop(data);
         map_target.unmap();
@@ -1751,7 +1777,65 @@ impl WgpuBackend {
             ),
             "film chain timings"
         );
-        out
+        crate::FilmChainOutput::Rgb(out)
+    }
+
+    fn encode_native_pack(&self, encoder: &mut wgpu::CommandEncoder,
+        rgb: &wgpu::Buffer, width: u32, height: u32, output: crate::NativeOutputSpec, mappable: bool,
+    ) -> (wgpu::Buffer, u32, u32, usize) {
+        use wgpu::util::DeviceExt;
+        let rotation = u32::from(output.quarters_ccw % 4);
+        let [crop_x, crop_y, crop_width, crop_height] = output.crop.unwrap_or([0, 0, width, height]);
+        assert!(crop_width > 0 && crop_height > 0 && crop_x + crop_width <= width
+            && crop_y + crop_height <= height, "native output crop exceeds input");
+        let (out_width, out_height) = if rotation % 2 == 0 { (crop_width, crop_height) } else { (crop_height, crop_width) };
+        let row_bytes = (out_width as usize * 4 + 255) & !255;
+        let groups = (width * height).div_ceil(256);
+        let size = (row_bytes * out_height as usize + groups as usize * 4) as u64;
+        let dispatch_height = groups.div_ceil(self.device.limits().max_compute_workgroups_per_dimension);
+        let dispatch_width = groups.div_ceil(dispatch_height);
+        let values = [width, height, (row_bytes / 4) as u32, rotation, crop_x, crop_y, crop_width, crop_height,
+            dispatch_width, 0, 0, 0];
+        let params = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("native_pack_params"), contents: bytemuck::cast_slice(&values),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+        let output = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("native_pack_rgba"), size,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC
+                | if mappable { wgpu::BufferUsages::MAP_READ } else { wgpu::BufferUsages::empty() },
+            mapped_at_creation: false,
+        });
+        let pipeline = self.cached_pipeline(
+            include_str!("../../spektrafilm-shaders/wgsl/native_pack.wgsl"),
+            &[wgpu::BufferBindingType::Uniform, wgpu::BufferBindingType::Storage { read_only: true },
+                wgpu::BufferBindingType::Storage { read_only: false }]);
+        let group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("native_pack"), layout: &pipeline.layout,
+            entries: &[
+                wgpu::BindGroupEntry { binding: 0, resource: params.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 1, resource: rgb.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 2, resource: output.as_entire_binding() },
+            ],
+        });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("native_pack"), timestamp_writes: None,
+            });
+            pass.set_pipeline(&pipeline.pipeline);
+            pass.set_bind_group(0, &group, &[]);
+            pass.dispatch_workgroups(dispatch_width, groups.div_ceil(dispatch_width), 1);
+        }
+        let mapped = if mappable { output } else {
+            let staging = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("native_pack_readback"), size,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            encoder.copy_buffer_to_buffer(&output, 0, &staging, 0, size);
+            staging
+        };
+        (mapped, out_width, out_height, row_bytes)
     }
 
     /// Get-or-compile a pipeline by shader source + binding layout. Cached by
@@ -2203,6 +2287,14 @@ impl ComputeBackend for WgpuBackend {
 
     fn try_run_film_chain(&self, params: &crate::FilmChainParams<'_>) -> Option<ImageBuf> {
         Some(self.run_film_chain(params))
+    }
+
+    fn try_run_film_chain_native(&self, params: &crate::FilmChainParams<'_>,
+        output: crate::NativeOutputSpec) -> Option<crate::NativePackedSurface> {
+        match self.run_film_chain_output(params, Some(output)) {
+            crate::FilmChainOutput::Native(surface) => Some(surface),
+            crate::FilmChainOutput::Rgb(_) => None,
+        }
     }
 
     fn resident_chain_applies_post_scan(&self) -> bool {
@@ -4645,6 +4737,7 @@ fn build_glare_state(
         base_seed: u32,
         mu: f32,
         sigma: f32,
+        pixel_geometry: [u32; 4],
     }
     let gen_params = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("glare_gen_params"),
@@ -4653,6 +4746,7 @@ fn build_glare_state(
             base_seed: gp.base_seed,
             mu: gp.mu,
             sigma: gp.sigma,
+            pixel_geometry: [width, gp.full_width, gp.pixel_origin[0], gp.pixel_origin[1]],
         }),
         usage: wgpu::BufferUsages::UNIFORM,
     });
@@ -5062,8 +5156,10 @@ fn build_grain_state(
         density_max: [f32; 4],
         n_particles_per_pixel: [f32; 4],
         grain_uniformity: [f32; 4],
+        pixel_geometry: [u32; 4],
     }
     let params = GrainParams {
+        pixel_geometry: [width, gp.full_width, gp.pixel_origin[0], gp.pixel_origin[1]],
         n_pixels: n_pixels as u32,
         base_seed: gp.base_seed,
         n_sub_layers: gp.n_sub_layers.max(1),
@@ -5283,4 +5379,42 @@ fn is_uniform(xs: &[f64]) -> bool {
         }
     }
     true
+}
+
+
+#[cfg(all(test, feature = "wgpu-backend"))]
+mod native_pack_tests {
+    use super::*;
+    use wgpu::util::DeviceExt;
+
+    #[test]
+    #[ignore = "requires a real GPU and a 17MP buffer; run explicitly outside the sandbox"]
+    fn native_pack_crosses_one_dimensional_dispatch_limit() {
+        let backend = WgpuBackend::new().expect("real WGPU device required");
+        // 65,568 workgroups: just beyond Metal's 65,535-per-axis limit.
+        let (width, height) = (8192_u32, 2049_u32);
+        let count = width as usize * height as usize;
+        let samples = vec![0.5_f32; count * 3];
+        let rgb = backend.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("large_native_pack_test"), contents: bytemuck::cast_slice(&samples),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+        let mut encoder = backend.device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let mappable = backend.device.features().contains(wgpu::Features::MAPPABLE_PRIMARY_BUFFERS);
+        let (packed, out_width, out_height, row) = backend.encode_native_pack(&mut encoder, &rgb,
+            width, height, crate::NativeOutputSpec::default(), mappable);
+        assert_eq!((out_width, out_height, row), (width, height, width as usize * 4));
+        backend.queue.submit(Some(encoder.finish()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        packed.slice(..).map_async(wgpu::MapMode::Read, move |result| { tx.send(result).unwrap(); });
+        backend.device.poll(wgpu::Maintain::Wait);
+        rx.recv().unwrap().unwrap();
+        let data = packed.slice(..).get_mapped_range();
+        let words: &[u32] = bytemuck::cast_slice(&data[..count * 4]);
+        assert!(words.iter().all(|&pixel| pixel == 0xff808080), "native pack lost or repeated pixels beyond first dispatch row");
+        let partials: &[f32] = bytemuck::cast_slice(&data[count * 4..]);
+        assert_eq!(partials.iter().map(|&n| n as f64).sum::<f64>() / (count as f64 * 3.0), 0.5);
+        drop(data);
+        packed.unmap();
+    }
 }

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/glare_gen.wgsl
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/glare_gen.wgsl
@@ -13,6 +13,7 @@ struct Params {
     base_seed: u32,
     mu: f32,
     sigma: f32,
+    pixel_geometry: vec4<u32>, // local width, full width, origin x/y
 }
 
 @group(0) @binding(0) var<uniform> params: Params;
@@ -39,7 +40,9 @@ fn splitmix32(x: u32) -> u32 {
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let idx = gid.x;
     if idx >= params.n_pixels { return; }
-    var rng = splitmix32(params.base_seed) ^ splitmix32(idx);
+    let geom = params.pixel_geometry;
+    let absolute_index = (geom.w + idx / geom.x) * geom.y + geom.z + idx % geom.x;
+    var rng = splitmix32(params.base_seed) ^ splitmix32(absolute_index);
     rng = pcg(rng);
     let u1 = unit_f32(rng);
     rng = pcg(rng);

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/grain.wgsl
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/grain.wgsl
@@ -23,6 +23,7 @@ struct Params {
     density_max: vec4<f32>,            // .xyz used (already includes density_min)
     n_particles_per_pixel: vec4<f32>,  // .xyz used (already divided by n_sub_layers)
     grain_uniformity: vec4<f32>,       // .xyz used
+    pixel_geometry: vec4<u32>, // local width, full width, origin x/y
 }
 
 @group(0) @binding(0) var<uniform> params: Params;
@@ -67,6 +68,8 @@ fn standard_normal(state: ptr<function, u32>) -> f32 {
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let idx = gid.x;
     if idx >= params.n_pixels { return; }
+    let geom = params.pixel_geometry;
+    let absolute_index = (geom.w + idx / geom.x) * geom.y + geom.z + idx % geom.x;
     let base = idx * 3u;
 
     let n_sl_f = f32(params.n_sub_layers);
@@ -98,7 +101,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                 seed_ch = 0u;
             }
             let layer_seed = seed_ch + u32(sl) * 10u + params.base_seed;
-            var rng = splitmix32(layer_seed) ^ splitmix32(idx);
+            var rng = splitmix32(layer_seed) ^ splitmix32(absolute_index);
 
             // Poisson(λ) via normal approximation: N(λ, √λ).
             let z1 = standard_normal(&rng);

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/native_pack.wgsl
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/native_pack.wgsl
@@ -1,0 +1,55 @@
+// Last display-only pass: rotation, ties-to-even RGBA8 packing and one
+// mean partial per workgroup. No full float frame returns to the CPU.
+struct Params {
+    width: u32, height: u32, row_words: u32, rotation: u32,
+    crop_x: u32, crop_y: u32, crop_width: u32, crop_height: u32,
+    dispatch_width: u32, _pad0: u32, _pad1: u32, _pad2: u32,
+}
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> rgb: array<f32>;
+@group(0) @binding(2) var<storage, read_write> packed: array<u32>;
+var<workgroup> sums: array<f32, 256>;
+fn byte(value: f32) -> u32 {
+    let scaled = clamp(value, 0.0, 1.0) * 255.0;
+    let lower = u32(floor(scaled));
+    let fraction = scaled - f32(lower);
+    return lower + select(0u, 1u, fraction > 0.5 || (fraction == 0.5 && (lower & 1u) != 0u));
+}
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>,
+        @builtin(local_invocation_id) lid: vec3<u32>,
+        @builtin(workgroup_id) group: vec3<u32>) {
+    let count = params.width * params.height;
+    let group_index = group.y * params.dispatch_width + group.x;
+    let index = group_index * 256u + lid.x;
+    var sum = 0.0;
+    let output_height = select(params.crop_height, params.crop_width, (params.rotation & 1u) != 0u);
+    if index < count {
+        let source_x = index % params.width;
+        let source_y = index / params.width;
+        if source_x >= params.crop_x && source_x < params.crop_x + params.crop_width &&
+            source_y >= params.crop_y && source_y < params.crop_y + params.crop_height {
+        let x = source_x - params.crop_x;
+        let y = source_y - params.crop_y;
+        let r = rgb[index * 3u];
+        let g = rgb[index * 3u + 1u];
+        let b = rgb[index * 3u + 2u];
+        var destination = vec2<u32>(x, y);
+        if params.rotation == 1u { destination = vec2<u32>(y, params.crop_width - 1u - x); }
+        if params.rotation == 2u { destination = vec2<u32>(params.crop_width - 1u - x, params.crop_height - 1u - y); }
+        if params.rotation == 3u { destination = vec2<u32>(params.crop_height - 1u - y, x); }
+        packed[destination.y * params.row_words + destination.x] =
+            byte(r) | (byte(g) << 8u) | (byte(b) << 16u) | 0xff000000u;
+        sum = r + g + b;
+        }
+    }
+    sums[lid.x] = sum;
+    workgroupBarrier();
+    for (var stride = 128u; stride > 0u; stride /= 2u) {
+        if lid.x < stride { sums[lid.x] += sums[lid.x + stride]; }
+        workgroupBarrier();
+    }
+    if lid.x == 0u && group_index < (count + 255u) / 256u {
+        packed[params.row_words * output_height + group_index] = bitcast<u32>(sums[0]);
+    }
+}

--- a/scripts/benchmark-raw-thumbnails.py
+++ b/scripts/benchmark-raw-thumbnails.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Compare ImageIO with rawpy embedded thumbnails on real RAW containers.
+
+Usage: python scripts/benchmark-raw-thumbnails.py photo.dng photo.raf ...
+Reports failures, dimensions, orientation, and warm medians separately. No
+renderer or live catalog is started, and originals are only read.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import color_pipeline
+import platform_image
+from PIL import Image
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sources", nargs="+", type=Path)
+    parser.add_argument("--repeats", type=int, default=5)
+    args = parser.parse_args()
+    if not 1 <= args.repeats <= 100:
+        parser.error("--repeats must be between 1 and 100")
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="lighttable-raw-thumb-") as directory:
+        for source in args.sources:
+            row = {"file": source.name}
+            for name in ("imageio", "rawpy"):
+                output = Path(directory) / f"{name}.jpg"
+                elapsed = []
+                try:
+                    for _ in range(args.repeats):
+                        start = time.perf_counter()
+                        if name == "imageio":
+                            platform_image._build_thumbnail_imageio(source, output)
+                        elif not color_pipeline.raw_embedded_thumbnail(source, output, 240, 80):
+                            raise ValueError("no embedded thumbnail")
+                        elapsed.append((time.perf_counter() - start) * 1000)
+                        with Image.open(output) as image:
+                            image.load()
+                            dimensions = image.size
+                            if max(dimensions) > 240:
+                                raise ValueError(f"unbounded dimensions: {dimensions}")
+                    row[name] = {"firstMs": round(elapsed[0], 2),
+                                 "medianMs": round(statistics.median(elapsed), 2),
+                                 "dimensions": dimensions}
+                except Exception as error:
+                    row[name] = {"error": str(error)}
+            rows.append(row)
+    print(json.dumps(rows, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark-rawpy-openmp.py
+++ b/scripts/benchmark-rawpy-openmp.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Verify RAW output identity across processes with 1 and 8 OpenMP threads.
+
+Pass real X-Trans and Bayer files. An optional stock-wheel interpreter adds
+baseline identity/timing. Each decode gets a fresh process, so OpenMP reads
+its thread limit before initialization. No original or catalog is modified.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+DECODE = r'''
+import hashlib, json, sys, time, rawpy
+from contextlib import ExitStack
+sys.path.insert(0, sys.argv[3])
+import raw_decode_runtime
+try:
+    import rawpy_openmp
+    available = rawpy_openmp.flags['OPENMP']
+except ImportError:
+    available = False
+t = time.perf_counter()
+with ExitStack() as stack:
+    if sys.argv[2] == 'stock':
+        decoder = rawpy
+        raw = stack.enter_context(rawpy.imread(sys.argv[1]))
+    else:
+        raw, decoder = stack.enter_context(raw_decode_runtime.open_raw(sys.argv[1]))
+    opened = time.perf_counter()
+    rgb = raw.postprocess(use_camera_wb=True, gamma=(1,1), no_auto_bright=True,
+        output_bps=16, output_color=decoder.ColorSpace.ProPhoto,
+        highlight_mode=decoder.HighlightMode.ReconstructDefault)
+done = time.perf_counter()
+print(json.dumps({'openmp':decoder.flags['OPENMP'], 'available':available,
+    'decoder':decoder.__name__, 'shape':rgb.shape,
+    'openMs':round((opened-t)*1000,2), 'processMs':round((done-opened)*1000,2),
+    'sha256':hashlib.sha256(rgb).hexdigest()}))
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sources", type=Path, nargs="+")
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--baseline-python")
+    parser.add_argument("--repeats", type=int, default=2)
+    args = parser.parse_args()
+    if not 1 <= args.repeats <= 10:
+        parser.error("--repeats must be 1 to 10")
+    rows = []
+    for source in args.sources:
+        row = {"file": source.name, "runs": []}
+        configurations = [("openmp", args.python, t) for t in (1, 8)]
+        if args.baseline_python:
+            configurations.insert(0, ("stock", args.baseline_python, 1))
+        for label, python, threads in configurations:
+            for _ in range(args.repeats):
+                env = dict(os.environ, OMP_NUM_THREADS=str(threads), OMP_DYNAMIC="FALSE")
+                # Explicit interpreters must not inherit a site-packages overlay.
+                env.pop("PYTHONPATH", None)
+                result = subprocess.run([python, "-c", DECODE, str(source.resolve()),
+                                         label, str(Path(__file__).resolve().parents[1])],
+                                        env=env, check=True, text=True,
+                                        capture_output=True, timeout=180)
+                run = json.loads(result.stdout)
+                if label == "openmp" and not run["available"]:
+                    raise SystemExit("Candidate rawpy does not support OpenMP")
+                row["runs"].append(dict(run, runtime=label, threads=threads))
+        row["byteIdentical"] = len({(tuple(r["shape"]), r["sha256"])
+                                      for r in row["runs"]}) == 1
+        rows.append(row)
+    print(json.dumps(rows, indent=2), flush=True)
+    if not all(row["byteIdentical"] for row in rows):
+        raise SystemExit("RAW output changed across thread counts or runtimes")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build-rawpy-native.sh
+++ b/scripts/build-rawpy-native.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Pinned source builds: Homebrew bottles can require a newer OS than our app.
+set -euo pipefail
+WORK="$1"
+PREFIX="$2"
+mkdir -p "$WORK" "$PREFIX" "$PREFIX/licenses"
+fetch() {
+  local NAME="$1" URL="$2" SHA="$3"
+  curl --fail --location --silent --show-error --retry 3 "$URL" -o "$WORK/$NAME.tar"
+  echo "$SHA  $WORK/$NAME.tar" | shasum -a 256 --check --status
+  mkdir -p "$WORK/$NAME"
+  tar -xf "$WORK/$NAME.tar" -C "$WORK/$NAME" --strip-components=1
+}
+fetch openmp https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/openmp-19.1.7.src.tar.xz bd7e6901ab086fd268750363017935fd4a717c153dad3c2aab86cb0140d9e3fe
+fetch cmake https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/cmake-19.1.7.src.tar.xz 11c5a28f90053b0c43d0dec3d0ad579347fc277199c005206b963c19aae514e3
+fetch jpeg https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.2.0/libjpeg-turbo-3.2.0.tar.gz 6f30092cef9fb839779646608f4ee14ae3cbac989c47fa05e841b0841f09878e
+fetch jasper https://github.com/jasper-software/jasper/releases/download/version-4.2.8/jasper-4.2.8.tar.gz 98058a94fbff57ec6e31dcaec37290589de0ba6f47c966f92654681a56c71fae
+fetch lcms https://downloads.sourceforge.net/project/lcms/lcms/2.19.1/lcms2-2.19.1.tar.gz bfc54f7bab59fbc921012014a8032e4cba4abd46db47d46b76416a8c0b2815c8
+build() {
+  local NAME="$1"
+  shift
+  cmake -S "$WORK/$NAME" -B "$WORK/$NAME-build" \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_INSTALL_NAME_DIR="$PREFIX/lib" \
+    -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_IGNORE_PREFIX_PATH=/opt/homebrew \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "$@"
+  cmake --build "$WORK/$NAME-build" --target install --parallel 8
+}
+build openmp -DOPENMP_ENABLE_LIBOMPTARGET=OFF -DOPENMP_ENABLE_OMPT_TOOLS=OFF \
+  -DLIBOMP_ENABLE_SHARED=ON
+build jpeg -DENABLE_STATIC=OFF -DWITH_JPEG8=ON -DWITH_TURBOJPEG=OFF
+build jasper -DJAS_ENABLE_PROGRAMS=OFF -DJAS_ENABLE_DOC=OFF \
+  -DJAS_ENABLE_OPENGL=OFF -DJAS_ENABLE_LIBHEIF=OFF \
+  -DJPEG_INCLUDE_DIR="$PREFIX/include" -DJPEG_LIBRARY_RELEASE="$PREFIX/lib/libjpeg.dylib"
+(
+  cd "$WORK/lcms"
+  CC=clang CPPFLAGS= lt_cv_sys_max_cmd_len=262144 \
+    CFLAGS="-O3 -mmacosx-version-min=13.0" LDFLAGS="-mmacosx-version-min=13.0" \
+    ./configure --prefix="$PREFIX" --disable-static --without-jpeg --without-tiff
+  make -j8
+  make install
+)
+cp "$WORK/openmp/LICENSE.TXT" "$PREFIX/licenses/LLVM-OpenMP.txt"
+cp "$WORK/jpeg/README.ijg" "$PREFIX/licenses/libjpeg.txt"
+cp "$WORK/jpeg/LICENSE.md" "$PREFIX/licenses/libjpeg-turbo.txt"
+cp "$WORK/jasper/LICENSE.txt" "$PREFIX/licenses/jasper.txt"
+cp "$WORK/lcms/LICENSE" "$PREFIX/licenses/lcms2.txt"

--- a/scripts/build-rawpy-openmp.sh
+++ b/scripts/build-rawpy-openmp.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Build a relocatable macOS wheel, including LibRaw and its OpenMP runtime.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+if [[ $# != 2 || "$(uname -m)" != arm64 || "$(uname -s)" != Darwin ]]; then
+  echo "usage: $0 /path/to/python /path/to/wheel-output (macOS arm64)" >&2
+  exit 2
+fi
+PYTHON="$1"
+OUTPUT="$2"
+RAWPY_REV=a411daac7d5bf1ab07f6285164e41596a205393e
+# Submodule commits are recorded by RAWPY_REV, rather than moving branches.
+LIBRAW_REV=0b56545a4f828743f28a4345cdfdd4c49f9f9a2a
+CMAKE_REV=6e26c9e73677dc04f9eb236a97c6a4dc225ba7e8
+for TOOL in git cmake pkg-config uv; do
+  command -v "$TOOL" >/dev/null
+done
+mkdir -p "$OUTPUT"
+OUTPUT="$(cd "$OUTPUT" && pwd)"
+# rawpy's upstream setup script contains unquoted shell paths. Keep its
+# disposable checkout out of user/workspace paths which can contain spaces.
+WORK="$(mktemp -d /tmp/lighttable-rawpy.XXXXXX)"
+trap '/bin/rm -rf "$WORK"' EXIT
+PREFIX="$WORK/native"
+export MACOSX_DEPLOYMENT_TARGET=13.0
+"$ROOT/scripts/build-rawpy-native.sh" "$WORK/native-source" "$PREFIX"
+git clone --filter=blob:none --no-checkout https://github.com/letmaik/rawpy.git "$WORK/source"
+git -C "$WORK/source" checkout --detach "$RAWPY_REV"
+git -C "$WORK/source" submodule update --init --depth 1 external/LibRaw external/LibRaw-cmake
+test "$(git -C "$WORK/source/external/LibRaw" rev-parse HEAD)" = "$LIBRAW_REV"
+test "$(git -C "$WORK/source/external/LibRaw-cmake" rev-parse HEAD)" = "$CMAKE_REV"
+git -C "$WORK/source/external/LibRaw" apply "$ROOT/packaging/libraw-xtrans-determinism.patch"
+"$PYTHON" - "$WORK/source" <<'PY'
+from pathlib import Path
+import sys
+root = Path(sys.argv[1])
+# Keep the upstream stock wheel alongside this extension. Separate Python
+# package and Mach-O loader paths prevent one decoder replacing the other.
+package = root / 'rawpy'
+source = package / '_rawpy.pyx'
+text = source.read_text()
+needle = '    property raw_type:\n'
+assert text.count(needle) == 1
+text = text.replace(needle, '''    property is_xtrans:
+        def __get__(self):
+            return self.p.imgdata.idata.filters == 9
+
+''' + needle)
+source.write_text(text)
+for path in [root/'setup.py', package/'__init__.py', package/'enhance.py']:
+    text = path.read_text().replace('rawpy', 'rawpy_openmp')
+    text = text.replace('_rawpy_openmp', '_rawpy')
+    path.write_text(text.replace('github.com/letmaik/rawpy_openmp',
+                                 'github.com/letmaik/rawpy'))
+package.rename(root/'rawpy_openmp')
+PY
+
+uv venv --python "$PYTHON" "$WORK/env"
+uv pip sync --python "$WORK/env/bin/python" "$ROOT/packaging/rawpy-build.lock"
+cmake -S "$WORK/source/external/LibRaw-cmake" -B "$WORK/libraw-build" \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON \
+  -DLIBRAW_PATH="$WORK/source/external/LibRaw" \
+  -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+  -DCMAKE_INSTALL_PREFIX="$WORK/install" \
+  -DCMAKE_INSTALL_NAME_DIR="$WORK/install/lib" \
+  -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_IGNORE_PREFIX_PATH=/opt/homebrew \
+  -DLCMS2_INCLUDE_DIR="$PREFIX/include" -DLCMS2_LIBRARIES="$PREFIX/lib/liblcms2.dylib" \
+  -DJPEG_INCLUDE_DIR="$PREFIX/include" -DJPEG_LIBRARY_RELEASE="$PREFIX/lib/libjpeg.dylib" \
+  -DJASPER_INCLUDE_DIR="$PREFIX/include" \
+  -DJASPER_LIBRARY_RELEASE="$PREFIX/lib/libjasper.dylib" \
+  -DENABLE_OPENMP=ON \
+  "-DOpenMP_CXX_FLAGS=-Xpreprocessor -fopenmp -I$PREFIX/include" \
+  -DOpenMP_CXX_LIB_NAMES=omp \
+  -DOpenMP_omp_LIBRARY="$PREFIX/lib/libomp.dylib" \
+  -DENABLE_EXAMPLES=OFF -DENABLE_X3FTOOLS=ON -DENABLE_6BY9RPI=ON \
+  -DENABLE_RAWSPEED=OFF
+cmake --build "$WORK/libraw-build" --target install --parallel 8
+/usr/bin/grep -q '#define LIBRAW_USE_OPENMP 1' "$WORK/install/include/libraw/libraw_config.h"
+(
+  cd "$WORK/source"
+  RAWPY_USE_SYSTEM_LIBRAW=1 PKG_CONFIG_PATH="$WORK/install/lib/pkgconfig" \
+    CFLAGS="-I$PREFIX/include" CXXFLAGS="-I$PREFIX/include" \
+    "$WORK/env/bin/python" setup.py bdist_wheel --dist-dir "$WORK/wheels"
+)
+"$WORK/env/bin/delocate-wheel" --require-archs arm64 \
+  --wheel-dir "$OUTPUT" "$WORK"/wheels/*.whl
+uv pip install --python "$WORK/env/bin/python" --reinstall --no-deps \
+  rawpy==0.26.1 "$OUTPUT"/rawpy_openmp-0.26.1-*.whl
+"$WORK/env/bin/python" "$ROOT/scripts/verify-rawpy-openmp.py"
+mkdir -p "$OUTPUT/licenses"
+cp "$WORK/source/LICENSE" "$OUTPUT/licenses/rawpy-MIT.txt"
+cp "$WORK/source/external/LibRaw/LICENSE.LGPL" "$OUTPUT/licenses/LibRaw-LGPL-2.1.txt"
+cp "$PREFIX/licenses/"* "$OUTPUT/licenses/"
+echo "OpenMP-enabled rawpy wheel: $OUTPUT"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -193,6 +193,15 @@ fi
 uv pip sync --no-config --compile-bytecode --system --break-system-packages \
   --python "$APP/Contents/Resources/Python/bin/python3.13" \
   "$ROOT/requirements-runtime.lock"
+RAWPY_WHEELS="$BUILD_ROOT/rawpy-openmp"
+"$ROOT/scripts/build-rawpy-openmp.sh" \
+  "$APP/Contents/Resources/Python/bin/python3.13" "$RAWPY_WHEELS"
+uv pip install --no-config --system --break-system-packages --no-deps --reinstall \
+  --python "$APP/Contents/Resources/Python/bin/python3.13" \
+  "$RAWPY_WHEELS"/rawpy_openmp-0.26.1-*.whl
+"$APP/Contents/Resources/Python/bin/python3.13" \
+  "$ROOT/scripts/verify-rawpy-openmp.py"
+/usr/bin/ditto "$RAWPY_WHEELS/licenses" "$PAYLOAD/licenses/rawpy-openmp"
 "$APP/Contents/Resources/Python/bin/python3.13" \
   "$ROOT/scripts/relocate-python-runtime.py" \
   "$APP/Contents/Resources/Python"

--- a/scripts/help_content.py
+++ b/scripts/help_content.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Validate, review, and bundle source-linked help using only the stdlib.
+
+Each article carries real source anchors. Per-article source and content hashes
+record the version reviewed by a maintainer; this is a drift alarm, not a claim
+that hashing can prove prose correct. See docs/help/README.md.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+CATEGORIES = ('Getting started', 'Library', 'Editing', 'Film', 'Export',
+              'Settings', 'Troubleshooting')
+LOCK = 'docs/help/review-lock.json'
+BUNDLE = 'web/help-content.json'
+
+
+class HelpError(ValueError):
+    pass
+
+
+def digest(value):
+    if not isinstance(value, bytes):
+        value = json.dumps(value, sort_keys=True, ensure_ascii=False).encode()
+    return hashlib.sha256(value).hexdigest()
+
+
+def read_json(path):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError) as error:
+        raise HelpError(f'{path.name}: {error}') from error
+
+
+def require_text(value, where):
+    if not isinstance(value, str) or not value.strip():
+        raise HelpError(f'{where}: expected nonempty text')
+
+
+def text_list(value, where, nonempty=False):
+    if not isinstance(value, list) or (nonempty and not value):
+        raise HelpError(f'{where}: expected a list of text')
+    for item in value:
+        require_text(item, where)
+
+
+def load_articles(root=ROOT):
+    articles = []
+    for path in sorted((root / 'docs/help').glob('*.json')):
+        if path.name == 'review-lock.json':
+            continue
+        content = read_json(path)
+        if not isinstance(content, list):
+            raise HelpError(f'{path.name}: expected an article array')
+        articles.extend(content)
+    if not articles:
+        raise HelpError('No help articles found')
+    ids = set()
+    for article in articles:
+        if not isinstance(article, dict):
+            raise HelpError('Each article must be an object')
+        aid = article.get('id', '')
+        if not isinstance(aid, str) or not re.fullmatch(r'[a-z0-9]+(?:-[a-z0-9]+)*', aid):
+            raise HelpError(f'Invalid article ID: {aid!r}')
+        if aid in ids:
+            raise HelpError(f'Duplicate article ID: {aid}')
+        ids.add(aid)
+        for key in ('title', 'summary'):
+            require_text(article.get(key), f'{aid}.{key}')
+        if article.get('category') not in CATEGORIES:
+            raise HelpError(f'{aid}: unknown category')
+        text_list(article.get('keywords'), f'{aid}.keywords', nonempty=True)
+        text_list(article.get('related', []), f'{aid}.related')
+        if not isinstance(article.get('sections'), list) or not article['sections']:
+            raise HelpError(f'{aid}: needs sections')
+        for section in article['sections']:
+            if not isinstance(section, dict):
+                raise HelpError(f'{aid}: invalid section')
+            require_text(section.get('title'), f'{aid}.section.title')
+            for key in ('paragraphs', 'steps', 'tips'):
+                text_list(section.get(key, []), f'{aid}.section.{key}')
+            section.setdefault('paragraphs', [])
+            if not any(section.get(key) for key in ('paragraphs', 'steps', 'tips')):
+                raise HelpError(f'{aid}: empty section')
+        if not isinstance(article.get('sources'), list) or not article['sources']:
+            raise HelpError(f'{aid}: needs source evidence')
+        for source in article['sources']:
+            if not isinstance(source, dict):
+                raise HelpError(f'{aid}: invalid source')
+            relative = source.get('path')
+            require_text(relative, f'{aid}.source.path')
+            path = (root / relative).resolve()
+            if Path(relative).is_absolute() or '..' in Path(relative).parts or not path.is_relative_to(root.resolve()):
+                raise HelpError(f'{aid}: source must stay inside repository: {relative}')
+            if not path.is_file() or relative.startswith('docs/help/') or relative == BUNDLE:
+                raise HelpError(f'{aid}: missing implementation source: {relative}')
+            require_text(source.get('anchor'), f'{aid}.source.anchor')
+            if source['anchor'] not in path.read_text():
+                raise HelpError(f'{aid}: source anchor no longer exists in {relative}: {source["anchor"]!r}')
+    for article in articles:
+        for related in article.get('related', []):
+            if related not in ids or related == article['id']:
+                raise HelpError(f'{article["id"]}: invalid related article {related}')
+    return sorted(articles, key=lambda item: (CATEGORIES.index(item['category']), item['title']))
+
+
+def current_records(articles, root=ROOT):
+    source_hashes = {}
+    for article in articles:
+        for source in article['sources']:
+            path = source['path']
+            if path not in source_hashes:
+                source_hashes[path] = digest((root / path).read_bytes())
+    return {article['id']: {
+        'content': digest(article),
+        'sources': {source['path']: source_hashes[source['path']] for source in article['sources']},
+    } for article in articles}
+
+
+def read_lock(root=ROOT):
+    path = root / LOCK
+    if not path.exists():
+        return {}
+    lock = read_json(path)
+    if not isinstance(lock, dict) or lock.get('version') != 1 or not isinstance(lock.get('articles'), dict):
+        raise HelpError('Invalid help review lock')
+    return lock['articles']
+
+
+def drift(current, reviewed):
+    issues = {}
+    for aid, record in current.items():
+        prior = reviewed.get(aid)
+        if not isinstance(prior, dict):
+            issues[aid] = ['new article; review required']
+            continue
+        reasons = []
+        if record['content'] != prior.get('content'):
+            reasons.append('article content or source links changed')
+        old_sources = prior.get('sources', {})
+        for path, source_hash in record['sources'].items():
+            if source_hash != old_sources.get(path):
+                reasons.append(f'source changed: {path}')
+        if reasons:
+            issues[aid] = reasons
+    for aid in reviewed.keys() - current.keys():
+        issues[aid] = ['article removed; rebuild the review lock']
+    return issues
+
+
+def bundle_text(articles):
+    # Evidence belongs in the authoring system, not the reader's instructions.
+    public = [{key: article[key] for key in
+               ('id', 'title', 'category', 'summary', 'keywords', 'sections', 'related') if key in article}
+              for article in articles]
+    return json.dumps({'version': 1, 'articles': public}, ensure_ascii=False, indent=2) + '\n'
+
+
+def write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + '\n')
+
+
+def run(argv=None, root=ROOT):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=('check', 'status', 'build', 'review'))
+    parser.add_argument('articles', nargs='*', help='Reviewed article IDs (review only)')
+    parser.add_argument('--all', action='store_true', help='Acknowledge review of every article')
+    args = parser.parse_args(argv)
+    if args.command != 'review' and (args.articles or args.all):
+        parser.error('Article IDs and --all are valid only with review')
+    try:
+        articles = load_articles(root)
+        current = current_records(articles, root)
+        reviewed = read_lock(root)
+        if args.command == 'review':
+            if not args.all and not args.articles:
+                raise HelpError('Name the articles you reviewed, or use --all after reviewing all content')
+            selected = set(current) if args.all else set(args.articles)
+            unknown = selected - set(current) - set(reviewed)
+            if unknown:
+                raise HelpError(f'Unknown article IDs: {", ".join(sorted(unknown))}')
+            for aid in selected:
+                if aid in current:
+                    reviewed[aid] = current[aid]
+                else:
+                    reviewed.pop(aid, None)
+            if args.all:
+                reviewed = current
+            write_json(root / LOCK, {'version': 1, 'articles': reviewed})
+            print(f'Recorded review of {len(selected)} articles. Run build to refresh the bundled help.')
+            return 0
+        issues = drift(current, reviewed)
+        if issues:
+            for aid, reasons in sorted(issues.items()):
+                print(f'{aid}: {"; ".join(reasons)}')
+            print('Review these articles against the changed code, then acknowledge their IDs with the review command.')
+            return 1
+        expected = bundle_text(articles)
+        target = root / BUNDLE
+        if args.command == 'build':
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(expected)
+        elif args.command == 'check' and (not target.exists() or target.read_text() != expected):
+            raise HelpError('Bundled help is stale. Run python3 scripts/help_content.py build')
+        print(f'Help {args.command}: {len(articles)} articles, source anchors and reviewed versions current.')
+        return 0
+    except (HelpError, OSError, UnicodeError) as error:
+        print(f'Help check failed: {error}', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(run())

--- a/scripts/native-app-smoke.py
+++ b/scripts/native-app-smoke.py
@@ -45,6 +45,8 @@ REQUIRED_PR_STEPS = {
     "compare-on",
     "compare-off",
     "zoom-actual",
+    "viewport-pan",
+    "viewport-film-slider",
     "zoom-fit",
     "export-photo",
     "visibility-controls-on",

--- a/scripts/update-personal-app.sh
+++ b/scripts/update-personal-app.sh
@@ -129,6 +129,13 @@ if [[ "$ACTUAL_PYTHON_VERSION" != "$PYTHON_VERSION" ]]; then
   exit 1
 fi
 
+# The version pin alone cannot distinguish the stock single-threaded wheel
+# from our bundled OpenMP build. Upgrade old base apps with a full release.
+if ! PYTHONDONTWRITEBYTECODE=1 "$BASE_PYTHON" "$ROOT/scripts/verify-rawpy-openmp.py"; then
+  echo "The bundled RAW runtime changed; run scripts/build-release.sh before the quick updater" >&2
+  exit 1
+fi
+
 TEMP_CHECK="$(mktemp -d "${TMPDIR:-/tmp}/lighttable-personal-check.XXXXXX")"
 cleanup_check() {
   /bin/rm -rf "$TEMP_CHECK"
@@ -143,7 +150,7 @@ PYTHONDONTWRITEBYTECODE=1 "$BASE_PYTHON" -c \
   'import importlib.metadata as m
 for d in sorted(m.distributions(), key=lambda item: item.metadata["Name"].lower()):
     name = d.metadata["Name"].lower().replace("_", "-")
-    if name != "pip":
+    if name not in ("pip", "rawpy-openmp"):
         print(f"{name}=={d.version}")' \
   | LC_ALL=C /usr/bin/sort > "$TEMP_CHECK/actual-packages.txt"
 if ! /usr/bin/diff -u "$TEMP_CHECK/expected-packages.txt" \

--- a/scripts/verify-rawpy-openmp.py
+++ b/scripts/verify-rawpy-openmp.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Fail packaging if OpenMP is missing or a dylib still needs the build host."""
+from pathlib import Path
+import re
+import subprocess
+import rawpy
+import rawpy_openmp
+
+assert rawpy.__version__ == "0.26.1", rawpy.__version__
+assert rawpy_openmp.__version__ == "0.26.1", rawpy_openmp.__version__
+assert rawpy_openmp.flags.get("OPENMP"), rawpy_openmp.flags
+assert hasattr(rawpy_openmp.RawPy, "is_xtrans"), "missing header-only sensor dispatch"
+package = Path(rawpy_openmp.__file__).resolve().parent
+libraries = list(package.rglob("*.dylib")) + list(package.glob("*.so"))
+assert any("libomp" in p.name for p in libraries), "OpenMP runtime not bundled"
+for path in libraries:
+    links = subprocess.check_output(["otool", "-L", str(path)], text=True)
+    # Delocate uses /DLC/... for a dylib's own LC_ID_DYLIB. It is an
+    # identifier, not a dependency; consumers use @loader_path references.
+    ids = subprocess.check_output(["otool", "-D", str(path)], text=True).splitlines()[1:]
+    for line in links.splitlines()[1:]:
+        dependency = line.strip().split(" (", 1)[0]
+        if dependency in ids:
+            continue
+        assert dependency.startswith(("@loader_path/", "@rpath/", "/usr/lib/",
+                                      "/System/Library/")), (path.name, dependency)
+        if dependency.startswith("@loader_path/"):
+            target = (path.parent / dependency.removeprefix("@loader_path/")).resolve()
+            assert target.is_relative_to(package) and target.is_file(), (path.name, dependency)
+    commands = subprocess.check_output(["otool", "-l", str(path)], text=True)
+    minimum = re.search(r"\bminos (\d+)\.(\d+)", commands)
+    if minimum is None:
+        minimum = re.search(r"LC_VERSION_MIN_MACOSX\s+cmdsize \d+\s+version (\d+)\.(\d+)", commands)
+    assert minimum is not None, (path.name, "missing macOS deployment target")
+    assert tuple(map(int, minimum.groups())) <= (13, 0), (path.name, minimum.group(0))
+print(f"rawpy {rawpy.__version__} retained; LibRaw {rawpy_openmp.libraw_version}, OpenMP bundled")

--- a/scripts/windows/build-release.ps1
+++ b/scripts/windows/build-release.ps1
@@ -114,6 +114,8 @@ try {
         "soft_proof.py",
         "catalog.py",
         "catalog_scan.py",
+        "thumbnail_warmup.py",
+        "raw_decode_runtime.py",
         "catalog_import.py",
         "xmp_sidecar.py",
         "durable_io.py",

--- a/scripts/windows/lighttable.cmd
+++ b/scripts/windows/lighttable.cmd
@@ -6,5 +6,10 @@ if not exist "%LIGHTTABLE_BUNDLE%Python\python.exe" (
   echo LightTable's bundled Python runtime was not found. Reinstall LightTable. 1>&2
   exit /b 1
 )
-"%LIGHTTABLE_BUNDLE%Python\python.exe" -B -m lighttable_cli %*
+rem The embedded runtime ignores PYTHON* variables, so the bytecode cache is
+rem an interpreter option. It shares the desktop app's cache folder and keeps
+rem the installation directory untouched for a clean uninstall.
+set "LIGHTTABLE_BYTECODE=%LOCALAPPDATA%\LightTable\python-bytecode"
+if not defined LOCALAPPDATA set "LIGHTTABLE_BYTECODE=%TEMP%\LightTable\python-bytecode"
+"%LIGHTTABLE_BUNDLE%Python\python.exe" -X "pycache_prefix=%LIGHTTABLE_BYTECODE%" -m lighttable_cli %*
 exit /b %errorlevel%

--- a/server.py
+++ b/server.py
@@ -136,6 +136,18 @@ WINDOWS_RESERVED_NAMES = {
 }
 
 
+def subprocess_flags() -> dict:
+    """Keyword arguments that keep helper processes off the desktop on Windows.
+
+    The desktop shell starts the server without a console. A console-subsystem
+    child such as the resident engine, the one-shot exporter, or a render
+    worker would otherwise open a visible command window for its lifetime.
+    """
+    if not IS_WINDOWS:
+        return {}
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)}
+
+
 def is_raw(name: str) -> bool:
     return Path(library_workflow.source_name(name)).suffix.lower() in RAW_EXTS
 
@@ -1976,6 +1988,25 @@ INPUT_CACHE_VERSION = 4  # learned denoise joins capture-stage RAW development
 RAW_PREVIEW_CACHE_VERSION = 4  # width-aware half-size accurate demosaic
 RAW_SHARED_MAGIC = b"LTRI"
 RAW_SHARED_HEADER = struct.Struct("<4sIII")
+_SHARED_INPUT_UNAVAILABLE = "shared RAW input is unavailable"
+_SHARED_INPUT_DISABLED = threading.Event()
+
+
+def shared_input_supported() -> bool:
+    """Whether decoded pixels can reach the resident engine through memory.
+
+    POSIX shared memory and Windows named file mappings are both read by the
+    bundled engine. An engine built without that reader reports the exchange
+    as unavailable; remember the answer so later renders go straight to the
+    TIFF route instead of restarting the engine on every request.
+    """
+    return os.name in ("posix", "nt") and not _SHARED_INPUT_DISABLED.is_set()
+
+
+def note_shared_input_failure(error: BaseException) -> None:
+    """Latch off the memory exchange when the engine itself cannot read it."""
+    if _SHARED_INPUT_UNAVAILABLE in str(error):
+        _SHARED_INPUT_DISABLED.set()
 
 
 @contextmanager
@@ -2012,11 +2043,12 @@ def raw_shared_input(name: str, params: dict | None = None, *,
                      denoise_status=None, denoise_cancel=None):
     """Expose one decoded RAW to the resident renderer without a TIFF hop.
 
-    ``multiprocessing.shared_memory`` maps the same anonymous POSIX object into
-    Python and Rust.  The renderer copies the pixels into its resident input
-    cache before replying, so the segment can be unlinked immediately after
-    the request.  This keeps the large full-resolution exchange in memory and
-    leaves ``tiff_for`` as the portable/failure fallback.
+    ``multiprocessing.shared_memory`` maps the same anonymous POSIX object, or
+    on Windows the same named file mapping, into Python and Rust.  The renderer
+    copies the pixels into its resident input cache before replying, so the
+    segment can be released immediately after the request.  This keeps the
+    large full-resolution exchange in memory and leaves ``tiff_for`` as the
+    failure fallback.
     """
     rgb = np.ascontiguousarray(color_pipeline.decode_raw(
         src_path(name), params, learned_denoise_status=denoise_status,
@@ -2812,11 +2844,25 @@ def _digest_file(path: Path | None) -> str | None:
     return digest.hexdigest()
 
 
+def _inside_git_checkout(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    return any((candidate / ".git").exists()
+               for candidate in (resolved, *resolved.parents))
+
+
 def _git_revision(path: Path) -> str | None:
+    # An installed bundle sits in no repository. Two guaranteed-miss git
+    # launches at import time were a visible startup cost on Windows.
+    if not _inside_git_checkout(path):
+        return None
     try:
         return subprocess.run(
             ["git", "-C", str(path), "rev-parse", "HEAD"],
             check=True, capture_output=True, text=True, timeout=5,
+            **subprocess_flags(),
         ).stdout.strip()
     except (OSError, subprocess.SubprocessError):
         return None
@@ -2883,7 +2929,8 @@ class RustEngineClient:
             return self.process
         self.process = subprocess.Popen(
             [str(self.binary)], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL, text=True, bufsize=1)
+            stderr=subprocess.DEVNULL, text=True, bufsize=1,
+            **subprocess_flags())
         if IS_WINDOWS:
             assert self.process.stdout
             self.reader = PipeLineReader(self.process.stdout)
@@ -3020,7 +3067,7 @@ def render_rust(name: str, params: dict, width: int,
             request["input"] = str(src_tif)
             return RUST_ENGINE.render(request)
 
-        if os.name == "posix":
+        if shared_input_supported():
             try:
                 arr = linear_for(name, width, params)
                 rgb16 = np.ascontiguousarray((np.clip(arr, 0, 1) * 65535 + 0.5).astype(np.uint16))
@@ -3030,7 +3077,8 @@ def render_rust(name: str, params: dict, width: int,
                     return RUST_ENGINE.render(request)
             except RenderCancelled:
                 raise
-            except Exception:
+            except Exception as shared_error:  # noqa: BLE001
+                note_shared_input_failure(shared_error)
                 for key in ("input_shm", "input_shm_len", "input_cache_key"):
                     request.pop(key, None)
 
@@ -3061,7 +3109,8 @@ def render_rust(name: str, params: dict, width: int,
         cmd += ["--paper", cp["paper"]]
     else:
         cmd += ["--scan-film"]
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=300,
+                       **subprocess_flags())
     if r.returncode != 0 or not out_png.exists():
         raise RuntimeError((r.stderr or r.stdout).strip()[-400:])
     img = np.asarray(Image.open(out_png).convert("RGB"))
@@ -3730,7 +3779,7 @@ def rust_direct_export_supported(job: dict) -> bool:
 def _resident_render_full(name: str, params: dict, request: dict) -> dict:
     """Render a full-resolution source using shared RAW pixels when possible."""
     request = dict(request)
-    if is_raw(name) and os.name == "posix":
+    if is_raw(name) and shared_input_supported():
         try:
             with raw_shared_input(name, params) as shared:
                 request.update(shared)
@@ -3741,9 +3790,10 @@ def _resident_render_full(name: str, params: dict, request: dict) -> dict:
         except RenderCancelled:
             raise
         except Exception as shared_error:  # noqa: BLE001
-            # A platform may expose POSIX shared memory yet cap a segment below
-            # a large sensor frame. Retain the proven TIFF route rather than
+            # A platform may expose shared memory yet cap a segment below a
+            # large sensor frame. Retain the proven TIFF route rather than
             # making export brittle.
+            note_shared_input_failure(shared_error)
             for key in ("input_shm", "input_shm_len", "input_cache_key"):
                 request.pop(key, None)
             source = tiff_for(name, params)
@@ -3864,7 +3914,7 @@ def _render_external_job(name: str, destination: Path, job: dict) -> None:
                  str(staged), str(job_file)],
                 capture_output=True, text=True,
                 env=dict(os.environ, OMP_NUM_THREADS="4", NUMBA_NUM_THREADS="4"),
-                timeout=1800, check=False)
+                timeout=1800, check=False, **subprocess_flags())
             if completed.returncode:
                 raise RuntimeError((completed.stderr or completed.stdout)[-300:])
             for line in reversed((completed.stdout or "").splitlines()):
@@ -4100,10 +4150,11 @@ class ExportBatch:
 
 def _run_export_process(command, env, batch):
     if batch is None:
-        return subprocess.run(command, capture_output=True, text=True, env=env, timeout=1800)
+        return subprocess.run(command, capture_output=True, text=True, env=env, timeout=1800,
+                              **subprocess_flags())
     batch.check()
     with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                          text=True, env=env) as process:
+                          text=True, env=env, **subprocess_flags()) as process:
         try:
             for _ in range(12000):
                 batch.check()

--- a/server.py
+++ b/server.py
@@ -7524,6 +7524,7 @@ def start_catalog_import(body: dict) -> dict:
                 operation = catalog_import.preview_import if body.get("previewOnly") else catalog_import.import_catalog
                 result = operation(cat, path, options=body.get("options") or {},
                     progress=progress, root_map=body.get("rootMap") or None,
+                    **({"add_sources": body.get("addSources") is True} if not body.get("previewOnly") else {}),
                     report_photo=lambda row: output.write(json.dumps(row) + "\n"))
                 output.flush()
                 os.fsync(output.fileno())

--- a/server.py
+++ b/server.py
@@ -59,6 +59,7 @@ import watch_workflow  # noqa: E402
 import media_formats  # noqa: E402
 import media_availability  # noqa: E402
 import durable_io  # noqa: E402
+import thumbnail_warmup  # noqa: E402
 import recovery  # noqa: E402
 from film_lab_ai import AIIndexService  # noqa: E402
 from film_lab_ai.providers import LocalPhotoAnalyzer, VisionProvider  # noqa: E402
@@ -356,7 +357,8 @@ def open_catalog() -> "catalog_module.Catalog | None":
             return None
     if FOLDER.is_dir():
         PRIMARY_SOURCE_ID = CATALOG.add_source(FOLDER)
-    SCANNER = catalog_scan.ScanService(CATALOG, render_busy=RENDER_LOCK.locked)
+    SCANNER = catalog_scan.ScanService(CATALOG, render_busy=RENDER_LOCK.locked,
+                                       on_local_file=THUMB_WARMUP.enqueue)
     return CATALOG
 
 
@@ -1985,7 +1987,7 @@ def orientation_deg(src: Path) -> int:
 
 
 INPUT_CACHE_VERSION = 4  # learned denoise joins capture-stage RAW development
-RAW_PREVIEW_CACHE_VERSION = 4  # width-aware half-size accurate demosaic
+RAW_PREVIEW_CACHE_VERSION = 5  # width-aware half-size accurate demosaic
 RAW_SHARED_MAGIC = b"LTRI"
 RAW_SHARED_HEADER = struct.Struct("<4sIII")
 _SHARED_INPUT_UNAVAILABLE = "shared RAW input is unavailable"
@@ -2040,7 +2042,8 @@ def array_shared_input(rgb: np.ndarray, cache_key: str):
 
 @contextmanager
 def raw_shared_input(name: str, params: dict | None = None, *,
-                     denoise_status=None, denoise_cancel=None):
+                     denoise_status=None, denoise_cancel=None,
+                     include_dimensions: bool = False):
     """Expose one decoded RAW to the resident renderer without a TIFF hop.
 
     ``multiprocessing.shared_memory`` maps the same anonymous POSIX object, or
@@ -2057,7 +2060,28 @@ def raw_shared_input(name: str, params: dict | None = None, *,
         f"raw-v{INPUT_CACHE_VERSION}:{file_key(name)}:"
         f"{color_pipeline.raw_decode_fingerprint(params)}")
     with array_shared_input(rgb, cache_key) as shared:
-        yield shared
+        yield (dict(shared, input_width=int(rgb.shape[1]), input_height=int(rgb.shape[0]))
+               if include_dimensions else shared)
+
+
+def valid_tiff_cache(path: Path) -> bool:
+    """Reject incomplete disposable TIFFs before treating existence as a hit."""
+    if not path.exists():
+        return False
+    try:
+        import tifffile as tf
+        size = path.stat().st_size
+        with tf.TiffFile(path) as image:
+            if not image.pages:
+                raise ValueError("empty TIFF")
+            for page in image.pages:
+                if not page.dataoffsets or any(offset < 0 or count <= 0 or offset + count > size
+                       for offset, count in zip(page.dataoffsets, page.databytecounts)):
+                    raise ValueError("truncated TIFF")
+        return True
+    except (OSError, ValueError, IndexError):
+        path.unlink(missing_ok=True)
+        return False
 
 
 def tiff_for(name: str, params: dict | None = None, *,
@@ -2067,7 +2091,7 @@ def tiff_for(name: str, params: dict | None = None, *,
     wb_key = color_pipeline.raw_decode_fingerprint(params) if is_raw(name) else "romm"
     t = CACHE / "tiff" / f"v{INPUT_CACHE_VERSION}_{file_key(name)}_{wb_key}.tif"
     with TIFF_BUILD_LOCK:
-        if not t.exists() or t.stat().st_mtime < src.stat().st_mtime:
+        if not valid_tiff_cache(t) or t.stat().st_mtime < src.stat().st_mtime:
             temporary = durable_io.temporary_path(t, "decode")
             try:
                 if is_raw(name):
@@ -2082,7 +2106,7 @@ def tiff_for(name: str, params: dict | None = None, *,
                 else:
                     platform_image.convert_processed_to_tiff(
                         src, temporary, app_root=APP, output_space="prophoto")
-                durable_io.publish_file(temporary, t)
+                durable_io.publish_cache(temporary, t)
             finally:
                 temporary.unlink(missing_ok=True)
             prune_cache(CACHE / "tiff", "*.tif", _TIFF_CACHE_MAX_BYTES)
@@ -2103,7 +2127,7 @@ def neutral_tiff_for(name: str, params: dict | None = None, *,
     t = CACHE / "neutral" / (
         f"v{INPUT_CACHE_VERSION}_{file_key(name)}_{raw_key}{color_key}.tif")
     with TIFF_BUILD_LOCK:
-        if not t.exists() or t.stat().st_mtime < src.stat().st_mtime:
+        if not valid_tiff_cache(t) or t.stat().st_mtime < src.stat().st_mtime:
             temporary = durable_io.temporary_path(t, "decode")
             try:
                 if is_raw(name):
@@ -2121,7 +2145,7 @@ def neutral_tiff_for(name: str, params: dict | None = None, *,
                 else:
                     platform_image.convert_processed_to_tiff(
                         src, temporary, app_root=APP, output_space=output_space)
-                durable_io.publish_file(temporary, t)
+                durable_io.publish_cache(temporary, t)
             finally:
                 temporary.unlink(missing_ok=True)
             prune_cache(CACHE / "neutral", "*.tif", _NEUTRAL_CACHE_MAX_BYTES)
@@ -2130,7 +2154,7 @@ def neutral_tiff_for(name: str, params: dict | None = None, *,
     return t
 
 
-NEUTRAL_PREVIEW_CACHE_VERSION = 2
+NEUTRAL_PREVIEW_CACHE_VERSION = 3
 
 
 def neutral_preview_path(name: str, width: int, rotate: float = 0,
@@ -2158,12 +2182,13 @@ def build_neutral_preview(name: str, width: int, rotate: float = 0,
                 src_path(name), params, max_width=width)
             image = color_pipeline.linear_prophoto_to_display_srgb(linear, params)
     else:
-        image = color_pipeline.load_float_rgb(neutral_tiff_for(name, params))
+        image = platform_image.processed_preview(
+            src_path(name), width, app_root=APP, output_space="srgb")
     image = color_pipeline.resize_float_width(image, width)
     k = rot90k(rotate)
     if k:
         image = np.ascontiguousarray(np.rot90(image, k))
-    durable_io.atomic_write_bytes(
+    durable_io.cache_write_bytes(
         output, jpeg_bytes((image * 255.0 + 0.5).astype(np.uint8)))
     prune_cache_throttled(CACHE / "neutral", "preview-*.jpg",
                           _NEUTRAL_PREVIEW_CACHE_MAX_BYTES)
@@ -2222,16 +2247,54 @@ def schedule_neutral_refinement(name: str, width: int,
     return created
 
 
+def valid_jpeg_cache(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        with path.open("rb") as handle:
+            if handle.read(2) != b"\xff\xd8":
+                raise ValueError("invalid JPEG header")
+            handle.seek(-2, os.SEEK_END)
+            if handle.read(2) != b"\xff\xd9":
+                raise ValueError("truncated JPEG")
+        with Image.open(path) as image:
+            image.verify()
+        return True
+    except (OSError, ValueError):
+        path.unlink(missing_ok=True)
+        return False
+
+
 def thumb_jpeg(name: str) -> bytes:
     """Small strip thumbnail straight from the source; never decodes full TIFF."""
     guard_local_photo(name)
     p = CACHE / "thumb" / f"{file_key(name)}.jpg"
-    if p.exists():
+    if valid_jpeg_cache(p):
         return p.read_bytes()
     with THUMB_SEM:
-        if p.exists():          # another request may have just built it
+        if valid_jpeg_cache(p):          # another request may have just built it
             return p.read_bytes()
         return _build_thumb(name, p)
+
+
+def _warm_thumbnail(name: str):
+    if not THUMB_SEM.acquire(blocking=False):
+        return
+    try:
+        guard_local_photo(name)
+        path = CACHE / "thumb" / f"{file_key(name)}.jpg"
+        if not path.exists():
+            _build_thumb(name, path)
+    finally:
+        THUMB_SEM.release()
+        cat = catalog_handle()
+        if cat is not None:
+            cat.close()
+
+
+THUMB_WARMUP = thumbnail_warmup.ThumbnailWarmup(
+    _warm_thumbnail, busy=lambda: RENDER_LOCK.locked())
+atexit.register(THUMB_WARMUP.cancel)
 
 
 def _build_thumb(name: str, p: Path) -> bytes:
@@ -2254,7 +2317,7 @@ def _build_thumb(name: str, p: Path) -> bytes:
                 im.save(temporary, "JPEG", quality=80)
         else:
             platform_image.build_thumbnail(src_path(name), temporary)
-        durable_io.publish_file(temporary, p)
+        durable_io.publish_cache(temporary, p)
     finally:
         temporary.unlink(missing_ok=True)
     prune_cache_throttled(p.parent, "*.jpg", _THUMB_CACHE_MAX_BYTES)
@@ -2415,6 +2478,19 @@ def exif_for(name: str) -> dict:
         out.update(capture_clock.exif_fields(info["override"]))
         out["CaptureTimeCorrection"] = "Catalog override · original unchanged"
     return out
+
+
+def preview_lens_metadata(name: str, optics=None) -> dict:
+    if edits.clean_optics(optics)["profileEnabled"]:
+        return exif_for(name)
+    cat = catalog_handle()
+    image_id = catalog_image_id(name) if cat is not None else None
+    row = cat.image_row(image_id) if image_id is not None else None
+    if row is not None:
+        return {"Make": row.get("camera_make") or "",
+                "Model": row.get("camera_model") or "",
+                "LensModel": row.get("lens") or ""}
+    return exif_for(name)
 
 
 def capture_time_action(body: dict) -> dict:
@@ -2635,7 +2711,7 @@ def build_raw_preview(name: str, width: int, quality: str,
                       params: dict | None = None) -> Path:
     import tifffile as tf
     output = raw_preview_path(name, width, quality, params)
-    if output.exists():
+    if valid_tiff_cache(output):
         return output
     rgb = (color_pipeline.decode_raw_draft(src_path(name), params, width)
            if quality == "fast" else
@@ -2647,7 +2723,7 @@ def build_raw_preview(name: str, width: int, quality: str,
     temporary = durable_io.temporary_path(output, "decode")
     try:
         tf.imwrite(temporary, rgb)
-        durable_io.publish_file(temporary, output)
+        durable_io.publish_cache(temporary, output)
     finally:
         temporary.unlink(missing_ok=True)
     prune_cache(output.parent, "*.tif", _RUST_INPUT_CACHE_MAX_BYTES)
@@ -2660,7 +2736,7 @@ def schedule_raw_refinement(name: str, width: int,
     wb_key = color_pipeline.raw_decode_fingerprint(params)
     key = (file_key(name), wb_key, width, client, generation)
     full = raw_preview_path(name, width, "full", params)
-    if full.exists() or render_is_stale(client, generation):
+    if valid_tiff_cache(full) or render_is_stale(client, generation):
         return False
     created = False
     with RAW_REFINE_LOCK:
@@ -2685,7 +2761,7 @@ def schedule_raw_refinement(name: str, width: int,
 def selected_preview_tiff(name: str, width: int,
                           params: dict | None = None) -> Path:
     full = raw_preview_path(name, width, "full", params)
-    if full.exists():
+    if valid_tiff_cache(full):
         return full
     return build_raw_preview(name, width, "fast", params)
 
@@ -2693,7 +2769,7 @@ def selected_preview_tiff(name: str, width: int,
 def preview_variant(name: str, width: int, params: dict | None = None) -> str:
     if not is_raw(name):
         return "standard"
-    return "full" if raw_preview_path(name, width, "full", params).exists() else "fast"
+    return "full" if valid_tiff_cache(raw_preview_path(name, width, "full", params)) else "fast"
 
 
 def linear_for(name: str, width: int, params: dict | None = None) -> np.ndarray:
@@ -2708,7 +2784,8 @@ def linear_for(name: str, width: int, params: dict | None = None) -> np.ndarray:
         preview = selected_preview_tiff(name, width, params)
         arr = fp.load_linear(str(preview))
     else:
-        arr = fp.load_linear(str(tiff_for(name, params)), max_width=width)
+        arr = platform_image.processed_preview(
+            src_path(name), width, app_root=APP, output_space="prophoto")
     with STATE_LOCK:
         _LINEAR_CACHE[key] = arr
         while (len(_LINEAR_CACHE) > 1 and
@@ -2734,7 +2811,7 @@ def raw_display(name: str) -> Path:
     decode; this is only what the eye is asked to compare against.
     """
     p = CACHE / "orig" / f"v2_{file_key(name)}_display.jpg"
-    if not p.exists():
+    if not valid_jpeg_cache(p):
         try:
             rgb = color_pipeline.raw_embedded_preview(src_path(name), 1600)
         except Exception:  # noqa: BLE001 - some RAW formats omit a preview
@@ -2747,7 +2824,7 @@ def raw_display(name: str) -> Path:
         im.thumbnail((1600, 1600), Image.LANCZOS)
         buffer = io.BytesIO()
         im.save(buffer, "JPEG", quality=88, subsampling=1)
-        durable_io.atomic_write_bytes(p, buffer.getvalue())
+        durable_io.cache_write_bytes(p, buffer.getvalue())
         prune_cache_throttled(p.parent, "*.jpg", _ORIGINAL_CACHE_MAX_BYTES)
     return p
 
@@ -2768,14 +2845,14 @@ def _orig_jpeg(name: str, width: int, rotate: float = 0) -> bytes:
     k = rot90k(rotate)
     if k:
         rotated = CACHE / "orig" / f"{file_key(name)}_{width}_{k}.jpg"
-        if not rotated.exists():
+        if not valid_jpeg_cache(rotated):
             base = Image.open(io.BytesIO(_orig_jpeg(name, width, 0))).convert("RGB")
             arr = np.rot90(np.asarray(base), k)
-            durable_io.atomic_write_bytes(
+            durable_io.cache_write_bytes(
                 rotated, jpeg_bytes(np.ascontiguousarray(arr)))
         return rotated.read_bytes()
     p = CACHE / "orig" / f"{file_key(name)}_{width}.jpg"
-    if not p.exists():
+    if not valid_jpeg_cache(p):
         if is_raw(name):
             im = Image.open(raw_display(name))
             im.load()
@@ -2784,10 +2861,10 @@ def _orig_jpeg(name: str, width: int, rotate: float = 0) -> bytes:
                                Image.LANCZOS)
             buffer = io.BytesIO()
             im.save(buffer, "JPEG", quality=88, subsampling=1)
-            durable_io.atomic_write_bytes(p, buffer.getvalue())
+            durable_io.cache_write_bytes(p, buffer.getvalue())
         else:
             arr = linear_for(name, width)
-            durable_io.atomic_write_bytes(
+            durable_io.cache_write_bytes(
                 p, jpeg_bytes((arr * 255 + 0.5).astype(np.uint8)))
         prune_cache_throttled(p.parent, "*.jpg", _ORIGINAL_CACHE_MAX_BYTES)
     return p.read_bytes()
@@ -2802,8 +2879,12 @@ def orig_mean_display(name: str, width: int,
             _ORIG_MEAN_CACHE.move_to_end(key)
             return _ORIG_MEAN_CACHE[key]
     if is_raw(name):
-        im = Image.open(io.BytesIO(orig_jpeg(name, width, 0))).convert("RGB")
-        mean = float(sum(ImageStat.Stat(im).mean) / (3.0 * 255.0))
+        try:
+            pixels = color_pipeline.raw_embedded_preview(src_path(name), width)
+            mean = float(pixels.mean()) / 255.0
+        except Exception:  # RAW without embedded preview retains neutral fallback
+            im = Image.open(io.BytesIO(orig_jpeg(name, width, 0))).convert("RGB")
+            mean = float(sum(ImageStat.Stat(im).mean) / (3.0 * 255.0))
     else:
         source = linear if linear is not None else linear_for(name, width)
         mean = float(source.mean())
@@ -2826,7 +2907,7 @@ RUST_WORKER_BIN = next((path for path in (
 RUST_DATA = APP / "engine" / "data"
 RUST_AVAILABLE = bool((RUST_WORKER_BIN or RUST_BIN.exists())
                       and RUST_DATA.is_dir())
-RENDER_CACHE_VERSION = 7  # sixteen-mask atlas, range masks, and uniformity
+RENDER_CACHE_VERSION = 8  # sixteen-mask atlas, range masks, and uniformity
 EDIT_PREVIEW_CACHE_VERSION = 1
 EDITED_THUMB_CACHE_VERSION = 1
 EDITED_THUMB_RENDER_EDGE = 512
@@ -2915,11 +2996,11 @@ class PipeLineReader:
 class RustEngineClient:
     """Long-lived JSON-lines client that keeps the GPU and shader caches warm."""
 
-    def __init__(self, binary: Path | None):
+    def __init__(self, binary: Path | None, *, lock=None):
         self.binary = binary
         self.process: subprocess.Popen | None = None
         self.reader: PipeLineReader | None = None
-        self.lock = RENDER_LOCK
+        self.lock = lock if lock is not None else RENDER_LOCK
         self.request_id = 0
 
     def _start(self) -> subprocess.Popen:
@@ -2969,7 +3050,8 @@ class RustEngineClient:
                     raise RenderCancelled("render superseded before engine dispatch")
                 process = self._start()
                 self.request_id += 1
-                payload = dict(request, id=self.request_id, command="render")
+                payload = dict(request, id=self.request_id)
+                payload.setdefault("command", "render")
                 try:
                     assert process.stdin and process.stdout
                     process.stdin.write(json.dumps(payload, separators=(",", ":"))
@@ -2995,31 +3077,63 @@ class RustEngineClient:
     def close_unlocked(self) -> None:
         if self.process and self.process.poll() is None:
             self.process.kill()
+            self.process.wait(timeout=2)
         self.process = None
         self.reader = None
 
+    def probe_input(self, key: str) -> bool:
+        return bool(self.render({"command": "probe_input", "input_cache_key": key})
+                    .get("input_cache_hit"))
+
     def warm(self) -> None:
-        """Initialize the GPU off the request path; failures retain normal fallback."""
+        """Compile the real GPU pipelines and spectral LUT before first open."""
         if not self.binary:
             return
-        with self.lock:
+        previous = getattr(RENDER_CONTEXT, "priority", "export")
+        RENDER_CONTEXT.priority = "background"
+        try:
+            import tifffile as tf
+            root = CACHE / "rust"
+            root.mkdir(parents=True, exist_ok=True)
+            source = durable_io.temporary_path(root / "warm.tif", "warm")
+            output = durable_io.temporary_path(root / "warm.rgba", "warm")
             try:
-                process = self._start()
-                self.request_id += 1
-                assert process.stdin and process.stdout
-                process.stdin.write(json.dumps({
-                    "id": self.request_id, "command": "ping",
-                }) + "\n")
-                process.stdin.flush()
-                if not self._readline(process, 30):
-                    self.close_unlocked()
-            except (BrokenPipeError, OSError, ValueError,
-                    TimeoutError, RuntimeError):
-                self.close_unlocked()
+                tf.imwrite(source, np.full((32, 32, 3), 18000, dtype=np.uint16))
+                pairs = [dict(fp.DEFAULT_PARAMS)]
+                remembered = load_json_file(CACHE / "last-film-pair.json", {})
+                if isinstance(remembered, dict) and remembered.get("stock") and remembered.get("paper"):
+                    pairs.append(fp.clean_params(remembered))
+                seen = set()
+                for cp in pairs:
+                    pair = (cp["stock"], cp["paper"])
+                    if pair in seen:
+                        continue
+                    seen.add(pair)
+                    self.render({"input": str(source), "native_output": str(output),
+                                 "data_dir": str(RUST_DATA), "film": pair[0],
+                                 "paper": pair[1], "scan_film": pair[0] in fp.POSITIVE_STOCKS,
+                                 "params": fp.rust_params_json(cp)})
+            finally:
+                source.unlink(missing_ok=True)
+                output.unlink(missing_ok=True)
+        except Exception:  # Startup must retain normal render fallback.
+            self.close()
+        finally:
+            RENDER_CONTEXT.priority = previous
 
 
 RUST_ENGINE = RustEngineClient(RUST_WORKER_BIN)
 atexit.register(RUST_ENGINE.close)
+BACKGROUND_RENDER_LOCK = PriorityGate(reentrant=True)
+BACKGROUND_ENGINE = RustEngineClient(RUST_WORKER_BIN, lock=BACKGROUND_RENDER_LOCK)
+atexit.register(BACKGROUND_ENGINE.close)
+_LAST_WARM_PAIR = None
+
+
+def preview_engine():
+    priority = getattr(RENDER_CONTEXT, "priority", "interactive")
+    return BACKGROUND_ENGINE if priority in ("prefetch", "background", "export") else RUST_ENGINE
+
 
 
 def render_key(name: str, params: dict, width: int, engine: str = "py") -> str:
@@ -3043,9 +3157,17 @@ def render_key(name: str, params: dict, width: int, engine: str = "py") -> str:
 
 def render_rust(name: str, params: dict, width: int,
                 output: Path | None,
-                native_output: Path | None = None) -> dict:
+                native_output: Path | None = None,
+                viewport: dict | None = None) -> dict:
     """Render JPEG and/or a native RGBA surface in one resident pass."""
+    global _LAST_WARM_PAIR
     cp = fp.clean_params(params)
+    pair = (cp["stock"], cp["paper"])
+    if pair != _LAST_WARM_PAIR and getattr(RENDER_CONTEXT, "priority", "interactive") == "interactive":
+        durable_io.cache_write_json(CACHE / "last-film-pair.json", {"stock": pair[0], "paper": pair[1]})
+        _LAST_WARM_PAIR = pair
+    if viewport is not None:
+        return render_viewport_rust(name, params, output, native_output, viewport)
     src_tif = selected_preview_tiff(name, width, params) if is_raw(name) else \
         CACHE / "rust" / f"v{INPUT_CACHE_VERSION}_{file_key(name)}_romm_{width}.tif"
     src_tif.parent.mkdir(parents=True, exist_ok=True)
@@ -3062,10 +3184,11 @@ def render_rust(name: str, params: dict, width: int,
             request["output"] = str(output)
         if native_output is not None:
             request["native_output"] = str(native_output)
+            request["native_shared"] = sys.platform == "darwin"
 
-        if src_tif.exists():
+        if valid_tiff_cache(src_tif):
             request["input"] = str(src_tif)
-            return RUST_ENGINE.render(request)
+            return preview_engine().render(request)
 
         if shared_input_supported():
             try:
@@ -3074,7 +3197,7 @@ def render_rust(name: str, params: dict, width: int,
                 cache_key = f"prev-v{INPUT_CACHE_VERSION}:{file_key(name)}:{width}:{preview_variant(name, width, params)}"
                 with array_shared_input(rgb16, cache_key) as shared:
                     request.update(shared)
-                    return RUST_ENGINE.render(request)
+                    return preview_engine().render(request)
             except RenderCancelled:
                 raise
             except Exception as shared_error:  # noqa: BLE001
@@ -3091,13 +3214,13 @@ def render_rust(name: str, params: dict, width: int,
                 staged_tiff,
                 (np.clip(arr, 0, 1) * 65535 + 0.5).astype(np.uint16),
             )
-            durable_io.publish_file(staged_tiff, src_tif)
+            durable_io.publish_cache(staged_tiff, src_tif)
         finally:
             staged_tiff.unlink(missing_ok=True)
         prune_cache(src_tif.parent, "*.tif", _RUST_INPUT_CACHE_MAX_BYTES)
 
         request["input"] = str(src_tif)
-        return RUST_ENGINE.render(request)
+        return preview_engine().render(request)
 
     pjson = CACHE / "rust" / f"p_{render_key(name, params, width, 'rs')}.json"
     durable_io.atomic_write_text(pjson, json.dumps(fp.rust_params_json(params)))
@@ -3118,7 +3241,7 @@ def render_rust(name: str, params: dict, width: int,
     if k:
         img = np.ascontiguousarray(np.rot90(img, k))
     if output is not None:
-        durable_io.atomic_write_bytes(output, jpeg_bytes(img))
+        durable_io.cache_write_bytes(output, jpeg_bytes(img))
     if native_output is not None:
         write_native_surface(native_output, img)
     out_png.unlink(missing_ok=True)
@@ -3129,8 +3252,165 @@ def render_rust(name: str, params: dict, width: int,
             "input_cache_hit": False, "pipeline_cache_hit": False}
 
 
+def clean_viewport(value) -> dict | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict) or set(value) != {"x", "y", "width", "height"}:
+        raise ValueError("viewport requires x, y, width and height")
+    if any(type(value[key]) is not int for key in value):
+        raise ValueError("viewport coordinates must be integer pixels")
+    if (value["x"] < 0 or value["y"] < 0 or value["width"] < 1 or value["height"] < 1
+            or value["width"] * value["height"] > 32_000_000
+            or max(value.values()) > 100_000):
+        raise ValueError("viewport is outside the supported pixel bounds")
+    return dict(value)
+
+
+def clamp_decoded_viewport(viewport: dict, width: int, height: int,
+                           quarters_ccw: int) -> dict:
+    """Clip display-axis pixels to the decoded frame, without rescaling them.
+
+    RAW catalog dimensions can describe a different active sensor area. Keep
+    the original pixel origin wherever it is valid, trimming just the edges.
+    """
+    if width < 1 or height < 1:
+        raise ValueError("decoded viewport source has no pixels")
+    if quarters_ccw % 2:
+        width, height = height, width
+    x = min(viewport["x"], width - 1)
+    y = min(viewport["y"], height - 1)
+    return {"x": x, "y": y,
+            "width": max(1, min(width, viewport["x"] + viewport["width"]) - x),
+            "height": max(1, min(height, viewport["y"] + viewport["height"]) - y)}
+
+
+def render_viewport_rust(name: str, params: dict, output: Path | None,
+                         native_output: Path | None, viewport: dict) -> dict:
+    cp = fp.clean_params(params)
+    engine = preview_engine()
+    request = {"data_dir": str(RUST_DATA), "film": cp["stock"], "paper": cp["paper"],
+               "scan_film": cp["stock"] in fp.POSITIVE_STOCKS,
+               "params": fp.rust_params_json(params), "quality": 88,
+               "rotate_quarters_ccw": rot90k(cp["rotate"]), "viewport": viewport}
+    if output is not None:
+        request["output"] = str(output)
+    if native_output is not None:
+        request.update(native_output=str(native_output), native_shared=sys.platform == "darwin")
+    def dispatch(source: dict, width: int, height: int) -> dict:
+        actual = clamp_decoded_viewport(viewport, width, height,
+                                        request["rotate_quarters_ccw"])
+        result = engine.render(dict(request, **source, viewport=actual))
+        return dict(result, viewport=actual)
+
+    if is_raw(name) and os.name == "posix":
+        key = (f"raw-v{INPUT_CACHE_VERSION}:{file_key(name)}:"
+               f"{color_pipeline.raw_decode_fingerprint(params)}")
+        probe = engine.render({"command": "probe_input", "input_cache_key": key})
+        if probe.get("input_cache_hit"):
+            try:
+                return dispatch({"input_cache_key": key}, int(probe["width"]), int(probe["height"]))
+            except RenderCancelled:
+                raise
+            except RuntimeError:
+                pass  # A restarted worker no longer owns the input.
+        try:
+            with raw_shared_input(name, params, include_dimensions=True) as shared:
+                source = {key: shared[key] for key in
+                          ("input_shm", "input_shm_len", "input_cache_key")}
+                return dispatch(source, shared["input_width"], shared["input_height"])
+        except RenderCancelled:
+            raise
+        except (OSError, MemoryError):
+            pass  # Portable TIFF fallback for constrained shared memory.
+    path = tiff_for(name, params)
+    import tifffile as tf
+    with tf.TiffFile(path) as source:
+        width, height = source.pages[0].imagewidth, source.pages[0].imagelength
+    return dispatch({"input": str(path)}, width, height)
+
+
 NATIVE_SURFACE_MAGIC = b"FLRA"
 NATIVE_SURFACE_HEADER = struct.Struct("<4sIII")
+
+
+# Immutable surfaces remain alive through native presentation. Eviction leaves
+# the ordinary disk cache available to stale native descriptors and web helpers.
+_NATIVE_SHARED = OrderedDict()
+_NATIVE_SHARED_LOCK = threading.RLock()
+_NATIVE_SHARED_MAX_BYTES = 128 * 1024 * 1024
+
+
+def _unlink_native_shared(descriptor):
+    import ctypes
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.shm_unlink.argtypes = [ctypes.c_char_p]
+    libc.shm_unlink(descriptor["name"].encode("ascii"))
+
+
+def _shared_pixels(descriptor):
+    import ctypes
+    import mmap
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.shm_open.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_uint]
+    libc.shm_open.restype = ctypes.c_int
+    fd = libc.shm_open(descriptor["name"].encode("ascii"), os.O_RDONLY, 0)
+    if fd < 0:
+        raise OSError(ctypes.get_errno(), "native surface unavailable")
+    try:
+        length = int(descriptor["length"])
+        if os.fstat(fd).st_size < length:
+            raise ValueError("truncated shared surface")
+        with mmap.mmap(fd, length, access=mmap.ACCESS_READ) as mapping:
+            width, height = int(descriptor["width"]), int(descriptor["height"])
+            return np.ndarray((height, width, 4), dtype=np.uint8, buffer=mapping,
+                              offset=int(descriptor.get("offset", 0)),
+                              strides=(int(descriptor["rowBytes"]), 4, 1)).copy()
+    finally:
+        os.close(fd)
+
+
+def materialize_native_surface(path: Path):
+    with _NATIVE_SHARED_LOCK:
+        descriptor = _NATIVE_SHARED.get(str(path))
+        if descriptor and not path.exists():
+            write_native_surface(path, _shared_pixels(descriptor))
+
+
+def retain_native_shared(path: Path, descriptor: dict):
+    name = str(descriptor.get("name", ""))
+    width, height = int(descriptor.get("width", 0)), int(descriptor.get("height", 0))
+    row = int(descriptor.get("rowBytes", 0))
+    length = int(descriptor.get("length", 0))
+    if (not re.fullmatch(r"/lt-[0-9a-f-]+", name) or width <= 0 or height <= 0
+            or row < width * 4 or length < row * height or length > 512 * 1024 * 1024):
+        raise ValueError("invalid resident shared surface")
+    with _NATIVE_SHARED_LOCK:
+        old = _NATIVE_SHARED.pop(str(path), None)
+        if old and old["name"] != name:
+            _unlink_native_shared(old)
+        _NATIVE_SHARED[str(path)] = dict(descriptor)
+        while len(_NATIVE_SHARED) > 1 and sum(d["length"] for d in _NATIVE_SHARED.values()) > _NATIVE_SHARED_MAX_BYTES:
+            oldest, victim = next(iter(_NATIVE_SHARED.items()))
+            try:
+                materialize_native_surface(Path(oldest))
+            finally:
+                _NATIVE_SHARED.pop(oldest)
+                _unlink_native_shared(victim)
+
+
+def close_native_shared():
+    with _NATIVE_SHARED_LOCK:
+        for descriptor in _NATIVE_SHARED.values():
+            _unlink_native_shared(descriptor)
+        _NATIVE_SHARED.clear()
+
+
+atexit.register(close_native_shared)
+
+
+def native_surface_exists(path: Path) -> bool:
+    with _NATIVE_SHARED_LOCK:
+        return str(path) in _NATIVE_SHARED or path.exists()
 
 
 def write_native_surface(path: Path, rgb: np.ndarray) -> dict:
@@ -3151,9 +3431,7 @@ def write_native_surface(path: Path, rgb: np.ndarray) -> dict:
             handle.write(NATIVE_SURFACE_HEADER.pack(
                 NATIVE_SURFACE_MAGIC, width, height, row_bytes))
             handle.write(rgba.tobytes(order="C"))
-            handle.flush()
-            os.fsync(handle.fileno())
-        durable_io.publish_file(temporary, path)
+        durable_io.publish_cache(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
     return {"width": width, "height": height, "rowBytes": row_bytes}
@@ -3161,6 +3439,12 @@ def write_native_surface(path: Path, rgb: np.ndarray) -> dict:
 
 def read_native_surface(path: Path) -> tuple[np.ndarray, dict]:
     """Read a native surface for cache conversion and contract tests."""
+    with _NATIVE_SHARED_LOCK:
+        descriptor = _NATIVE_SHARED.get(str(path))
+        if descriptor:
+            pixels = _shared_pixels(descriptor)
+            return pixels, {"width": descriptor["width"], "height": descriptor["height"],
+                            "rowBytes": descriptor["width"] * 4}
     with path.open("rb") as handle:
         header = handle.read(NATIVE_SURFACE_HEADER.size)
         magic, width, height, row_bytes = NATIVE_SURFACE_HEADER.unpack(header)
@@ -3175,6 +3459,14 @@ def read_native_surface(path: Path) -> tuple[np.ndarray, dict]:
 
 
 def native_surface_payload(key: str, path: Path) -> dict:
+    with _NATIVE_SHARED_LOCK:
+        descriptor = _NATIVE_SHARED.get(str(path))
+        if descriptor:
+            _NATIVE_SHARED.move_to_end(str(path))
+            return {"url": f"/api/render/native?key={key}", "format": "rgba8",
+                    "width": descriptor["width"], "height": descriptor["height"],
+                    "rowBytes": descriptor["width"] * 4, "headerBytes": NATIVE_SURFACE_HEADER.size,
+                    "sharedMemory": dict(descriptor)}
     with path.open("rb") as handle:
         magic, width, height, row_bytes = NATIVE_SURFACE_HEADER.unpack(
             handle.read(NATIVE_SURFACE_HEADER.size))
@@ -3193,7 +3485,7 @@ def native_surface_payload(key: str, path: Path) -> dict:
 
 
 def ensure_native_surface(path: Path, jpg: Path) -> None:
-    if path.exists() or not jpg.exists():
+    if native_surface_exists(path) or not jpg.exists():
         return
     with Image.open(jpg) as image:
         write_native_surface(path, np.asarray(image.convert("RGB")))
@@ -3201,7 +3493,7 @@ def ensure_native_surface(path: Path, jpg: Path) -> None:
 
 def ensure_jpeg_surface(jpg: Path, native: Path,
                         max_width: int | None = None) -> None:
-    if jpg.exists() or not native.exists():
+    if jpg.exists() or not native_surface_exists(native):
         return
     rgba, _ = read_native_surface(native)
     image = Image.fromarray(np.asarray(rgba[..., :3]), "RGB")
@@ -3210,7 +3502,7 @@ def ensure_jpeg_surface(jpg: Path, native: Path,
         image = image.resize((max_width, height), Image.Resampling.LANCZOS,
                              reducing_gap=3.0)
     jpg.parent.mkdir(parents=True, exist_ok=True)
-    durable_io.atomic_write_bytes(jpg, jpeg_bytes(np.asarray(image)))
+    durable_io.cache_write_bytes(jpg, jpeg_bytes(np.asarray(image)))
 
 
 def _render_bundle_metadata(meta: Path, jpg: Path, native: Path) -> dict | None:
@@ -3230,7 +3522,7 @@ def _render_bundle_metadata(meta: Path, jpg: Path, native: Path) -> dict | None:
     except (OSError, UnicodeDecodeError, ValueError):
         meta.unlink(missing_ok=True)
         return None
-    if native.exists():
+    if native_surface_exists(native):
         try:
             native_surface_payload("", native)
         except (OSError, ValueError, struct.error):
@@ -3249,10 +3541,12 @@ def preview_response(meta: dict, key: str, jpg: Path, native: Path,
     response.setdefault("queue_ms", 0.0)
     if jpg.exists():
         response["img"] = f"/api/render/image?key={key}"
-    if native.exists():
+    if native_surface_exists(native):
         surface = native_surface_payload(key, native)
+        if meta.get("viewport"):
+            surface["viewport"] = meta["viewport"]
         response["native"] = surface
-        if surface["width"] <= NATIVE_BROWSER_HELPER_MAX_WIDTH:
+        if not meta.get("viewport") and surface["width"] <= NATIVE_BROWSER_HELPER_MAX_WIDTH:
             response["helper"] = f"/api/render/helper?key={key}"
     return response
 
@@ -3272,7 +3566,8 @@ def render_preview(name: str, params: dict, width: int,
                    engine: str = "py", client: str = "",
                    generation: int | None = None,
                    native: bool = False,
-                   priority: str = "interactive") -> dict:
+                   priority: str = "interactive", viewport: dict | None = None) -> dict:
+    viewport = clean_viewport(viewport)
     # A decoder or engine crash takes the whole process down, so the photo
     # being processed is recorded first; the next launch reads that marker.
     guard_photo(name)
@@ -3284,7 +3579,7 @@ def render_preview(name: str, params: dict, width: int,
         RENDER_CONTEXT.cancelled = lambda: render_is_stale(client, generation)
         try:
             return _render_preview(name, params, width, engine, client,
-                                   generation, native, priority)
+                                   generation, native, priority, viewport)
         except RenderCancelled:
             return {"cancelled": True, "reason": "superseded"}
         finally:
@@ -3296,7 +3591,7 @@ def _render_preview(name: str, params: dict, width: int,
                     engine: str = "py", client: str = "",
                     generation: int | None = None,
                     native: bool = False,
-                    priority: str = "interactive") -> dict:
+                    priority: str = "interactive", viewport: dict | None = None) -> dict:
     params = dict(params)
     params["linear_input"] = is_raw(name)
     cp = fp.clean_params(params)
@@ -3336,12 +3631,16 @@ def _render_preview(name: str, params: dict, width: int,
         engine = "rs"
     elif engine == "rs" and not RUST_AVAILABLE:
         engine = "py"
-    variant = preview_variant(name, width, params)
+    if viewport is not None and (engine != "rs" or not native):
+        raise ValueError("viewport rendering requires the resident native preview")
+    variant = "full" if viewport else preview_variant(name, width, params)
 
     def response_refining() -> bool:
         return bool(is_raw(name) and variant == "fast")
 
     key = render_key(name, params, width, engine)
+    if viewport is not None:
+        key = hashlib.md5(json.dumps([key, "viewport-v1", viewport], sort_keys=True).encode()).hexdigest()
     jpg = CACHE / "render" / f"{key}.jpg"
     native_surface = CACHE / "render" / f"{key}.rgba"
     meta = CACHE / "render" / f"{key}.json"
@@ -3361,7 +3660,7 @@ def _render_preview(name: str, params: dict, width: int,
                 ensure_jpeg_surface(jpg, native_surface)
             except (OSError, ValueError, struct.error):
                 native_surface.unlink(missing_ok=True)
-    if cached_meta is not None and (not native or native_surface.exists()) and (
+    if cached_meta is not None and (not native or native_surface_exists(native_surface)) and (
             not need_jpg or jpg.exists()):
         return preview_response(
             cached_meta, key, jpg, native_surface, cached=True,
@@ -3371,7 +3670,8 @@ def _render_preview(name: str, params: dict, width: int,
             if generation < LATEST_GENERATION.get(client, generation):
                 return {"cancelled": True}
     queued_at = time.perf_counter()
-    acquired = RENDER_LOCK.acquire(
+    gate = BACKGROUND_RENDER_LOCK if priority in ("prefetch", "background", "export") else RENDER_LOCK
+    acquired = gate.acquire(
         blocking=priority != "prefetch", priority=priority,
         cancelled=lambda: render_is_stale(client, generation))
     if not acquired:
@@ -3395,7 +3695,7 @@ def _render_preview(name: str, params: dict, width: int,
                 except (OSError, ValueError, struct.error):
                     native_surface.unlink(missing_ok=True)
         if cached_meta is not None and (
-                not native or native_surface.exists()) and (
+                not native or native_surface_exists(native_surface)) and (
                 not need_jpg or jpg.exists()):      # raced with prefetch
             return dict(preview_response(
                 cached_meta, key, jpg, native_surface, cached=True,
@@ -3407,7 +3707,9 @@ def _render_preview(name: str, params: dict, width: int,
             rust_metrics = render_rust(
                 name, params, width,
                 jpg if need_jpg else None,
-                native_surface if native else None)
+                native_surface if native else None, viewport)
+            if native and rust_metrics.get("native_shared"):
+                retain_native_shared(native_surface, rust_metrics["native_shared"])
             film_mean = float(rust_metrics["mean"])
         else:
             arr = linear_for(name, width, params)
@@ -3419,25 +3721,32 @@ def _render_preview(name: str, params: dict, width: int,
                 out = np.ascontiguousarray(np.rot90(out, k))
             film_mean = float(out.mean()) / 255.0
             if need_jpg:
-                durable_io.atomic_write_bytes(jpg, jpeg_bytes(out))
+                durable_io.cache_write_bytes(jpg, jpeg_bytes(out))
             if native:
                 write_native_surface(native_surface, out)
-        orig_mean = orig_mean_display(name, width, arr)
-        match = max(0.3, min(2.5, orig_mean / max(film_mean, 1e-6)))
-        m = {"ms": ms, "match": round(match, 3), "engine": engine}
+        m = {"ms": ms, "engine": engine}
+        if viewport is None:
+            orig_mean = orig_mean_display(name, width, arr)
+            match = max(0.3, min(2.5, orig_mean / max(film_mean, 1e-6)))
+            m["match"] = round(match, 3)
+        else:
+            m["viewport"] = dict(rust_metrics.get("viewport", viewport),
+                                 fullWidth=rust_metrics["full_width"],
+                                 fullHeight=rust_metrics["full_height"])
+            m["viewport_accelerated"] = bool(rust_metrics.get("viewport_accelerated"))
         if rust_metrics:
             m["backend"] = rust_metrics.get("backend")
             m["gpu_ms"] = rust_metrics.get("render_ms")
             m["resident_ms"] = rust_metrics.get("total_ms")
             m["input_cache_hit"] = rust_metrics.get("input_cache_hit")
             m["pipeline_cache_hit"] = rust_metrics.get("pipeline_cache_hit")
-        durable_io.atomic_write_json(meta, m, indent=None, keep_backup=False)
+        durable_io.cache_write_json(meta, m)
         prune_render_cache_throttled(meta.parent, _RENDER_CACHE_MAX_BYTES)
         return dict(preview_response(
             m, key, jpg, native_surface, cached=False,
             refining=response_refining()), queue_ms=round(queue_ms, 3))
     finally:
-        RENDER_LOCK.release()
+        gate.release()
 
 
 def _preview_source_bytes(result: dict, name: str, width: int,
@@ -3776,39 +4085,81 @@ def rust_direct_export_supported(job: dict) -> bool:
     return True
 
 
+@contextmanager
+def export_phase(job: dict, phase: str):
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        timings = job.setdefault("phase_ms", {})
+        timings[phase] = round(timings.get(phase, 0.0) +
+                               (time.perf_counter() - started) * 1000, 3)
+
+
 def _resident_render_full(name: str, params: dict, request: dict) -> dict:
-    """Render a full-resolution source using shared RAW pixels when possible."""
+    # Serialize only the background process. Probe + decode + render must be
+    # one admission so parallel recipes do not decode the same RAW twice.
+    with BACKGROUND_RENDER_LOCK:
+        return _resident_render_full_locked(name, params, request)
+
+
+def _resident_render_full_locked(name: str, params: dict, request: dict) -> dict:
     request = dict(request)
+    phases = {}
+    started = time.perf_counter()
     if is_raw(name) and shared_input_supported():
         try:
-            with raw_shared_input(name, params) as shared:
-                request.update(shared)
-                metrics = RUST_ENGINE.render(request)
-            metrics["input_transport"] = "shared-memory-rgb16"
-            metrics["input_exchange_bytes"] = int(shared["input_shm_len"])
-            return metrics
+            key = (f"raw-v{INPUT_CACHE_VERSION}:{file_key(name)}:"
+                   f"{color_pipeline.raw_decode_fingerprint(params)}")
+            probe_start = time.perf_counter()
+            hit = BACKGROUND_ENGINE.probe_input(key)
+            phases["input_probe"] = (time.perf_counter() - probe_start) * 1000
+            if hit:
+                # A restarted/evicted engine can miss between probe and render;
+                # only that path falls through to a fresh decode.
+                try:
+                    render_start = time.perf_counter()
+                    metrics = BACKGROUND_ENGINE.render(dict(request, input_cache_key=key))
+                    phases["engine"] = (time.perf_counter() - render_start) * 1000
+                    return dict(metrics, input_transport="resident-cache",
+                                input_exchange_bytes=0, phase_ms=phases)
+                except RenderCancelled:
+                    raise
+                except Exception:
+                    pass
         except RenderCancelled:
             raise
-        except Exception as shared_error:  # noqa: BLE001
-            # A platform may expose shared memory yet cap a segment below a
-            # large sensor frame. Retain the proven TIFF route rather than
-            # making export brittle.
+        except Exception:
+            pass  # Old worker or missing input: normal shared/TIFF fallback.
+        try:
+            decode_start = time.perf_counter()
+            with raw_shared_input(name, params) as shared:
+                phases["decode_exchange"] = (time.perf_counter() - decode_start) * 1000
+                request.update(shared)
+                render_start = time.perf_counter()
+                metrics = BACKGROUND_ENGINE.render(request)
+                phases["engine"] = (time.perf_counter() - render_start) * 1000
+            return dict(metrics, input_transport="shared-memory-rgb16",
+                        input_exchange_bytes=int(shared["input_shm_len"]), phase_ms=phases)
+        except RenderCancelled:
+            raise
+        except Exception as shared_error:
             note_shared_input_failure(shared_error)
             for key in ("input_shm", "input_shm_len", "input_cache_key"):
                 request.pop(key, None)
-            source = tiff_for(name, params)
-            request["input"] = str(source)
-            metrics = RUST_ENGINE.render(request)
-            metrics["input_transport"] = "tiff-fallback"
-            metrics["input_exchange_bytes"] = source.stat().st_size
-            metrics["input_fallback"] = type(shared_error).__name__
-            return metrics
+            fallback = type(shared_error).__name__
+    else:
+        fallback = None
+    decode_start = time.perf_counter()
     source = tiff_for(name, params)
+    phases["decode_exchange"] = phases.get("decode_exchange", 0) + (time.perf_counter() - decode_start) * 1000
     request["input"] = str(source)
-    metrics = RUST_ENGINE.render(request)
-    metrics["input_transport"] = "tiff"
-    metrics["input_exchange_bytes"] = source.stat().st_size
-    return metrics
+    render_start = time.perf_counter()
+    metrics = BACKGROUND_ENGINE.render(request)
+    phases["engine"] = (time.perf_counter() - render_start) * 1000
+    return dict(metrics, input_transport="tiff-fallback" if fallback else "tiff",
+                input_exchange_bytes=source.stat().st_size, input_fallback=fallback,
+                phase_ms=phases)
 
 
 def export_with_resident_engine(name: str, dst: Path, job: dict) -> dict:
@@ -3834,10 +4185,14 @@ def export_with_resident_engine(name: str, dst: Path, job: dict) -> dict:
         }
         try:
             metrics = _resident_render_full(name, params, request)
-            platform_image.embed_jpeg_icc(dst, profile)
-            embed_export_metadata(dst, job)
+            job.setdefault("phase_ms", {}).update(metrics.get("phase_ms", {}))
+            with export_phase(job, "icc"):
+                platform_image.embed_jpeg_icc(dst, profile)
+            with export_phase(job, "metadata"):
+                embed_export_metadata(dst, job)
             return dict(metrics, width=int(metrics["width"]),
-                        height=int(metrics["height"]), direct_export=True)
+                        height=int(metrics["height"]), direct_export=True,
+                        phase_ms=dict(job.get("phase_ms", {})))
         except RenderCancelled:
             raise
         except Exception as error:  # noqa: BLE001
@@ -3866,14 +4221,16 @@ def export_with_resident_engine(name: str, dst: Path, job: dict) -> dict:
                     "bit_depth": 32,
                 }
                 metrics = _resident_render_full(name, params, request)
-                durable_io.publish_file(staged, film_png)
+                durable_io.publish_cache(staged, film_png)
             finally:
                 staged.unlink(missing_ok=True)
             prune_cache(film_png.parent, "*.tif", _EXPORT_FILM_CACHE_MAX_BYTES)
     if cancelled and cancelled():
         raise RenderCancelled("export cancelled before encoding")
-    width, height = finish_export(film_png, dst, job)
-    return dict(metrics, width=width, height=height,
+    job.setdefault("phase_ms", {}).update(metrics.get("phase_ms", {}))
+    with export_phase(job, "finish"):
+        width, height = finish_export(film_png, dst, job)
+    return dict(metrics, width=width, height=height, phase_ms=dict(job.get("phase_ms", {})),
                 direct_export=False, direct_fallback=direct_error)
 
 
@@ -4036,6 +4393,7 @@ def start_external_edit(body: dict) -> dict:
 def benchmark_export(name: str, job: dict) -> dict:
     """Exercise the same resident export path without writing into the photo folder."""
     started = time.perf_counter()
+    job = dict(job, phase_ms={})
     dst = CACHE / "benchmark-export.jpg"
     metrics = export_with_resident_engine(name, dst, job)
     result = {
@@ -4047,6 +4405,7 @@ def benchmark_export(name: str, job: dict) -> dict:
                               else 0),
         "input_exchange_bytes": metrics.get("input_exchange_bytes", 0),
         "input_transport": metrics.get("input_transport"),
+        "phase_ms": metrics.get("phase_ms", {}),
         "backend": metrics.get("backend"),
         "gpu_ms": metrics.get("render_ms"),
         "resident_ms": metrics.get("total_ms"),
@@ -4137,6 +4496,10 @@ class ExportBatch:
             if outcome.get("log"):
                 self.status["log"].append(outcome["log"])
                 self.status["log"] = self.status["log"][-200:]
+            if outcome.get("phase_ms"):
+                timings = self.status.setdefault("timings", [])
+                timings.append({"name": name, "phase_ms": outcome["phase_ms"]})
+                self.status["timings"] = timings[-200:]
             if outcome.get("warnings"):
                 self.status["warnings"].append({
                     "name": name, "path": outcome.get("path"),
@@ -4195,6 +4558,10 @@ def export_one(name: str, job: dict, batch: ExportBatch | None = None) -> None:
                 EXPORT["errors"].append(f"{name}: {outcome['error']}")
             if outcome.get("log"):
                 EXPORT["log"].append(outcome["log"])
+            if outcome.get("phase_ms"):
+                timings = EXPORT.setdefault("timings", [])
+                timings.append({"name": name, "phase_ms": outcome["phase_ms"]})
+                EXPORT["timings"] = timings[-200:]
             EXPORT["done"] += 1
             if EXPORT["done"] >= EXPORT["total"]:
                 EXPORT["running"] = False
@@ -4214,6 +4581,7 @@ def _export_one(name: str, job: dict, batch: ExportBatch | None = None) -> dict:
         edits.require_saved_mask_assets(job.get("masks"))
         started = time.perf_counter()
         job = dict(job)
+        job["phase_ms"] = {}
         job["warnings"] = list(job.get("warnings") or [])
         out_dir = Path(job["destination"])
         if "destinationMode" in job and out_dir.resolve() != out_dir:
@@ -4222,11 +4590,13 @@ def _export_one(name: str, job: dict, batch: ExportBatch | None = None) -> dict:
         out_dir.mkdir(parents=True, exist_ok=True)
         cp = fp.clean_params(job["params"])
         # Resolve metadata only for the worker's source, as in preview.
+        metadata_started = time.perf_counter()
         metadata = exif_for(name)
         job["lensProfile"] = edits.lens_profile_for(metadata,
             edits.clean_optics(job.get("optics")).get("profileOverride"))
         job["metadataFields"] = export_metadata_fields(name)
         requested = export_requested_path(name, job, metadata)
+        job["phase_ms"]["prepare_metadata"] = (time.perf_counter() - metadata_started) * 1000
         check()
         with EXPORT_PATH_LOCK:
             dst = export_workflow.collision_path(
@@ -4264,14 +4634,16 @@ def _export_one(name: str, job: dict, batch: ExportBatch | None = None) -> dict:
             _, metadata_source, _ = _export_metadata_payload(job)
             if metadata_source is not None:
                 job["metadataSource"] = str(metadata_source)
-            render_source = export_render_source(name, job)
+            with export_phase(job, "decode_exchange"):
+                render_source = export_render_source(name, job)
             durable_io.atomic_write_text(jfile, json.dumps(job))
             env = dict(os.environ, OMP_NUM_THREADS="4", NUMBA_NUM_THREADS="4")
             try:
                 check()
-                r = _run_export_process(
-                    [sys.executable, str(APP / "render_cli.py"),
-                     str(render_source), str(staged), str(jfile)], env, batch)
+                with export_phase(job, "render_encode_metadata"):
+                    r = _run_export_process(
+                        [sys.executable, str(APP / "render_cli.py"),
+                         str(render_source), str(staged), str(jfile)], env, batch)
             finally:
                 jfile.unlink(missing_ok=True)
             if r.returncode != 0:
@@ -4314,7 +4686,7 @@ def _export_one(name: str, job: dict, batch: ExportBatch | None = None) -> dict:
         # Cancellation and publication share a short critical section. Once
         # publication starts, this complete output survives later cancellation.
         publish_lock = batch.lock if batch else EXPORT_PATH_LOCK
-        with publish_lock:
+        with export_phase(job, "publish"), publish_lock:
             check()
             if dst.parent.resolve() != out_dir:
                 raise ValueError("The export destination moved while rendering; nothing was published")
@@ -4335,7 +4707,8 @@ def _export_one(name: str, job: dict, batch: ExportBatch | None = None) -> dict:
                 except OSError as error:
                     job["warnings"].append(f"Photo exported, but its recipe sidecar could not be saved: {error}")
         elapsed = time.perf_counter() - started
-        outcome = {"completed": 1, "path": str(dst), "warnings": list(dict.fromkeys(job["warnings"])),
+        job["phase_ms"]["total"] = round(elapsed * 1000, 3)
+        outcome = {"completed": 1, "path": str(dst), "phase_ms": job["phase_ms"], "warnings": list(dict.fromkeys(job["warnings"])),
                    "log": f"{name} -> {dst.name} ({elapsed:.1f}s, {detail})"}
     except (ExportCancelled, RenderCancelled):
         outcome = {"cancelledCount": 1}
@@ -5398,6 +5771,9 @@ READ_ONLY_POST_PATHS = {
 
 
 class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    timeout = 30
+
     def log_message(self, *a):  # quiet
         pass
 
@@ -5414,6 +5790,8 @@ class Handler(BaseHTTPRequestHandler):
               cache_control: str = "no-store", *,
               headers: dict[str, str] | None = None) -> None:
         self._response_status = code
+        if code >= 400:
+            self.close_connection = True
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
@@ -5426,6 +5804,8 @@ class Handler(BaseHTTPRequestHandler):
     def _send_file(self, code: int, path: Path, ctype: str,
                    cache_control: str = "no-store") -> None:
         self._response_status = code
+        if code >= 400:
+            self.close_connection = True
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(path.stat().st_size))
@@ -5585,7 +5965,8 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Cache-Control", "no-store")
-        self.send_header("Connection", "keep-alive")
+        self.send_header("Connection", "close")
+        self.close_connection = True
         self.end_headers()
         try:
             self.wfile.write(encode_sse({
@@ -5745,6 +6126,7 @@ class Handler(BaseHTTPRequestHandler):
                 if len(key) != 32 or any(c not in "0123456789abcdef" for c in key):
                     raise ValueError("bad render key")
                 surface = CACHE / "render" / f"{key}.rgba"
+                materialize_native_surface(surface)
                 if not surface.exists():
                     self._json({"error": "native render not found"}, 404)
                 else:
@@ -5949,12 +6331,14 @@ class Handler(BaseHTTPRequestHandler):
                     with GENERATION_LOCK:
                         LATEST_GENERATION[client] = max(
                             generation, LATEST_GENERATION.get(client, generation))
+                if b.get("viewport") and not edits.base_edits_are_identity(b.get("optics"), b.get("heals")):
+                    raise ValueError("viewport rendering requires unwarped source geometry")
                 result = render_preview(
                     b["name"], b.get("params", {}), int(b.get("w", 1100)),
                     b.get("engine", "py"), client,
                     generation if isinstance(generation, int) else None,
                     bool(b.get("native", False)),
-                    str(b.get("priority", "interactive")))
+                    str(b.get("priority", "interactive")), b.get("viewport"))
                 if bool(b.get("native", False)):
                     result = apply_preview_edits(
                         result, b["name"], int(b.get("w", 1100)),
@@ -5962,7 +6346,7 @@ class Handler(BaseHTTPRequestHandler):
                         native=True)
                     if not result.get("cancelled"):
                         result = dict(result, lens_profile=edits.lens_profile_for(
-                            exif_for(b["name"]),
+                            preview_lens_metadata(b["name"], b.get("optics")),
                             edits.clean_optics(b.get("optics")).get("profileOverride")))
                     self._json(result)
                 else:
@@ -6962,7 +7346,7 @@ def catalog_sources_action(body: dict) -> dict:
         if body.get("importState", True):
             # A folder that was edited before the catalog existed carries its
             # own state file; fold it in on first sight so nothing is lost.
-            catalog_scan.scan_source(cat, source_id)
+            catalog_scan.scan_source(cat, source_id, on_local_file=THUMB_WARMUP.enqueue)
             imported = catalog_scan.import_state_file(cat, source_id)
         elif SCANNER is not None:
             SCANNER.request(source_id)
@@ -7228,7 +7612,7 @@ def start_ingest(body: dict) -> dict:
             if cat is not None and destinations:
                 root = Path(request["destination"])
                 source_id = cat.add_source(root)
-                catalog_scan.scan_source(cat, source_id)
+                catalog_scan.scan_source(cat, source_id, on_local_file=THUMB_WARMUP.enqueue)
         except Exception as error:  # noqa: BLE001
             with INGEST_LOCK:
                 INGEST["errors"].append({"error": str(error)})
@@ -7405,7 +7789,7 @@ def start_enhance(body: dict) -> dict:
         source, destination, mode, request=body.get("request"))
     cat = catalog_handle()
     if result.get("ok") and cat is not None and PRIMARY_SOURCE_ID is not None:
-        catalog_scan.scan_source(cat, PRIMARY_SOURCE_ID)
+        catalog_scan.scan_source(cat, PRIMARY_SOURCE_ID, on_local_file=THUMB_WARMUP.enqueue)
     return result
 
 

--- a/server.py
+++ b/server.py
@@ -1793,8 +1793,6 @@ _BASE_CACHE_BUDGET_BYTES = sum((
     _NATIVE_SURFACE_CACHE_MAX_BYTES, _RENDER_CACHE_MAX_BYTES,
     _ORIGINAL_CACHE_MAX_BYTES, _THUMB_CACHE_MAX_BYTES,
 ))
-NATIVE_BROWSER_HELPER_MAX_WIDTH = int(os.environ.get(
-    "LIGHTTABLE_NATIVE_HELPER_WIDTH", "1100"))
 NATIVE_BROWSER_HELPER_OUTPUT_WIDTH = int(os.environ.get(
     "LIGHTTABLE_NATIVE_HELPER_OUTPUT_WIDTH", "256"))
 
@@ -3546,7 +3544,9 @@ def preview_response(meta: dict, key: str, jpg: Path, native: Path,
         if meta.get("viewport"):
             surface["viewport"] = meta["viewport"]
         response["native"] = surface
-        if not meta.get("viewport") and surface["width"] <= NATIVE_BROWSER_HELPER_MAX_WIDTH:
+        # A full native surface needs sampling at every resolution. Viewport
+        # tiles retain the existing full-photo helper.
+        if not meta.get("viewport"):
             response["helper"] = f"/api/render/helper?key={key}"
     return response
 

--- a/tests/first-run.test.mjs
+++ b/tests/first-run.test.mjs
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { installFirstRunSetup, shouldShowSetup } from '../web/first-run.js';
+
+const empty = { total: 0, images: [], catalog: { sources: [] } };
+test('waits for both responses, respects durable completion, and spares existing installations', () => {
+  assert.equal(shouldShowSetup(null, empty), false);
+  assert.equal(shouldShowSetup({}, null), false);
+  assert.equal(shouldShowSetup({}, empty), true);
+  assert.equal(shouldShowSetup({}, { total: 7000 }), false);
+  assert.equal(shouldShowSetup({}, empty, false), false);
+  assert.equal(shouldShowSetup({}, { total: 10 }, true), true);
+  for (const status of ['completed', 'skipped']) {
+    assert.equal(shouldShowSetup({ firstRunSetup: { version: 1, status } }, empty, true), false);
+  }
+});
+
+function fixture({ native = false, failSave = false } = {}) {
+  const all = new Map();
+  class Element {
+    hidden = false; disabled = false; value = ''; textContent = ''; inert = false;
+    constructor(id) {
+      this.id = id;
+      const classes = new Set();
+      this.classList = { contains: (key) => classes.has(key), toggle: (key, on) => on ? classes.add(key) : classes.delete(key) };
+    }
+    setAttribute(name, value) { this[name] = value; }
+    removeAttribute(name) { delete this[name]; }
+    focus() { document.activeElement = this; }
+    querySelector() { return new Element('heading'); }
+    querySelectorAll(selector) { return selector === '[data-setup-page]' ? pages : []; }
+  }
+  const markup = readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
+  for (const [, id] of markup.matchAll(/id="([^"]+)"/g)) all.set(id, new Element(id));
+  const pages = [...markup.matchAll(/data-setup-page="([^"]+)"/g)].map(([, name]) => {
+    const node = new Element(name); node.dataset = { setupPage: name }; return node;
+  });
+  const shell = all.get('appShell');
+  globalThis.window = { __LIGHTTABLE_PLATFORM__: native ? 'macos' : undefined };
+  globalThis.document = { activeElement: null, body: new Element('body'), addEventListener() {} };
+  document.body.children = [shell, all.get('firstRunDialog')];
+  globalThis.requestAnimationFrame = (fn) => fn();
+  const writes = [], actions = [];
+  let reloads = 0, catalogOpens = 0;
+  const controller = installFirstRunSetup({
+    el: (id) => all.get(id),
+    post: async (path, body) => { writes.push({ path, body }); return failSave ? { error: 'Disk full' } : { ok: true }; },
+    nativeBridge: () => native,
+    sendNative: (action) => { actions.push(action); return native; },
+    openCatalog: () => { catalogOpens++; },
+    reloadLibrary: async () => { reloads++; }, toast() {},
+  });
+  controller.setPrefs({}); controller.setLibrary(empty);
+  return { controller, all, writes, actions, shell,
+    open: () => all.get('firstRunDialog').classList.contains('on'),
+    click: (id) => all.get(id).onclick(),
+    counts: () => ({ reloads, catalogOpens }) };
+}
+
+test('native startup waits for shell identity; cancelled folder picker never completes setup', async () => {
+  const f = fixture({ native: true });
+  assert.equal(f.open(), false);
+  f.controller.nativeEvent({ type: 'sources', firstRun: true, photosLibraryImportAvailable: true });
+  assert.equal(f.open(), true); assert.equal(f.shell.inert, true);
+  await f.click('setupFolderChoose');
+  assert.ok(f.actions.includes('setupChooseFolder'));
+  f.controller.nativeEvent({ type: 'setupFolderCancelled' });
+  assert.equal(f.open(), true); assert.equal(f.writes.length, 0);
+  f.controller.nativeEvent({ type: 'setupFolderSelected', path: '/fixture' });
+  assert.equal(f.writes.length, 0);
+  await f.click('setupDone');
+  assert.equal(f.writes.at(-1).body.firstRunSetup.source, 'folder');
+  assert.equal(f.writes.at(-1).body.includeSubfolders, true);
+  assert.equal(f.open(), false); assert.equal(f.shell.inert, false);
+  assert.ok(f.actions.includes('completeFirstRun'));
+});
+
+test('skip is saved and remains dismissed on subsequent startup events', async () => {
+  const f = fixture();
+  assert.equal(f.open(), true);
+  await f.click('setupLater');
+  assert.equal(f.writes[0].body.firstRunSetup.status, 'skipped');
+  f.controller.setLibrary(empty);
+  assert.equal(f.open(), false);
+  await f.click('setupReopen'); assert.equal(f.open(), true);
+});
+
+test('failed persistence keeps the panel open with a recoverable error', async () => {
+  const f = fixture({ failSave: true });
+  await f.click('setupLater');
+  assert.equal(f.open(), true);
+  assert.match(f.all.get('setupError').textContent, /Disk full/);
+  assert.equal(f.all.get('setupLater').disabled, false);
+  assert.equal(f.actions.includes('completeFirstRun'), false);
+});
+
+test('Lightroom handoff returns on cancellation; marks completion only after successful import', async () => {
+  const f = fixture();
+  await f.click('setupLightroom'); await f.click('setupCatalogChoose');
+  assert.equal(f.open(), false); assert.equal(f.counts().catalogOpens, 1);
+  f.controller.catalogClosed(); assert.equal(f.open(), true);
+  assert.equal(f.writes.length, 0);
+  await f.click('setupCatalogChoose');
+  f.controller.catalogCompleted({ images: 5, matched: 3, unmatched: 2 });
+  f.controller.catalogClosed();
+  assert.match(f.all.get('setupResultMessage').textContent, /2 originals could not be found/);
+  await f.click('setupDone');
+  assert.equal(f.writes.at(-1).body.firstRunSetup.source, 'lightroom');
+});
+
+test('Photos access failure and cancellation are retryable; imported counts stay honest', async () => {
+  const f = fixture({ native: true });
+  f.controller.nativeEvent({ type: 'sources', firstRun: true, photosLibraryImportAvailable: true });
+  await f.click('setupPhotosAll');
+  assert.ok(f.actions.includes('importApplePhotosLibrary'));
+  assert.equal(f.all.get('setupLater').hidden, true);
+  f.controller.nativeEvent({ type: 'photosLibraryImport', state: 'error', message: 'Photos access denied' });
+  assert.equal(f.writes.length, 0);
+  assert.match(f.all.get('setupError').textContent, /access denied/);
+  await f.click('setupPhotosAll');
+  f.controller.nativeEvent({ type: 'photosLibraryImport', state: 'running', completed: 4, total: 10 });
+  assert.equal(f.all.get('setupPhotosProgress').value, 4);
+  await f.click('setupPhotosCancel');
+  assert.ok(f.actions.includes('cancelApplePhotosLibraryImport'));
+  f.controller.nativeEvent({ type: 'photosLibraryImport', state: 'cancelled' });
+  assert.equal(f.writes.length, 0);
+  f.controller.nativeEvent({ type: 'photosLibraryImport', state: 'completed', imported: 8, existing: 2, failures: 1 });
+  assert.match(f.all.get('setupResultMessage').textContent, /8 originals imported · 2 already added · 1 could not/);
+  await f.click('setupDone');
+  assert.equal(f.writes.at(-1).body.firstRunSetup.source, 'photos');
+});
+
+test('browser folder flow adds source through server before completing', async () => {
+  const f = fixture();
+  f.all.get('setupFolderPath').value = '/fixture/photos';
+  await f.click('setupFolderChoose');
+  assert.equal(f.writes[0].path, '/api/catalog/sources');
+  assert.equal(f.counts().reloads, 1);
+  assert.equal(f.writes.length, 1);
+  await f.click('setupDone');
+  assert.equal(f.writes[1].body.firstRunSetup.source, 'folder');
+});

--- a/tests/fixtures/photos-library-import.swift
+++ b/tests/fixtures/photos-library-import.swift
@@ -1,0 +1,310 @@
+// Compiled by test_photos_library_import.py with production Swift inserted.
+// Fake PhotoKit only supplies assets/chunks; file IO, locking, counters, and
+// cancellation use the production importer unchanged. No Photos access occurs.
+import Foundation
+import CryptoKit
+import UniformTypeIdentifiers
+import Darwin
+
+enum PHAssetResourceType: Int { case photo, alternatePhoto, fullSizePhoto, pairedVideo }
+enum PHAssetMediaType { case image }
+typealias PHAssetResourceDataRequestID = Int
+final class PHFetchOptions { var includeHiddenAssets = false; var includeAllBurstAssets = false }
+final class PHAssetResource {
+    let type: PHAssetResourceType
+    let originalFilename: String
+    let uniformTypeIdentifier = "public.jpeg"
+    let data: Data
+    let delay: Double
+    let fail: Bool
+    init(_ name: String, _ type: PHAssetResourceType = .photo, _ delay: Double = 0, _ fail: Bool = false) {
+        self.originalFilename = name; self.type = type; self.delay = delay; self.fail = fail
+        self.data = Data(("fixture-" + name).utf8)
+    }
+    static func assetResources(for asset: PHAsset) -> [PHAssetResource] { asset.resources }
+}
+final class PHAsset {
+    static var fixtures: [PHAsset] = []
+    let localIdentifier: String
+    let resources: [PHAssetResource]
+    init(_ id: String, _ resources: [PHAssetResource]) { localIdentifier = id; self.resources = resources }
+    static func fetchAssets(with type: PHAssetMediaType, options: PHFetchOptions) -> AssetResult { AssetResult(fixtures) }
+}
+final class AssetResult {
+    let values: [PHAsset]
+    init(_ values: [PHAsset]) { self.values = values }
+    func enumerateObjects(_ body: (PHAsset, Int, UnsafeMutablePointer<ObjCBool>) -> Void) {
+        var stop = ObjCBool(false)
+        for (index, asset) in values.enumerated() { body(asset, index, &stop); if stop.boolValue { break } }
+    }
+}
+final class PHAssetResourceRequestOptions {
+    var isNetworkAccessAllowed = false
+    var progressHandler: ((Double) -> Void)?
+}
+final class PHAssetResourceManager {
+    static let shared = PHAssetResourceManager()
+    static func `default`() -> PHAssetResourceManager { shared }
+    private let lock = NSLock()
+    private var nextID = 0
+    private var cancelled = Set<Int>()
+    var requests = 0
+    var onRequest: ((PHAssetResource) -> Void)?
+    func requestData(for resource: PHAssetResource, options: PHAssetResourceRequestOptions?, dataReceivedHandler: @escaping (Data) -> Void, completionHandler: @escaping (Error?) -> Void) -> Int {
+        lock.lock(); nextID += 1; let id = nextID; requests += 1; lock.unlock()
+        onRequest?(resource)
+        DispatchQueue.global().async {
+            options?.progressHandler?(0.5)
+            if resource.delay > 0 { Thread.sleep(forTimeInterval: resource.delay) }
+            self.lock.lock(); let cancelled = self.cancelled.contains(id); self.lock.unlock()
+            if cancelled { completionHandler(CocoaError(.userCancelled)); return }
+            let split = resource.data.count / 2
+            dataReceivedHandler(resource.data.prefix(split))
+            dataReceivedHandler(resource.data.suffix(from: split))
+            completionHandler(resource.fail ? CocoaError(.fileReadUnknown) : nil)
+        }
+        return id
+    }
+    func cancelDataRequest(_ id: Int) { lock.lock(); cancelled.insert(id); lock.unlock() }
+}
+
+IMPORTER_SOURCE
+
+struct FolderSource: Codable, Equatable { var path: String; var favorite: Bool }
+let defaultPhotoFolder = "/fixture/Pictures"
+
+func require(_ value: @autoclosure () -> Bool, _ message: String) {
+    if !value() { fatalError(message) }
+}
+func wait(_ body: () -> Bool) {
+    let deadline = Date().addingTimeInterval(6)
+    while !body(), Date() < deadline { RunLoop.main.run(until: Date().addingTimeInterval(0.01)) }
+    require(body(), "fixture timed out")
+}
+
+private func testImporter() throws {
+let root = FileManager.default.temporaryDirectory.appendingPathComponent("lighttable-photos-fixture-" + UUID().uuidString)
+try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+defer { try? FileManager.default.removeItem(at: root) }
+func copied(_ folder: URL) -> [URL] {
+    (FileManager.default.enumerator(at: folder, includingPropertiesForKeys: nil)?.allObjects as? [URL] ?? []).filter { $0.pathExtension == "jpg" || $0.pathExtension == "dng" }
+}
+func partials(_ folder: URL) -> [URL] {
+    (FileManager.default.enumerator(at: folder, includingPropertiesForKeys: nil)?.allObjects as? [URL] ?? []).filter { $0.pathExtension == "partial" }
+}
+func run(_ assets: [PHAsset], folder: URL, cancelAtResource: String? = nil) -> [String: Any] {
+    PHAsset.fixtures = assets
+    var terminal: [String: Any]?
+    let importer = PhotosLibraryImporter(directory: folder) { event in
+        if event["state"] as? String != "running" { terminal = event }
+    }
+    if let cancelAtResource {
+        PHAssetResourceManager.shared.onRequest = { resource in
+            if resource.originalFilename == cancelAtResource {
+                DispatchQueue.main.async { importer.cancel() }
+            }
+        }
+    }
+    defer { PHAssetResourceManager.shared.onRequest = nil }
+    importer.start()
+    wait { terminal != nil }
+    require(partials(folder).isEmpty, "partial files survived")
+    return terminal!
+}
+let pair = PHAsset("same-asset", [PHAssetResource("same.jpg"), PHAssetResource("same.dng", .alternatePhoto), PHAssetResource("edited.jpg", .fullSizePhoto), PHAssetResource("video.mov", .pairedVideo)])
+var result = run([pair], folder: root)
+require(result["imported"] as? Int == 2 && result["total"] as? Int == 2, "original pair counts")
+require(copied(root).count == 2, "adjusted/video excluded")
+let original = copied(root).first { $0.pathExtension == "jpg" }!
+let originalData = try Data(contentsOf: original)
+require(originalData == Data("fixture-same.jpg".utf8), "streaming preserves bytes")
+let before = PHAssetResourceManager.shared.requests
+let unicode = PHAsset("new-asset", [PHAssetResource(String(repeating: "👨‍👩‍👦", count: 80) + ".jpg")])
+result = run([pair, unicode], folder: root)
+require(result["imported"] as? Int == 1 && result["existing"] as? Int == 2, "rerun must add only new")
+require(PHAssetResourceManager.shared.requests - before == 1, "dedup must skip downloading")
+require(copied(root).count == 3, "long Unicode filenames")
+let failed = PHAsset("failed-asset", [PHAssetResource("fail.jpg", .photo, 0, true)])
+result = run([failed], folder: root)
+require(result["failures"] as? Int == 1 && result["imported"] as? Int == 0, "failed transfer counted")
+let fast = PHAsset("fast-asset", [PHAssetResource("fast.jpg")])
+let slow = PHAsset("slow-asset", [PHAssetResource("slow.jpg", .photo, 0.5)])
+result = run([fast, slow], folder: root, cancelAtResource: "slow.jpg")
+require(result["state"] as? String == "cancelled" && result["imported"] as? Int == 1, "cancel keeps completed copies")
+result = run([fast, slow], folder: root)
+require(result["imported"] as? Int == 1 && result["existing"] as? Int == 1, "cancelled run resumes without duplicates")
+result = run([], folder: root)
+require(result["total"] as? Int == 0 && result["imported"] as? Int == 0, "empty library counts")
+PHAsset.fixtures = [PHAsset("lock-asset", [PHAssetResource("lock.jpg", .photo, 1)])]
+var firstResult: [String: Any]?
+var lockResult: [String: Any]?
+let first = PhotosLibraryImporter(directory: root) { event in if event["state"] as? String != "running" { firstResult = event } }
+PHAssetResourceManager.shared.onRequest = { _ in
+    DispatchQueue.main.async {
+        PHAssetResourceManager.shared.onRequest = nil
+        let second = PhotosLibraryImporter(directory: root) { event in if event["state"] as? String != "running" { lockResult = event } }
+        second.start()
+    }
+}
+first.start()
+wait { lockResult != nil }
+require(lockResult?["state"] as? String == "error", "concurrent import locked out")
+first.cancel()
+wait { firstResult != nil }
+require(partials(root).isEmpty, "cancellation removed partial")
+print("PASS: byte-preserving stream; original-only RAW+JPEG; dedup/new assets; Unicode filename; transfer failure; cancellation/resume; empty library; concurrent import lock")
+
+}
+
+private final class FirstRunHarness {
+    let defaults: UserDefaults
+    let environment: [String: String]
+    let workspace: URL
+    var firstRun = false
+    var folder = ""
+    var sources: [FolderSource] = []
+    var pendingSetupFolderEvent: [String: Any]?
+    var pendingSetupCatalogEvent: [String: Any]?
+    var launches: [String] = []
+    var photosLibraryImportEvent: [String: Any]?
+    var events: [[String: Any]] = []
+    init(defaults: UserDefaults, environment: [String: String] = [:], workspace: URL) {
+        self.defaults = defaults
+        self.environment = environment
+        self.workspace = workspace
+    }
+    func begin() {
+        INITIALIZATION_SOURCE
+        let clean = folder
+        STARTUP_PERSISTENCE_SOURCE
+    }
+    func complete() { finishFirstRun() }
+    func replay() { replaySetupEvents() }
+    func addFolder(_ path: String) { addSource(path); folder = path }
+    func importCatalog(_ body: [String: Any]) { completeSetupCatalogImport(body) }
+    private func launch(folder: String) {
+        self.folder = folder
+        launches.append(folder)
+        let clean = folder
+        STARTUP_PERSISTENCE_SOURCE
+    }
+    private func gettingStartedFolder() throws -> URL { workspace }
+    private func showFatal(_ message: String) { fatalError(message) }
+    private func sendEvent(_ payload: [String: Any]) { events.append(payload) }
+    FIRST_RUN_METHODS
+}
+
+private func testFirstRun() throws {
+    let suite = "org.lighttable.test.first-run." + UUID().uuidString
+    let defaults = UserDefaults(suiteName: suite)!
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(suite)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let workspace = root.appendingPathComponent("Getting Started")
+    try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+    func reset() { defaults.removePersistentDomain(forName: suite) }
+    func shell(_ environment: [String: String] = [:]) -> FirstRunHarness {
+        FirstRunHarness(defaults: defaults, environment: environment, workspace: workspace)
+    }
+    let fresh = shell()
+    fresh.begin()
+    require(fresh.firstRun && fresh.folder == workspace.path && fresh.sources.isEmpty,
+            "fresh install must open an empty workspace")
+    require(defaults.object(forKey: "photoFolder") == nil && defaults.object(forKey: "folderSources") == nil,
+            "automatic startup must not acknowledge setup or save Pictures")
+    let reload = shell()
+    reload.begin()
+    require(reload.firstRun, "uncompleted first run must survive restart")
+    fresh.pendingSetupFolderEvent = ["type": "setupFolderSelected", "path": root.path]
+    fresh.photosLibraryImportEvent = ["type": "photosLibraryImport", "state": "completed", "imported": 3]
+    fresh.replay()
+    fresh.replay()
+    require(fresh.events.count == 4, "terminal setup events must survive multiple page navigations")
+    fresh.complete()
+    require(defaults.integer(forKey: "firstRunCompleted") == 1 && defaults.string(forKey: "photoFolder") == workspace.path,
+            "skip must persist completion and the empty workspace")
+    require(fresh.pendingSetupFolderEvent == nil && fresh.photosLibraryImportEvent == nil,
+            "acknowledgement must clear terminal events")
+    let event = fresh.events.last!
+    require(event["firstRun"] as? Bool == false && event["photosLibraryImportAvailable"] as? Bool == true,
+            "completion must publish current setup state and capability")
+    let skipped = shell()
+    skipped.begin()
+    require(!skipped.firstRun && skipped.folder == workspace.path,
+            "restart after skip must never fall back to Pictures")
+    reset()
+    let whitespace = shell(["LIGHTTABLE_DIR": " \n "])
+    whitespace.begin()
+    require(whitespace.firstRun, "empty environment override is not an existing library")
+    reset()
+    let automated = shell(["LIGHTTABLE_DIR": "  /fixture/automation  "])
+    automated.begin()
+    require(!automated.firstRun && automated.folder == "/fixture/automation",
+            "explicit environment path must retain automated startup behavior")
+    require(defaults.object(forKey: "photoFolder") == nil && defaults.object(forKey: "folderSources") == nil,
+            "automated launch must not save native user preferences")
+    reset()
+    defaults.set("/fixture/existing", forKey: "photoFolder")
+    let existing = shell()
+    existing.begin()
+    require(!existing.firstRun && existing.folder == "/fixture/existing", "existing folder preference skips setup")
+    reset()
+    defaults.set(try JSONEncoder().encode([FolderSource(path: "/fixture/source", favorite: true)]), forKey: "folderSources")
+    let savedSources = shell()
+    savedSources.begin()
+    require(!savedSources.firstRun && savedSources.folder == "/fixture/source", "existing sources skip setup")
+    reset()
+    let selected = shell()
+    selected.begin()
+    selected.addFolder(root.path)
+    selected.photosLibraryImportEvent = ["type": "photosLibraryImport", "state": "running"]
+    selected.complete()
+    require(selected.photosLibraryImportEvent?["state"] as? String == "running", "completion must retain an active background import")
+    let resumed = shell()
+    resumed.begin()
+    require(!resumed.firstRun && resumed.folder == root.path && resumed.sources.contains { $0.path == root.path },
+            "successful folder choice must persist across restart")
+    reset()
+    let catalog = shell()
+    catalog.begin()
+    let firstFolder = root.appendingPathComponent("First photos")
+    let secondFolder = root.appendingPathComponent("Second photos")
+    try FileManager.default.createDirectory(at: firstFolder, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: secondFolder, withIntermediateDirectories: true)
+    let plainFile = root.appendingPathComponent("not-a-folder.jpg")
+    try Data("fixture".utf8).write(to: plainFile)
+    catalog.importCatalog([
+        "paths": [root.appendingPathComponent("missing").path, plainFile.path,
+                  "relative-path", firstFolder.path, firstFolder.path + "/.", secondFolder.path],
+        "matched": 3, "unmatched": 2,
+    ])
+    require(catalog.launches == [firstFolder.path] && catalog.sources.count == 2,
+            "catalog handoff must register only available distinct directories and launch first")
+    require(defaults.string(forKey: "photoFolder") == firstFolder.path,
+            "catalog handoff must persist native startup beyond Getting Started")
+    catalog.replay()
+    catalog.replay()
+    require(catalog.events.count == 2 && catalog.events.last?["matched"] as? Int == 3
+            && catalog.events.last?["unmatched"] as? Int == 2,
+            "catalog counts must survive server and page reloads")
+    catalog.complete()
+    require(catalog.pendingSetupCatalogEvent == nil, "completion must clear catalog handoff")
+    let importedRestart = shell()
+    importedRestart.begin()
+    require(importedRestart.folder == firstFolder.path && importedRestart.sources.count == 2,
+            "catalog sources and chosen startup must survive native restart")
+    reset()
+    let offlineCatalog = shell()
+    offlineCatalog.begin()
+    offlineCatalog.importCatalog(["paths": [root.appendingPathComponent("offline").path],
+                                 "matched": 0, "unmatched": 4])
+    require(offlineCatalog.launches.isEmpty && offlineCatalog.sources.isEmpty,
+            "offline catalog handoff must not launch or register missing sources")
+    require(offlineCatalog.events.last?["type"] as? String == "setupCatalogImported"
+            && offlineCatalog.events.last?["unmatched"] as? Int == 4,
+            "offline catalog still reports its terminal counts")
+    print("PASS: fresh/existing/environment startup, no implicit indexing, skip/folder/catalog persistence, validated source handoff, event replay and acknowledgement")
+}
+if CommandLine.arguments.last == "first-run" { try testFirstRun() }
+else { try testImporter() }

--- a/tests/help-search.test.mjs
+++ b/tests/help-search.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { HELP_SECTION_TOPICS, helpSearch, normalizeHelpText } from '../web/help-search.js';
+
+const articles = [
+  { id: 'export', title: 'Export photos', category: 'Export',
+    summary: 'Save a finished file.', keywords: ['save', 'jpeg', 'tiff'],
+    sections: [{ title: 'Prepare', paragraphs: ['Check the crop before saving.'],
+      steps: ['Choose a destination folder.'], tips: ['Use a new filename.'] }] },
+  { id: 'crop', title: 'Crop and straighten', category: 'Editing',
+    summary: 'Change framing and aspect ratio.', keywords: ['rotate', 'horizon'],
+    sections: [{ title: 'Frame', paragraphs: ['Drag the edges.'], steps: ['Choose Done.'] }] },
+];
+
+test('title matches rank above an incidental body mention', () => {
+  assert.equal(helpSearch(articles, 'crop')[0].id, 'crop');
+});
+test('natural questions and partial tool names work', () => {
+  assert.equal(helpSearch(articles, 'How do I crop?')[0].id, 'crop');
+  assert.equal(helpSearch(articles, 'straigh')[0].id, 'crop');
+});
+test('all query terms must match, including steps and tips', () => {
+  assert.deepEqual(helpSearch(articles, 'destination filename').map((a) => a.id), ['export']);
+  assert.deepEqual(helpSearch(articles, 'crop spacecraft'), []);
+});
+test('categories apply to empty and nonempty searches', () => {
+  assert.deepEqual(helpSearch(articles, '', 'Editing').map((a) => a.id), ['crop']);
+  assert.deepEqual(helpSearch(articles, 'crop', 'Export').map((a) => a.id), ['export']);
+});
+test('punctuation, case, accents, and empty results are harmless', () => {
+  assert.equal(normalizeHelpText('CAFÉ / RAW+JPEG'), 'cafe raw jpeg');
+  assert.equal(helpSearch(articles, '?!').length, 2);
+  assert.deepEqual(helpSearch(articles, '<script>'), []);
+});
+test('every shipped title finds its own article first', () => {
+  const content = JSON.parse(readFileSync(new URL('../web/help-content.json', import.meta.url)));
+  for (const article of content.articles) {
+    assert.equal(helpSearch(content.articles, article.title)[0]?.id, article.id, article.title);
+  }
+});
+test('shipped help answers common workflow searches', () => {
+  const { articles: shipped } = JSON.parse(readFileSync(new URL('../web/help-content.json', import.meta.url)));
+  for (const query of ['crop', 'mask', 'export', 'missing photos', 'grain', 'keyboard', 'white balance', 'presets']) {
+    assert.ok(helpSearch(shipped, query).length > 0, query);
+  }
+});
+test('every contextual help button has a bundled destination and a real section label', () => {
+  const { articles: shipped } = JSON.parse(readFileSync(new URL('../web/help-content.json', import.meta.url)));
+  const ids = new Set(shipped.map((article) => article.id));
+  const html = readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
+  for (const topics of Object.values(HELP_SECTION_TOPICS)) {
+    for (const [label, id] of Object.entries(topics)) {
+      assert.ok(ids.has(id), `Missing contextual help: ${id}`);
+      assert.ok(html.includes(`<span>${label}</span>`), `Missing section: ${label}`);
+    }
+  }
+});

--- a/tests/scope-sampling.test.mjs
+++ b/tests/scope-sampling.test.mjs
@@ -1,0 +1,276 @@
+/* Behavioural cover for the scope panel and the sampling texture it reads.
+ *
+ * The scopes draw from a small WebGL "helper" surface. When the render
+ * response for a settled preview stopped offering that helper, every scope
+ * silently drew an empty canvas. These tests execute the drawing functions
+ * against a recording 2D context so a scope that stops putting pixels on the
+ * canvas, or maps luminance to the wrong row, fails here.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import vm from 'node:vm';
+
+const appSource = readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+
+const slice = (from, to) => {
+  const start = appSource.indexOf(from);
+  const end = appSource.indexOf(to);
+  assert.ok(start >= 0, `app.js must define ${from}`);
+  assert.ok(end > start, `app.js must define ${to} after ${from}`);
+  return appSource.slice(start, end);
+};
+
+/* A 2D context that keeps the pixels the scopes write, so assertions can look
+ * at the canvas rather than at the calls that produced it. */
+function recordingCanvas(width, height) {
+  const buffer = new Uint8ClampedArray(width * height * 4);
+  const noop = () => {};
+  const ctx = {
+    strokeStyle: '', fillStyle: '', lineWidth: 1, font: '',
+    globalCompositeOperation: 'source-over',
+    beginPath: noop, closePath: noop, moveTo: noop, lineTo: noop,
+    stroke: noop, fill: noop, arc: noop, fillRect: noop, fillText: noop,
+    clearRect: noop,
+    measureText: () => ({ width: 8 }),
+    getImageData: (x, y, w, h) => ({ width: w, height: h, data: buffer.slice() }),
+    putImageData: (image) => { buffer.set(image.data); },
+  };
+  return {
+    ctx,
+    cv: { width, height },
+    /* Rows carrying any drawn density, top row first. */
+    litRows() {
+      const rows = [];
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          if (buffer[(y * width + x) * 4 + 3]) { rows.push(y); break; }
+        }
+      }
+      return rows;
+    },
+    litColumns(row) {
+      const columns = [];
+      for (let x = 0; x < width; x++) {
+        if (buffer[(row * width + x) * 4 + 3]) columns.push(x);
+      }
+      return columns;
+    },
+  };
+}
+
+/* The shape GradeRenderer.sample() returns: tightly packed RGBA. */
+function sampleOf(width, height, pixel) {
+  const px = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = pixel(x, y);
+      const offset = (y * width + x) * 4;
+      px[offset] = r; px[offset + 1] = g; px[offset + 2] = b; px[offset + 3] = 255;
+    }
+  }
+  return { px, w: width, h: height };
+}
+
+function scopes({ canvas, sample = null } = {}) {
+  const refreshes = [];
+  const context = vm.createContext({
+    S: { clip: false, gl: sample === null ? null : { sample: () => sample } },
+    $: () => ({ ...(canvas ? canvas.cv : {}),
+      getContext: () => (canvas ? canvas.ctx : null) }),
+    refreshWebGLSamplingSurface: () => refreshes.push(true),
+  });
+  vm.runInContext(
+    `${slice("let scopeMode = 'histogram';", "document.querySelectorAll('[data-scope]')")}
+     globalThis.scopeApi = {
+       drawWaveformScope, drawVectorscope, drawHistogramScope, drawHistogram,
+       setMode(mode) { scopeMode = mode; },
+     };`,
+    context);
+  return { ...context.scopeApi, refreshes };
+}
+
+const WIDTH = 300;
+const HEIGHT = 110;
+/* The waveform maps 0..255 onto the full canvas height, brightest at the top. */
+const rowFor = (value) => HEIGHT - 1 - Math.round((value / 255) * (HEIGHT - 1));
+
+test('the waveform draws pixels for a normal sample', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawWaveformScope(surface.ctx, surface.cv,
+    sampleOf(64, 48, (x) => [x * 4, x * 4, x * 4]));
+  assert.ok(surface.litRows().length > 8,
+    'a gradient must light up many waveform rows, not an empty canvas');
+});
+
+test('the waveform places luminance at the matching IRE row', () => {
+  for (const value of [0, 128, 255]) {
+    const surface = recordingCanvas(WIDTH, HEIGHT);
+    scopes().drawWaveformScope(surface.ctx, surface.cv,
+      sampleOf(32, 24, () => [value, value, value]));
+    assert.deepEqual(surface.litRows(), [rowFor(value)],
+      `a flat ${value} sample belongs on exactly one row`);
+  }
+  assert.equal(rowFor(0), HEIGHT - 1, 'black sits at 0 IRE, the bottom row');
+  assert.equal(rowFor(255), 0, 'white sits at 100 IRE, the top row');
+});
+
+test('the waveform weights luminance rather than averaging channels', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  /* Pure green is much brighter than pure blue under Rec.709 weights. */
+  scopes().drawWaveformScope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [0, 255, 0]));
+  assert.deepEqual(surface.litRows(), [rowFor(255 * 0.7152)]);
+});
+
+test('the RGB parade separates the channels into three columns', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawWaveformScope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [255, 0, 0]), true);
+  const section = Math.floor(WIDTH / 3);
+  const red = surface.litColumns(rowFor(255));
+  const dark = surface.litColumns(rowFor(0));
+  assert.ok(red.length > 0 && red.every((x) => x < section),
+    'a pure red frame lights only the red section at full height');
+  assert.ok(dark.every((x) => x >= section),
+    'the green and blue sections stay at the bottom of the parade');
+});
+
+test('the vectorscope puts a neutral frame at the centre', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawVectorscope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [128, 128, 128]));
+  assert.deepEqual(surface.litRows(), [Math.round(HEIGHT / 2)],
+    'a neutral frame carries no chroma, so it lands on the centre row');
+});
+
+test('the vectorscope pushes a saturated frame away from the centre', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  scopes().drawVectorscope(surface.ctx, surface.cv,
+    sampleOf(32, 24, () => [220, 30, 30]));
+  const rows = surface.litRows();
+  assert.equal(rows.length, 1);
+  assert.ok(rows[0] < HEIGHT / 2 - 5,
+    'red carries a positive Cr, which plots above the centre line');
+});
+
+
+/* ------------------------------------------------ scope mode dispatch */
+
+test('each scope mode draws through drawHistogram', () => {
+  const modes = ['histogram', 'waveform', 'parade', 'vectorscope'];
+  for (const mode of modes) {
+    const surface = recordingCanvas(WIDTH, HEIGHT);
+    const api = scopes({
+      canvas: surface,
+      sample: sampleOf(48, 32, (x, y) => [x * 5, y * 7, 128]),
+    });
+    api.setMode(mode);
+    api.drawHistogram();
+    assert.equal(api.refreshes.length, 1,
+      `${mode} must refresh the sampling surface before reading it`);
+    if (mode !== 'histogram') {
+      assert.ok(surface.litRows().length > 0,
+        `${mode} must put pixels on the canvas`);
+    }
+  }
+});
+
+test('a scope with no sampling surface draws nothing instead of stale pixels', () => {
+  const surface = recordingCanvas(WIDTH, HEIGHT);
+  const api = scopes({ canvas: surface, sample: null });
+  api.setMode('waveform');
+  api.drawHistogram();
+  assert.deepEqual(surface.litRows(), [],
+    'without a helper texture the scope leaves a cleared canvas');
+});
+
+/* ----------------------------------------- the sampling helper request */
+
+/* scheduleNativeHelper defers the WebGL sampling texture until interaction
+ * settles. It runs against a fake clock so the ordering is deterministic. */
+function helperHarness() {
+  let now = 0;
+  let nextTimer = 0;
+  const timers = new Map();
+  const loaded = [];
+  const context = vm.createContext({
+    record(url, options) { loaded.push({ url, options: { ...options } }); },
+    performance: { now: () => now },
+    setTimeout(fn, ms) {
+      const id = ++nextTimer;
+      timers.set(id, { fn, at: now + (ms || 0) });
+      return id;
+    },
+    clearTimeout(id) { timers.delete(id); },
+  });
+  vm.runInContext(
+    `let nativeHelperTimer = null;
+     let lastContinuousInputAt = 0;
+     const S = { seq: 0 };
+     function setWebGLBaseImage(url, options) {
+       globalThis.record(url, options);
+       return Promise.resolve({});
+     }
+     ${slice('function scheduleNativeHelper(', 'function setNativeBaseImage(')}
+     globalThis.api = {
+       schedule: scheduleNativeHelper,
+       renderStarts() { return ++S.seq; },
+     };`,
+    context);
+  const api = context.api;
+  return {
+    loaded,
+    renderStarts: api.renderStarts,
+    schedule: api.schedule,
+    advance(ms) {
+      const target = now + ms;
+      for (;;) {
+        const due = [...timers.entries()]
+          .filter(([, timer]) => timer.at <= target)
+          .sort((a, b) => a[1].at - b[1].at)[0];
+        if (!due) break;
+        timers.delete(due[0]);
+        now = due[1].at;
+        due[1].fn();
+      }
+      now = target;
+    },
+  };
+}
+
+test('the settled render loads the sampling helper the interactive one lost', () => {
+  const h = helperHarness();
+  const interactive = h.renderStarts();
+  h.schedule('/api/render/helper?key=interactive', interactive);
+  /* The full-resolution render supersedes it before the deferred fetch runs. */
+  h.advance(161);
+  const settled = h.renderStarts();
+  h.schedule('/api/render/helper?key=settled', settled);
+  h.advance(400);
+  assert.deepEqual(h.loaded.map((entry) => entry.url),
+    ['/api/render/helper?key=settled'],
+    'exactly one helper loads, and it belongs to the settled render');
+  assert.deepEqual(h.loaded[0].options,
+    { preserveCanvasSize: true, forceWebGLDraw: true, generation: settled });
+});
+
+test('a superseded helper never overwrites the current sampling texture', () => {
+  const h = helperHarness();
+  const stale = h.renderStarts();
+  h.schedule('/api/render/helper?key=stale', stale);
+  h.renderStarts();
+  h.advance(400);
+  assert.deepEqual(h.loaded, [],
+    'the generation guard drops a helper whose render was replaced');
+});
+
+test('a render without a helper leaves the pending request armed', () => {
+  const h = helperHarness();
+  const generation = h.renderStarts();
+  h.schedule('/api/render/helper?key=only', generation);
+  h.schedule(undefined, generation);
+  h.advance(400);
+  assert.deepEqual(h.loaded.map((entry) => entry.url),
+    ['/api/render/helper?key=only']);
+});

--- a/tests/test_cli_control.py
+++ b/tests/test_cli_control.py
@@ -16,10 +16,13 @@ import server
 from events import EventBroker, encode_sse
 from jobs import JobRegistry
 from lighttable_cli.__main__ import (
+    OPTICS_DEFAULTS,
     build_parser,
     curve_assignments,
+    dispatch,
     dispatch_domain,
     normalize_global_arguments,
+    preset_state,
     state_merge_update,
 )
 from lighttable_cli.instances import discover, select
@@ -329,3 +332,84 @@ class CLIContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PresetApplicationTests(unittest.TestCase):
+    """A preset applies only the groups it carries, the way the window does."""
+
+    PRESET = {
+        "name": "Warm", "includeFilm": False, "params": {},
+        "grade": {"exposure": 0.3, "contrast": 0.0},
+        "includedGrade": ["exposure"], "masks": [], "heals": [],
+        "optics": dict(OPTICS_DEFAULTS),
+    }
+    PHOTO = {
+        "params": {"stock": "kodak_portra_400"}, "grade": {"contrast": 0.1},
+        "masks": [{"id": "mask-1", "type": "radial"}],
+        "heals": [{"id": "heal-1"}],
+        "optics": {**OPTICS_DEFAULTS, "rotate": 2.0},
+    }
+
+    def client(self, preset):
+        photo = self.PHOTO
+
+        class FakeClient:
+            def __init__(self): self.posts = []
+            def get(self, path):
+                if path == "/api/presets": return [preset]
+                return json.loads(json.dumps(photo))
+            def post(self, path, body):
+                self.posts.append((path, body)); return {"ok": True}
+        return FakeClient()
+
+    def arguments(self, **extra):
+        base = dict(command="presets", action="apply", name="Warm",
+                    refs=["a.jpg"], where=[], names_from=None, limit=10,
+                    sort="capture:desc", origin="test")
+        base.update(extra)
+        return SimpleNamespace(**base)
+
+    def test_cli_lens_defaults_match_the_server(self):
+        import edits
+        self.assertEqual(OPTICS_DEFAULTS, edits.clean_optics({}))
+
+    def test_a_grade_only_preset_carries_only_its_grade(self):
+        self.assertEqual(preset_state(self.PRESET), {"grade": {"exposure": 0.3}})
+
+    def test_applying_a_grade_only_preset_keeps_film_masks_and_lens(self):
+        client = self.client(self.PRESET)
+        dispatch(client, self.arguments())
+        path, body = client.posts[0]
+        self.assertEqual(path, "/api/state")
+        self.assertEqual(body["grade"], {"contrast": 0.1, "exposure": 0.3})
+        for group in ("params", "masks", "heals", "optics"):
+            self.assertNotIn(group, body)
+
+    def test_preset_masks_layer_over_the_photo_with_fresh_identities(self):
+        preset = dict(self.PRESET, masks=[{"id": "mask-1", "type": "linear"}],
+                      optics={**OPTICS_DEFAULTS, "vignette": 0.5})
+        client = self.client(preset)
+        dispatch(client, self.arguments())
+        body = client.posts[0][1]
+        self.assertEqual([mask["type"] for mask in body["masks"]],
+                         ["radial", "linear"])
+        self.assertEqual(body["masks"][0]["id"], "mask-1")
+        self.assertNotEqual(body["masks"][1]["id"], "mask-1")
+        self.assertEqual(body["optics"],
+                         {**OPTICS_DEFAULTS, "rotate": 2.0, "vignette": 0.5})
+        self.assertNotIn("heals", body)
+
+    def test_edit_with_a_preset_follows_the_same_rules(self):
+        client = self.client(self.PRESET)
+        args = SimpleNamespace(
+            command="edit", action="set", refs=["a.jpg"], where=[],
+            names_from=None, limit=10, sort="capture:desc", origin="test",
+            grade=[], film=[], rotate=None, curve=[], hsl=[], crop=None,
+            patch=None, replace=None, copy_from=None,
+            include="film,grade,crop,masks,heals,optics", preset="Warm",
+            layer=False, group="all", history_label="Preset")
+        dispatch(client, args)
+        body = client.posts[0][1]
+        self.assertEqual(body["grade"], {"contrast": 0.1, "exposure": 0.3})
+        for group in ("params", "masks", "heals", "optics"):
+            self.assertNotIn(group, body)

--- a/tests/test_export_parity.py
+++ b/tests/test_export_parity.py
@@ -53,7 +53,7 @@ class ExportParityTests(unittest.TestCase):
             seen.append(dict(request)) or {"width": 2, "height": 1})
         with mock.patch.object(server, "is_raw", return_value=True), \
                 mock.patch.object(server, "raw_shared_input", shared), \
-                mock.patch.object(server, "RUST_ENGINE", engine), \
+                mock.patch.object(server, "BACKGROUND_ENGINE", engine), \
                 mock.patch.object(server, "tiff_for") as tiff:
             metrics = server._resident_render_full("frame.dng", {}, {})
         tiff.assert_not_called()
@@ -70,7 +70,7 @@ class ExportParityTests(unittest.TestCase):
             with mock.patch.object(server, "is_raw", return_value=True), \
                     mock.patch.object(server, "raw_shared_input",
                                       side_effect=PermissionError("denied")), \
-                    mock.patch.object(server, "RUST_ENGINE", engine), \
+                    mock.patch.object(server, "BACKGROUND_ENGINE", engine), \
                     mock.patch.object(server, "tiff_for",
                                       return_value=source):
                 metrics = server._resident_render_full("frame.dng", {}, {})

--- a/tests/test_first_run.py
+++ b/tests/test_first_run.py
@@ -1,0 +1,70 @@
+"""Run setup lifecycle regression tests with the standard Python test suite."""
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+@unittest.skipUnless(shutil.which("node"), "Node.js required")
+class FirstRunTests(unittest.TestCase):
+    def test_setup_lifecycle(self):
+        root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(
+            ["node", "--test", "tests/first-run.test.mjs"], cwd=root,
+            capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+class FirstRunLightroomTests(unittest.TestCase):
+    def setUp(self):
+        import gzip
+        import tempfile
+        import catalog
+        import catalog_import
+        from tests.test_real_assets import LIGHTROOM_FIXTURE, LIGHTROOM_ASSETS
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.photos = self.root / 'photos'
+        self.photos.mkdir()
+        for photo in LIGHTROOM_ASSETS:
+            shutil.copy2(photo, self.photos / photo.name)
+        self.lrcat = self.root / 'sample.lrcat'
+        self.lrcat.write_bytes(gzip.decompress(LIGHTROOM_FIXTURE.read_bytes()))
+        self.source_bytes = self.lrcat.read_bytes()
+        self.catalog = catalog.Catalog(self.root / 'library.sqlite3')
+        self.addCleanup(self.catalog.close)
+        original = catalog_import.inspect(self.lrcat)['roots'][0]['originalPath']
+        self.root_map = {original: str(self.photos)}
+
+    def run_import(self, **kwargs):
+        import catalog_import
+        return catalog_import.import_catalog(
+            self.catalog, self.lrcat, root_map=self.root_map, **kwargs)
+
+    def test_opt_in_import_populates_empty_catalog_without_scanning_unrelated_files(self):
+        extra = self.photos / 'unrelated.jpg'
+        shutil.copy2(self.photos / 'contact-sheet.jpg', extra)
+        result = self.run_import(add_sources=True)
+        self.assertEqual(result['matched'], 3)
+        self.assertEqual(result['unmatched'], 0)
+        self.assertGreater(result['keywords'], 0)
+        sources = self.catalog.sources()
+        self.assertEqual(len(sources), 1)
+        names = {row[0] for row in self.catalog.connection.execute('SELECT filename FROM files')}
+        self.assertEqual(names, {'contact-sheet.jpg', 'portrait-contact-sheet.jpg'})
+        self.assertEqual(self.lrcat.read_bytes(), self.source_bytes)
+        self.assertEqual(self.run_import(add_sources=True)['matched'], 3)
+        self.assertEqual(len(self.catalog.sources()), 1)
+        self.assertEqual(self.catalog.connection.execute('SELECT COUNT(*) FROM files').fetchone()[0], 2)
+
+    def test_default_import_still_requires_preexisting_sources(self):
+        result = self.run_import()
+        self.assertEqual(result['matched'], 0)
+        self.assertEqual(self.catalog.sources(), [])
+
+    def test_unavailable_original_is_reported_while_present_files_import(self):
+        (self.photos / 'contact-sheet.jpg').unlink()
+        result = self.run_import(add_sources=True)
+        self.assertGreater(result['matched'], 0)
+        self.assertGreater(result['unmatched'], 0)
+        self.assertEqual(self.lrcat.read_bytes(), self.source_bytes)

--- a/tests/test_help_content.py
+++ b/tests/test_help_content.py
@@ -1,0 +1,121 @@
+"""Source drift must require article review, even when the bundle still builds."""
+import contextlib
+import copy
+import importlib.util
+import io
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location('help_content', ROOT / 'scripts/help_content.py')
+help_content = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(help_content)
+
+
+class HelpContentTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        (self.root / 'docs/help').mkdir(parents=True)
+        (self.root / 'web').mkdir()
+        (self.root / 'web/tool.js').write_text('function crop() { return "Crop"; }\n')
+        self.article = {
+            'id': 'crop', 'title': 'Crop a photo', 'category': 'Editing',
+            'summary': 'Change the framing.', 'keywords': ['crop', 'straighten'],
+            'sections': [{'title': 'Crop', 'paragraphs': ['Open Crop.'],
+                          'steps': ['Drag the corners.', 'Choose Done.']}],
+            'related': [], 'sources': [{'path': 'web/tool.js', 'anchor': 'function crop()'}],
+        }
+        self.write_articles([self.article])
+
+    def write_articles(self, articles):
+        (self.root / 'docs/help/editing.json').write_text(json.dumps(articles))
+
+    def run_command(self, *args):
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            return help_content.run(list(args), self.root)
+
+    def test_shipped_content_is_reviewed_and_bundle_current(self):
+        self.assertEqual(help_content.run(['check'], ROOT), 0)
+
+    def test_build_cannot_acknowledge_review(self):
+        self.assertEqual(self.run_command('build'), 1)
+        self.assertFalse((self.root / help_content.LOCK).exists())
+        self.assertEqual(self.run_command('review', 'crop'), 0)
+        self.assertEqual(self.run_command('check'), 1, 'missing bundle must fail')
+        self.assertEqual(self.run_command('build'), 0)
+        self.assertEqual(self.run_command('check'), 0)
+
+    def test_source_change_requires_review_even_when_anchor_survives(self):
+        self.run_command('review', '--all')
+        self.run_command('build')
+        (self.root / 'web/tool.js').write_text('function crop() { return "New crop behavior"; }\n')
+        self.assertEqual(self.run_command('check'), 1)
+        self.assertEqual(self.run_command('build'), 1)
+        self.run_command('review', 'crop')
+        self.assertEqual(self.run_command('build'), 0)
+
+    def test_content_changes_require_review_and_regeneration(self):
+        self.run_command('review', '--all')
+        self.run_command('build')
+        self.article['summary'] = 'Use the new framing control.'
+        self.write_articles([self.article])
+        self.assertEqual(self.run_command('check'), 1)
+        self.run_command('review', 'crop')
+        self.assertEqual(self.run_command('check'), 1)
+        self.assertEqual(self.run_command('build'), 0)
+
+    def test_unrelated_changes_do_not_invalidate_help(self):
+        self.run_command('review', '--all')
+        self.run_command('build')
+        (self.root / 'web/unrelated.js').write_text('new unrelated feature')
+        self.assertEqual(self.run_command('check'), 0)
+
+    def test_review_is_scoped_per_article(self):
+        second = copy.deepcopy(self.article)
+        second['id'] = 'second'
+        self.write_articles([self.article, second])
+        self.run_command('review', '--all')
+        (self.root / 'web/tool.js').write_text('function crop() { return "changed"; }')
+        self.run_command('review', 'crop')
+        issues = help_content.drift(help_content.current_records(
+            help_content.load_articles(self.root), self.root), help_content.read_lock(self.root))
+        self.assertEqual(set(issues), {'second'})
+        self.assertEqual(self.run_command('build'), 1)
+
+    def test_removed_anchor_cannot_be_reviewed_away(self):
+        (self.root / 'web/tool.js').write_text('function removedCrop() {}')
+        self.assertEqual(self.run_command('review', '--all'), 1)
+
+    def test_duplicate_ids_missing_links_and_path_escape_fail(self):
+        self.write_articles([self.article, self.article])
+        self.assertEqual(self.run_command('review', '--all'), 1)
+        self.article['related'] = ['missing']
+        self.write_articles([self.article])
+        self.assertEqual(self.run_command('review', '--all'), 1)
+        self.article['related'] = []
+        self.article['sources'][0]['path'] = '../outside'
+        self.write_articles([self.article])
+        self.assertEqual(self.run_command('review', '--all'), 1)
+
+    def test_bundle_strips_source_evidence(self):
+        self.run_command('review', '--all')
+        self.run_command('build')
+        bundled = json.loads((self.root / help_content.BUNDLE).read_text())
+        self.assertNotIn('sources', bundled['articles'][0])
+        self.assertIn('steps', bundled['articles'][0]['sections'][0])
+
+    @unittest.skipUnless(shutil.which('node'), 'Node.js is unavailable')
+    def test_search_behaviors(self):
+        result = subprocess.run(['node', '--test', 'tests/help-search.test.mjs'],
+                                cwd=ROOT, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_interaction_cache.py
+++ b/tests/test_interaction_cache.py
@@ -23,7 +23,9 @@ const req = {w:1100,engine:'rs',native:true,params:{b:2,a:1},optics:{},heals:[]}
 const key = renderRequestKey(im,req);
 const same = renderRequestKey(im,{...req,params:{a:1,b:2},generation:99});
 const changed = [ {...req,w:2200}, {...req,params:{a:2,b:2}},
- {...req,optics:{distortion:0.2}}, {...req,heals:[{id:'spot'}]}]
+ {...req,optics:{distortion:0.2}}, {...req,heals:[{id:'spot'}]},
+ {...req,viewport:{x:0,y:0,width:200,height:100}},
+ {...req,viewport:{x:100,y:0,width:200,height:100}}]
  .map(r=>renderRequestKey(im,r)!==key);
 changed.push(renderRequestKey({...im,fileKey:'v2'},req)!==key);
 const c=createPresentationCache(2); c.set('a',{key:'A'}); c.set('b',{key:'B'});

--- a/tests/test_native_edit_recovery.py
+++ b/tests/test_native_edit_recovery.py
@@ -18,7 +18,7 @@ class NativeEditRecoveryTests(unittest.TestCase):
         cls.build = tempfile.TemporaryDirectory(prefix="lighttable-native-recovery-test-")
         directory = Path(cls.build.name)
         source = (ROOT / "app/main.swift").read_text()
-        store = source.split("// MARK: - Durable edit recovery", 1)[1].split("// MARK: - App", 1)[0]
+        store = source.split("// MARK: - Durable edit recovery", 1)[1].split("// MARK:", 1)[0]
         main = directory / "main.swift"
         main.write_text("import Foundation\nimport Darwin\n" + store + '''
 let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)

--- a/tests/test_native_recovery_journey.py
+++ b/tests/test_native_recovery_journey.py
@@ -1,0 +1,125 @@
+"""Run the actual recovery journey against the real state API and catalog."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import threading
+from http.server import ThreadingHTTPServer
+from unittest import mock
+
+import server
+from tests.test_server_catalog import CatalogServerTestCase
+
+
+ROOT = Path(__file__).resolve().parents[1]
+JOURNEY = r"""
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import vm from 'node:vm';
+const [root, url, name] = process.argv.slice(1);
+const read = file => readFileSync(`${root}/web/${file}`, 'utf8');
+const moduleFor = file => import(`data:text/javascript;base64,${Buffer.from(read(file)).toString('base64')}`);
+const {createEditSaveQueue} = await moduleFor('edit-save-queue.js');
+const {createEditRecovery, recoveryPayloadMatches} = await moduleFor('edit-recovery.js');
+const {createCloseBarrier} = await moduleFor('close-barrier.js');
+const {GRADE_DEFAULTS} = await moduleFor('gl.js');
+const records = new Map();
+const storage = {get length() {return records.size;}, key: i => [...records.keys()][i],
+  getItem: key => records.get(key) ?? null, setItem: (key, value) => records.set(key, value),
+  removeItem: key => records.delete(key)};
+const window = {fetch: (path, options) => fetch(url + path, options)};
+const getJSON = async path => {
+  const response = await window.fetch(path);
+  assert.equal(response.status, 200);
+  return response.json();
+};
+const data = await getJSON('/api/images');
+const createJournal = options => createEditRecovery({...options, storage});
+const editRecovery = createJournal({scope: data.catalog?.path || `folder:${data.folder}`});
+const writes = [];
+const editSaveQueue = createEditSaveQueue({journal: editRecovery, send: async (_, payload) => {
+  const response = await window.fetch('/api/state', {method: 'POST',
+    headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload.state)});
+  const result = await response.json();
+  if (!response.ok || !result.ok) throw new Error(result.error || 'Save failed');
+  writes.push(await getJSON(`/api/state?name=${encodeURIComponent(name)}`));
+}});
+const closeBarrier = createCloseBarrier({capture: () => {}, setBlocked: () => {},
+  flush: async () => {try {await editSaveQueue.flush(); return true;} catch {return false;}}});
+window.lightTablePrepareToClose = () => closeBarrier.prepare();
+window.lightTableCancelClose = () => closeBarrier.cancel();
+const source = read('app.js').match(/^async function runEditRecoveryJourney\([^]*?^}/m)[0];
+const context = {window, cur: () => ({name}), getJSON, GRADE_DEFAULTS, editSaveQueue,
+  editRecovery, createEditRecovery: createJournal, nativeJournalRequest: undefined,
+  recoveryPayloadMatches};
+vm.runInNewContext(source + '\nglobalThis.run = runEditRecoveryJourney;', context);
+try {
+  const result = await context.run();
+  console.log(JSON.stringify({result, writes, remainingDrafts: (await editRecovery.list()).length}));
+} catch (error) {
+  console.log(JSON.stringify({error: error.message, writes}));
+  process.exitCode = 1;
+}
+"""
+
+
+class NativeRecoveryJourneyTests(CatalogServerTestCase):
+    def run_journey(self):
+        if not shutil.which('node'):
+            self.skipTest('requires Node.js')
+
+        class Handler(server.Handler):
+            def _enforce_security(self, **kwargs):
+                pass
+
+            def log_message(self, *args):
+                pass
+
+        http = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        thread = threading.Thread(target=http.serve_forever, daemon=True)
+        thread.start()
+        try:
+            result = subprocess.run(
+                ['node', '--input-type=module', '--eval', JOURNEY, str(ROOT),
+                 f'http://127.0.0.1:{http.server_port}', self.qualified('a.jpg')],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertTrue(result.stdout.strip(), result.stderr)
+            return result.returncode, json.loads(result.stdout)
+        finally:
+            http.shutdown()
+            http.server_close()
+            thread.join(timeout=5)
+
+    def test_unedited_photo_recovery_saves_and_restores_only_the_grade(self):
+        name = self.qualified('a.jpg')
+        original = server.catalog_entry_for(name)
+        code, result = self.run_journey()
+        self.assertEqual(code, 0, result)
+        self.assertTrue(all(result['result'].values()))
+        self.assertEqual(result['remainingDrafts'], 0)
+        self.assertEqual([state['grade']['exposure'] for state in result['writes']], [.321, 0])
+        for state in result['writes']:
+            self.assertEqual({key: value for key, value in state.items() if key != 'grade'},
+                             {key: value for key, value in original.items() if key != 'grade'})
+
+    def test_existing_film_edits_and_metadata_survive_the_recovery_journey(self):
+        name = self.qualified('a.jpg')
+        state, _ = server.cleaned_state_request({
+            'name': name, 'params': {'profile_enabled': False},
+            'grade': {'exposure': 1.25, 'contrast': .2},
+            'crop': {'x': .1, 'y': .2, 'w': .7, 'h': .6},
+            'rating': 4, 'keywords': ['Keep'],
+        }, strict=False)
+        server.save_image_state(name, state)
+        original = server.catalog_entry_for(name)
+        code, result = self.run_journey()
+        self.assertEqual(code, 0, result)
+        self.assertEqual(result['writes'][-1], original)
+        self.assertEqual(result['writes'][0]['grade']['exposure'], .321)
+
+    def test_recovery_still_rejects_a_success_response_without_a_saved_edit(self):
+        with mock.patch.object(server, 'save_image_states'):
+            code, result = self.run_journey()
+        self.assertNotEqual(code, 0)
+        self.assertEqual(result['error'], 'Recovered edit did not reach the catalog')

--- a/tests/test_native_shared_surface.py
+++ b/tests/test_native_shared_surface.py
@@ -1,0 +1,201 @@
+"""Exercise the real mmap-backed Metal texture and immutable lifetime contract."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(sys.platform == "darwin" and shutil.which("swiftc"), "requires macOS Metal")
+class NativeSharedSurfaceTests(unittest.TestCase):
+    def test_texture_reads_padded_rows_and_retains_mapping_after_unlink(self):
+        from multiprocessing import shared_memory
+        page = os.sysconf("SC_PAGE_SIZE")
+        segment = shared_memory.SharedMemory(create=True, size=page, name=f"lt-{os.getpid():x}-test")
+        segment.buf[:8] = bytes([0, 128, 255, 255, 255, 0, 64, 255])
+        segment.buf[256:264] = bytes([64, 128, 191, 255, 0, 0, 0, 255])
+        source = r'''
+import Darwin
+import MetalKit
+@main struct SharedSurfaceContract {
+    static func verifyRegionSampling(device: MTLDevice, library: MTLLibrary, shader: String) throws {
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.vertexFunction = library.makeFunction(name: "nativePreviewVertex")
+        descriptor.fragmentFunction = library.makeFunction(name: "nativePreviewFragment")
+        descriptor.colorAttachments[0].pixelFormat = .rgba8Unorm
+        let pipeline = try device.makeRenderPipelineState(descriptor: descriptor)
+        let queue = device.makeCommandQueue()!
+        let samplerDescriptor = MTLSamplerDescriptor()
+        samplerDescriptor.minFilter = .linear; samplerDescriptor.magFilter = .linear
+        samplerDescriptor.sAddressMode = .clampToEdge; samplerDescriptor.tAddressMode = .clampToEdge
+        let sampler = device.makeSamplerState(descriptor: samplerDescriptor)!
+        func texture(_ width: Int, _ height: Int, _ bytes: [UInt8]) -> MTLTexture {
+            let desc = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .rgba8Unorm,
+                width: width, height: height, mipmapped: false)
+            desc.usage = [.shaderRead, .renderTarget]; desc.storageMode = .shared
+            let result = device.makeTexture(descriptor: desc)!
+            bytes.withUnsafeBytes { source in
+                result.replace(region: MTLRegionMake2D(0, 0, width, height), mipmapLevel: 0,
+                    withBytes: source.baseAddress!, bytesPerRow: width * 4)
+            }
+            return result
+        }
+        var pixels = [UInt8]()
+        for index in 0..<16 { pixels += [UInt8(index * 13), UInt8(200-index*7), UInt8(index*9), 255] }
+        let full = texture(4, 4, pixels)
+        let cropPixels = Array(pixels[20..<28]) + Array(pixels[36..<44])
+        let tile = texture(2, 2, cropPixels)
+        let placeholder = texture(1, 1, [0, 0, 0, 0])
+        let structStart = shader.range(of: "struct GradeUniforms {")!.upperBound
+        let structEnd = shader.range(of: "};", range: structStart..<shader.endIndex)!.lowerBound
+        let fields = String(shader[structStart..<structEnd]).split(separator: "\n").compactMap { line -> String? in
+            let text = line.trimmingCharacters(in: .whitespaces)
+            guard text.hasPrefix("float4 ") else { return nil }
+            return String(text.dropFirst(7).prefix(while: { $0 != ";" }))
+        }
+        func render(_ image: MTLTexture, region: [Float]) -> [UInt8] {
+            var uniforms = [Float](repeating: 0, count: fields.count * 4)
+            func set(_ name: String, _ value: [Float]) {
+                let start = fields.firstIndex(of: name)! * 4
+                uniforms.replaceSubrange(start..<start+4, with: value)
+            }
+            set("viewport", [1, 1, 0, 0]); set("sourceRegion", region)
+            set("tone3", [0, 0.2, 0.25, 0.25]); set("optics1", [1, 0, 0, 1])
+            set("tone2", [0, 0, 0.2, 0.1]); set("detail0", [0.1, 1, 0.25, 0])
+            let target = texture(4, 4, [UInt8](repeating: 0, count: 64))
+            let pass = MTLRenderPassDescriptor()
+            pass.colorAttachments[0].texture = target
+            pass.colorAttachments[0].loadAction = .clear; pass.colorAttachments[0].storeAction = .store
+            let command = queue.makeCommandBuffer()!
+            let encoder = command.makeRenderCommandEncoder(descriptor: pass)!
+            encoder.setRenderPipelineState(pipeline)
+            encoder.setFragmentTexture(image, index: 0); encoder.setFragmentTexture(placeholder, index: 1)
+            encoder.setFragmentTexture(full, index: 2); encoder.setFragmentTexture(placeholder, index: 3)
+            encoder.setFragmentTexture(placeholder, index: 4); encoder.setFragmentTexture(full, index: 5)
+            encoder.setFragmentSamplerState(sampler, index: 0)
+            uniforms.withUnsafeBytes { encoder.setFragmentBytes($0.baseAddress!, length: $0.count, index: 0) }
+            let blank = [Float](repeating: 0, count: 32)
+            blank.withUnsafeBytes {
+                encoder.setFragmentBytes($0.baseAddress!, length: $0.count, index: 1)
+                encoder.setFragmentBytes($0.baseAddress!, length: $0.count, index: 2)
+            }
+            encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+            encoder.endEncoding(); command.commit(); command.waitUntilCompleted()
+            precondition(command.error == nil, "region sampling render failed")
+            var output = [UInt8](repeating: 0, count: 64)
+            target.getBytes(&output, bytesPerRow: 16, from: MTLRegionMake2D(0, 0, 4, 4), mipmapLevel: 0)
+            return output
+        }
+        let baseline = render(full, region: [1, 1, 0, 0])
+        let region = render(tile, region: [0.5, 0.5, 0.25, 0.25])
+        precondition(region == baseline, "tile plus fallback changed full-frame grade or neighbor sampling")
+        precondition(Set(region).count > 10, "render proof contains no image detail")
+    }
+
+    static func main() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { exit(77) }
+        let shader = try String(contentsOfFile: CommandLine.arguments[3], encoding: .utf8)
+        let library = try device.makeLibrary(source: shader, options: nil)
+        try verifyRegionSampling(device: device, library: library, shader: shader)
+        let length = Int(CommandLine.arguments[2])!
+        let description: [String: Any] = ["name": CommandLine.arguments[1],
+            "length": length, "rowBytes": 256, "offset": 0]
+        let surface = SharedNativeSurface(payload: description)!
+        let texture = try surface.texture(device: device, width: 2, height: 2)
+        precondition(texture.buffer != nil, "must retain the shared backing buffer")
+        precondition(shm_unlink(surface.name) == 0)
+        var pixels = [UInt8](repeating: 0, count: 16)
+        texture.getBytes(&pixels, bytesPerRow: 8,
+            from: MTLRegionMake2D(0, 0, 2, 2), mipmapLevel: 0)
+        precondition(pixels == [0,128,255,255,255,0,64,255,64,128,191,255,0,0,0,255])
+        precondition(SharedNativeSurface(payload: ["name": "/untrusted", "length": length,
+            "rowBytes": 256]) == nil)
+        precondition(SharedNativeSurface(payload: ["name": surface.name, "length": length,
+            "rowBytes": 255]) == nil)
+        do {
+            _ = try surface.texture(device: device, width: 128, height: 2)
+            fatalError("undersized row was accepted")
+        } catch {}
+    }
+}
+'''
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                harness = root / "SharedSurfaceContract.swift"
+                executable = root / "shared-surface-contract"
+                harness.write_text(source)
+                subprocess.run(["swiftc", "-swift-version", "5", "-module-cache-path",
+                                str(root / "module-cache"), str(ROOT / "app/NativePreview.swift"),
+                                str(harness), "-o", str(executable)], check=True,
+                               capture_output=True, text=True)
+                result = subprocess.run([str(executable), "/" + segment.name, str(page),
+                                         str(ROOT / "app/NativePreview.metal")],
+                                        capture_output=True, text=True)
+                if result.returncode == 77:
+                    self.skipTest("Metal device unavailable")
+                self.assertEqual(result.returncode, 0, result.stderr)
+        finally:
+            segment.close()
+            try:
+                segment.unlink()
+            except FileNotFoundError:
+                # The Swift harness owns the explicit unlink lifetime check.
+                from multiprocessing import resource_tracker
+                resource_tracker.unregister(segment._name, "shared_memory")
+
+    def test_viewport_window_is_bounded_and_accounts_for_pan(self):
+        script = (ROOT / "web/app.js").read_text()
+        start = script.index("function viewportPixelWindow(")
+        end = script.index("\nlet viewportRegionTimer", start)
+        result = subprocess.run(["node", "-e", script[start:end] + r'''
+const assert = require('node:assert/strict');
+const clip = {left:0,top:0,right:600,bottom:400};
+const full = {left:-1200,top:-900,right:1800,bottom:1100,width:3000,height:2000};
+const region = viewportPixelWindow(full,clip,3000,2000);
+assert.ok(region.x <= 1200 && region.y <= 900);
+assert.ok(region.x+region.width >= 1800 && region.y+region.height >= 1300);
+assert.ok(region.width < 900 && region.height < 700);
+const corner = viewportPixelWindow({left:0,top:0,right:3000,bottom:2000,width:3000,height:2000},clip,3000,2000);
+assert.equal(corner.x,0); assert.equal(corner.y,0);
+assert.equal(viewportPixelWindow({...full,width:0},clip,3000,2000),null);
+const all = viewportPixelWindow({left:0,top:0,right:400,bottom:300,width:400,height:300},clip,400,300);
+assert.deepEqual(all,{x:0,y:0,width:400,height:300});
+// Native ROI always uses original source pixels, even beyond the old 8000px
+// full-frame preview cap.
+function viewportRegionEnabled() { return true; }
+function cur() { return {width:10000,height:6000}; }
+function requestedPreviewWidth() { return 8000; }
+const S = {params:{rotate:0}};
+function $(id) { return {getBoundingClientRect: () => id === 'cv'
+  ? {left:-4000,top:-2000,right:6000,bottom:4000,width:10000,height:6000}
+  : clip}; }
+assert.equal(requestedViewportRegion().x,3904);
+S.viewportSourceGeometry = {key:viewportSourceGeometryKey(),width:12000,height:7200};
+assert.equal(requestedViewportRegion().x,4672);
+S.viewportSourceGeometry.key = 'different-photo';
+assert.equal(requestedViewportRegion().x,3904);
+'''], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_adaptive_interval_tracks_round_trips_without_cache_feedback(self):
+        script = (ROOT / "web/app.js").read_text()
+        start = script.index("function adaptiveInteractiveInterval(")
+        end = script.index("\nlet interactiveRenderIntervalMs", start)
+        result = subprocess.run(["node", "-e", script[start:end] + r'''
+const assert = require('node:assert/strict');
+assert.equal(adaptiveInteractiveInterval(null, 8), 1000 / 60);
+assert.equal(adaptiveInteractiveInterval(null, 60), 60);
+assert.equal(adaptiveInteractiveInterval(null, 900), 250);
+assert.equal(adaptiveInteractiveInterval(40, NaN), 40);
+let interval = 60;
+for (let i = 0; i < 20; i++) interval = adaptiveInteractiveInterval(interval, 8);
+assert.ok(interval < 17);
+interval = adaptiveInteractiveInterval(interval, 100);
+assert.ok(interval > 40 && interval < 45);
+'''], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -1169,7 +1169,16 @@ class PlatformProcessTests(unittest.TestCase):
         source = (ROOT / "server.py").read_text()
         self.assertIn("stderr=subprocess.DEVNULL, text=True, bufsize=1,\n"
                       "            **subprocess_flags())", source)
-        self.assertEqual(source.count("**subprocess_flags()"), 5)
+        with mock.patch.object(server, "IS_WINDOWS", True), \
+                mock.patch.object(server.subprocess, "run") as run, \
+                mock.patch.object(server.subprocess, "Popen") as popen:
+            server._run_export_process(["renderer"], {}, None)
+            self.assertEqual(run.call_args.kwargs["creationflags"], 0x08000000)
+            process = popen.return_value.__enter__.return_value
+            process.communicate.return_value = ("", "")
+            process.returncode = 0
+            server._run_export_process(["renderer"], {}, mock.Mock())
+            self.assertEqual(popen.call_args.kwargs["creationflags"], 0x08000000)
         self.assertIn("**_creation_flags()",
                       (ROOT / "render_cli.py").read_text())
 
@@ -1203,6 +1212,7 @@ class PlatformProcessTests(unittest.TestCase):
 
         engine = mock.Mock()
         engine.render.side_effect = render
+        engine.probe_input.return_value = False
         server._SHARED_INPUT_DISABLED.clear()
         try:
             with tempfile.TemporaryDirectory() as directory:
@@ -1210,7 +1220,8 @@ class PlatformProcessTests(unittest.TestCase):
                 source.write_bytes(b"cached input")
                 with mock.patch.object(server, "is_raw", return_value=True), \
                         mock.patch.object(server, "raw_shared_input", shared), \
-                        mock.patch.object(server, "RUST_ENGINE", engine), \
+                        mock.patch.object(server, "BACKGROUND_ENGINE", engine), \
+                        mock.patch.object(server, "file_key", return_value="source"), \
                         mock.patch.object(server, "tiff_for",
                                           return_value=source):
                     first = server._resident_render_full("frame.dng", {}, {})

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -180,10 +180,10 @@ class GenerationTests(unittest.TestCase):
         self.assertTrue(stale)
         self.assertFalse(current)
 
-    def test_prefetch_does_not_wait_for_the_render_lock(self):
+    def test_prefetch_does_not_wait_for_the_background_render_lock(self):
         lock = mock.Mock()
         lock.acquire.return_value = False
-        with mock.patch.object(server, "RENDER_LOCK", lock):
+        with mock.patch.object(server, "BACKGROUND_RENDER_LOCK", lock):
             with (
                 mock.patch.object(server, "is_raw", return_value=False),
                 mock.patch.object(server, "render_key", return_value="a" * 32),

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -253,6 +253,50 @@ class ResponsivePreviewTests(unittest.TestCase):
             with Image.open(helper) as image:
                 self.assertEqual(image.size, (256, 171))
 
+    def test_every_native_surface_offers_a_sampling_helper(self):
+        """Scopes, Auto tone, and the samplers read a WebGL helper texture.
+
+        A photo is rendered twice: an interactive preview and, once the view
+        settles, a wider full-resolution one. Both have to offer a helper. When
+        the response for the settled render omitted it, the browser was left
+        with no sampled pixels at all and every scope drew an empty canvas.
+        """
+        interactive, settled = 1100, 3000
+        with tempfile.TemporaryDirectory() as directory:
+            folder = Path(directory)
+            for width in (interactive, settled):
+                native = folder / f"render-{width}.rgba"
+                server.write_native_surface(
+                    native, np.zeros((120, width, 3), dtype=np.uint8))
+                response = server.preview_response(
+                    {"ms": 1}, "a" * 32, folder / "missing.jpg", native,
+                    cached=False, refining=False)
+                self.assertEqual(response["native"]["width"], width)
+                self.assertEqual(
+                    response.get("helper"),
+                    f"/api/render/helper?key={'a' * 32}",
+                    f"a {width}px native surface must offer a sampling helper",
+                )
+
+    def test_sampling_helper_cost_does_not_grow_with_the_settled_surface(self):
+        """The helper is always encoded at the sampling width, so serving one
+        for a full-resolution surface stays as cheap as the interactive one."""
+        with tempfile.TemporaryDirectory() as directory:
+            folder = Path(directory)
+            sizes = []
+            for width, height in ((1100, 874), (3000, 2382)):
+                native = folder / f"render-{width}.rgba"
+                helper = folder / f"render-{width}.jpg"
+                server.write_native_surface(
+                    native, np.full((height, width, 3), 127, dtype=np.uint8))
+                server.ensure_jpeg_surface(
+                    helper, native, server.NATIVE_BROWSER_HELPER_OUTPUT_WIDTH)
+                with Image.open(helper) as image:
+                    sizes.append(image.size)
+        self.assertEqual(sizes[0][0], server.NATIVE_BROWSER_HELPER_OUTPUT_WIDTH)
+        self.assertEqual(sizes[1][0], server.NATIVE_BROWSER_HELPER_OUTPUT_WIDTH)
+        self.assertEqual(sizes[0], sizes[1])
+
     def test_resampling_edits_fall_back_to_the_edited_image(self):
         with tempfile.TemporaryDirectory() as directory:
             cache = Path(directory)
@@ -831,6 +875,21 @@ process.stdout.write(JSON.stringify(states.map(nativePreviewCanDraw)));
         self.assertIn("preserveCanvasSize: true", helper)
         self.assertIn("forceWebGLDraw: true", helper)
         self.assertIn("generation,", helper)
+        # A response that carries no dedicated helper still presents a JPEG
+        # surface, and sampling falls back to it rather than going blind.
+        native_loader = self.javascript[
+            self.javascript.index("function setNativeBaseImage"):
+            self.javascript.index("function originalPreviewURL")
+        ]
+        self.assertIn("scheduleNativeHelper(render.helper || render.img, generation)",
+                      native_loader)
+        # Cancelling the pending helper when a render starts stranded the
+        # sampling surface, because the early return skips the generation bump.
+        render_preamble = self.javascript[
+            self.javascript.index("async function doRender("):
+            self.javascript.index("const my = ++S.seq;")
+        ]
+        self.assertNotIn("clearTimeout(nativeHelperTimer)", render_preamble)
         webgl_loader = self.javascript[
             self.javascript.index("function setWebGLBaseImage"):
             self.javascript.index(

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import time
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -1096,6 +1097,81 @@ class PlatformProcessTests(unittest.TestCase):
                 with self.subTest(name=name), self.assertRaises(ValueError):
                     server.clean_folder_name(name)
             self.assertEqual(server.clean_folder_name("Scans 2026"), "Scans 2026")
+
+    def test_windows_helper_processes_never_open_console_windows(self):
+        """The shell starts the server without a console, so every console
+        child (resident engine, one-shot exporter, render worker, git) would
+        otherwise pop a command window on the desktop."""
+        with mock.patch.object(server, "IS_WINDOWS", True):
+            self.assertEqual(server.subprocess_flags(),
+                             {"creationflags": 0x08000000})
+        with mock.patch.object(server, "IS_WINDOWS", False):
+            self.assertEqual(server.subprocess_flags(), {})
+        source = (ROOT / "server.py").read_text()
+        self.assertIn("stderr=subprocess.DEVNULL, text=True, bufsize=1,\n"
+                      "            **subprocess_flags())", source)
+        self.assertEqual(source.count("**subprocess_flags()"), 5)
+        self.assertIn("**_creation_flags()",
+                      (ROOT / "render_cli.py").read_text())
+
+    def test_shared_input_is_offered_on_windows_until_the_engine_refuses_it(self):
+        server._SHARED_INPUT_DISABLED.clear()
+        try:
+            with mock.patch.object(server.os, "name", "nt"):
+                self.assertTrue(server.shared_input_supported())
+            server.note_shared_input_failure(PermissionError("denied"))
+            self.assertTrue(server.shared_input_supported())
+            server.note_shared_input_failure(RuntimeError(
+                "shared RAW input is unavailable on this platform"))
+            self.assertFalse(server.shared_input_supported())
+        finally:
+            server._SHARED_INPUT_DISABLED.clear()
+
+    def test_full_render_latches_to_tiff_after_the_engine_refuses_shared_input(self):
+        calls = []
+
+        @contextmanager
+        def shared(*_args, **_kwargs):
+            calls.append("shared")
+            yield {"input_shm": "wnsm_test", "input_shm_len": 64,
+                   "input_cache_key": "source"}
+
+        def render(request):
+            if "input_shm" in request:
+                raise RuntimeError(
+                    "shared RAW input is unavailable on this platform")
+            return {"width": 2, "height": 1}
+
+        engine = mock.Mock()
+        engine.render.side_effect = render
+        server._SHARED_INPUT_DISABLED.clear()
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                source = Path(directory) / "input.tif"
+                source.write_bytes(b"cached input")
+                with mock.patch.object(server, "is_raw", return_value=True), \
+                        mock.patch.object(server, "raw_shared_input", shared), \
+                        mock.patch.object(server, "RUST_ENGINE", engine), \
+                        mock.patch.object(server, "tiff_for",
+                                          return_value=source):
+                    first = server._resident_render_full("frame.dng", {}, {})
+                    second = server._resident_render_full("frame.dng", {}, {})
+            self.assertEqual(first["input_transport"], "tiff-fallback")
+            self.assertEqual(second["input_transport"], "tiff")
+            self.assertEqual(calls, ["shared"])
+        finally:
+            server._SHARED_INPUT_DISABLED.clear()
+
+    def test_provenance_skips_git_outside_a_checkout(self):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(server.subprocess, "run") as run:
+            self.assertIsNone(server._git_revision(Path(directory)))
+            run.assert_not_called()
+        completed = mock.Mock(stdout="abc123\n")
+        with mock.patch.object(server.subprocess, "run",
+                               return_value=completed) as run:
+            self.assertEqual(server._git_revision(ROOT), "abc123")
+            run.assert_called_once()
 
 
 class EngineSelectionContractTests(unittest.TestCase):

--- a/tests/test_photo_tool_flow.py
+++ b/tests/test_photo_tool_flow.py
@@ -25,7 +25,7 @@ const pushUndo = () => counts.undo++;
 const saveState = () => counts.save++;
 const renderFilm = () => counts.render++;
 const refreshBaseEdits = () => counts.refresh++;
-const syncCropPresentationNow = noop, zoomReset = noop, applyView = noop;
+const syncCropPresentationNow = noop, zoomReset = noop, applyView = noop, applyViewNow = noop;
 const syncOpticsPanel = noop, syncMaskPanel = noop, syncControls = noop;
 const syncGrade = noop, drawGrade = noop, syncCurveFromGrade = noop, syncHsl = noop;
 const renderKeywords = noop, renderVersions = noop, refreshLists = noop, updateUndoRedoButtons = noop;
@@ -130,6 +130,10 @@ class PhotoToolFlowTests(unittest.TestCase):
         functions = [function(name) for name in (
             'snapshot', 'restore', 'filmRenderFingerprint', 'baseEditsFingerprint',
             'exitPhotoTool', 'selectPhotoTool', 'switchPane', 'setCropMode',
+            'cropViewState', 'cropViewPrefersImmediate', 'cropViewFrame', 'cropFitScale',
+            'cropViewTarget', 'cropViewBackgroundRGB', 'cropViewDimStyle', 'snapCropView',
+            'stepCropView', 'applyCropView', 'syncCropView', 'finishCropViewExit',
+            'cropViewTransition', 'cropViewWrapKey',
             'cropSourceSize', 'cropImageAspect', 'cropOutputRatio', 'cropLayerRatio',
             'clampCrop', 'previewCrop', 'previewSourceX', 'cropForRatio', 'syncCropPanel',
             'restoreCropChoices', 'rememberCropChoices', 'applyCropRatioChoice', 'setCropRatio',

--- a/tests/test_photos_library_import.py
+++ b/tests/test_photos_library_import.py
@@ -1,0 +1,77 @@
+"""Execute native import IO and first-run persistence without accessing Photos."""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(sys.platform == "darwin", "native Photos import is macOS-only")
+class PhotosLibraryImportTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        swiftc = shutil.which("swiftc")
+        if not swiftc:
+            raise unittest.SkipTest("swiftc is unavailable")
+        source = (ROOT / "app" / "main.swift").read_text()
+        importer = source[source.index("private final class PhotosLibraryImporter"):
+                          source.index("// MARK: - App\n")]
+        initialization = source[source.index("        let defaults = UserDefaults.standard"):
+                                source.index("        var isDir: ObjCBool = false", source.index("func applicationDidFinishLaunching"))]
+        launch = source[source.index("    private func launch(folder: String)"):]
+        persistence = launch[launch.index("        let automated ="):
+                             launch.index("        window.title =")]
+
+        def method(name):
+            start = source.index(f"    private func {name}(")
+            end = source.index("\n    }", start) + len("\n    }")
+            return source[start:end]
+
+        methods = "\n\n".join(method(name) for name in (
+            "finishFirstRun", "loadSources", "saveSources", "addSource",
+            "normalized", "isDirectory", "sourcePayload", "replaySetupEvents",
+            "completeSetupCatalogImport",
+        ))
+
+        def isolate(body):
+            # Execute the actual control flow with disposable inputs. Only
+            # process-global defaults/environment are replaced by test fields.
+            return body.replace("UserDefaults.standard", "self.defaults").replace(
+                "ProcessInfo.processInfo.environment", "self.environment")
+
+        harness = (ROOT / "tests" / "fixtures" / "photos-library-import.swift").read_text()
+        for placeholder, implementation in (
+            ("IMPORTER_SOURCE", importer),
+            ("INITIALIZATION_SOURCE", isolate(initialization)),
+            ("STARTUP_PERSISTENCE_SOURCE", isolate(persistence)),
+            ("FIRST_RUN_METHODS", isolate(methods)),
+        ):
+            harness = harness.replace(placeholder, implementation)
+        cls.temporary = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls.temporary.cleanup)
+        directory = Path(cls.temporary.name)
+        swift_file = directory / "main.swift"
+        swift_file.write_text(harness)
+        cls.executable = directory / "photos-import-test"
+        result = subprocess.run([
+            swiftc, "-swift-version", "5", "-module-cache-path",
+            str(directory / "module-cache"), str(swift_file), "-o", str(cls.executable),
+        ], capture_output=True, text=True, timeout=120)
+        if result.returncode:
+            raise AssertionError(result.stdout + result.stderr)
+
+    def run_fixture(self, scenario):
+        result = subprocess.run([str(self.executable), scenario], capture_output=True,
+                                text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PASS:", result.stdout)
+
+    def test_streamed_originals_retry_cancellation_and_concurrent_imports(self):
+        self.run_fixture("importer")
+
+    def test_first_run_detection_persistence_and_navigation_replay(self):
+        self.run_fixture("first-run")

--- a/tests/test_raw_decode_runtime.py
+++ b/tests/test_raw_decode_runtime.py
@@ -1,0 +1,74 @@
+from enum import Enum
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+import raw_decode_runtime
+
+
+class RawDecodeRuntimeTests(unittest.TestCase):
+    def runtimes(self, *, xtrans=False):
+        class Error(Exception):
+            pass
+        class NativeError(Exception):
+            pass
+        stock_raw = mock.MagicMock()
+        stock_raw.__enter__.return_value = stock_raw
+        accelerated_raw = mock.MagicMock(is_xtrans=xtrans)
+        accelerated_raw.__enter__.return_value = accelerated_raw
+        stock = SimpleNamespace(imread=mock.Mock(return_value=stock_raw),
+                                LibRawError=Error)
+        accelerated = SimpleNamespace(imread=mock.Mock(return_value=accelerated_raw),
+                                      LibRawError=NativeError)
+        return stock, accelerated, stock_raw, accelerated_raw
+
+    def test_bayer_uses_one_header_and_parallel_decoder(self):
+        stock, accelerated, _, raw = self.runtimes()
+        with mock.patch.object(raw_decode_runtime.importlib, "import_module",
+                               side_effect=[stock, accelerated]):
+            with raw_decode_runtime.open_raw("photo.dng") as result:
+                self.assertEqual(result, (raw, accelerated))
+        stock.imread.assert_not_called()
+        accelerated.imread.assert_called_once_with("photo.dng")
+        raw.__exit__.assert_called_once()
+
+    def test_xtrans_closes_probe_and_preserves_stock_decoder(self):
+        stock, accelerated, stock_raw, probe = self.runtimes(xtrans=True)
+        with mock.patch.object(raw_decode_runtime.importlib, "import_module",
+                               side_effect=[stock, accelerated]):
+            with raw_decode_runtime.open_raw("photo.raf") as result:
+                self.assertEqual(result, (stock_raw, stock))
+                probe.close.assert_called_once()
+                probe.unpack.assert_not_called()
+        stock_raw.__exit__.assert_called_once()
+
+    def test_optional_accelerator_absence_keeps_portable_path(self):
+        stock, _, raw, _ = self.runtimes()
+        with mock.patch.object(raw_decode_runtime.importlib, "import_module",
+                               side_effect=[stock, ImportError("not installed")]):
+            with raw_decode_runtime.open_raw("photo.dng") as result:
+                self.assertEqual(result, (raw, stock))
+
+    def test_translate_native_exception_to_existing_public_error(self):
+        stock, accelerated, _, _ = self.runtimes()
+        with mock.patch.object(raw_decode_runtime.importlib, "import_module",
+                               side_effect=[stock, accelerated]):
+            with self.assertRaisesRegex(stock.LibRawError, "decode failed"):
+                with raw_decode_runtime.open_raw("photo.dng"):
+                    raise accelerated.LibRawError("decode failed")
+
+    def test_options_preserve_values_across_extension_enum_classes(self):
+        class ColorSpace(Enum):
+            ProPhoto = 4
+        NativeColorSpace = Enum("ColorSpace", {"ProPhoto": 4})
+        options = {"output_color": ColorSpace.ProPhoto, "gamma": (1, 1),
+                   "half_size": True}
+        converted = raw_decode_runtime.native_options(
+            options, SimpleNamespace(ColorSpace=NativeColorSpace))
+        self.assertIs(converted["output_color"], NativeColorSpace.ProPhoto)
+        self.assertEqual(converted["gamma"], (1, 1))
+        self.assertTrue(converted["half_size"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remaining_performance.py
+++ b/tests/test_remaining_performance.py
@@ -1,0 +1,259 @@
+"""Behavioral contracts for cold decoding, disposable writes and engine isolation."""
+import http.client
+import io
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from PIL import Image, ImageCms
+import color_pipeline
+import durable_io
+import platform_image
+import server
+
+
+class ColdPreviewTests(unittest.TestCase):
+    def test_raw_input_and_match_share_one_embedded_decode_and_invalidate_on_change(self):
+        import rawpy
+        buffer = io.BytesIO()
+        Image.new("RGB", (4000, 3000), (90, 140, 180)).save(buffer, "JPEG")
+        thumb = mock.Mock(format=rawpy.ThumbFormat.JPEG, data=buffer.getvalue())
+        raw = mock.MagicMock()
+        raw.__enter__.return_value.extract_thumb.return_value = thumb
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "frame.nef"
+            source.write_bytes(b"raw")
+            with mock.patch.object(rawpy, "imread", return_value=raw) as decode:
+                first = color_pipeline.raw_embedded_preview(source, 1100)
+                before = color_pipeline.raw_embedded_preview(source, 1600)
+                self.assertEqual(first.shape, (825, 1100, 3))
+                self.assertEqual(before.shape, (1200, 1600, 3))
+                self.assertEqual(decode.call_count, 1)
+                self.assertLess(abs(float(first.mean()) - float(before.mean())), 1)
+                source.write_bytes(b"raw changed")
+                color_pipeline.raw_embedded_preview(source, 1100)
+                self.assertEqual(decode.call_count, 2)
+
+    def test_processed_draft_preserves_orientation_and_color_without_full_tiff(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "portrait.jpg"
+            exif = Image.Exif(); exif[274] = 6
+            profile = ImageCms.ImageCmsProfile(ImageCms.createProfile("sRGB")).tobytes()
+            Image.new("RGB", (4000, 3000), (80, 140, 200)).save(source, exif=exif, icc_profile=profile)
+            with mock.patch.object(platform_image, "convert_processed_to_tiff", side_effect=AssertionError("full decode")):
+                image = platform_image.processed_preview(source, 600, app_root=server.APP, output_space="srgb")
+            self.assertEqual(image.shape, (800, 600, 3))
+            np.testing.assert_allclose(image[0, 0], np.array([80, 140, 200]) / 255, atol=2/255)
+
+    def test_cache_publication_is_atomic_but_durable_writes_still_fsync(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "cache.json"
+            path.write_bytes(b"old")
+            with mock.patch.object(durable_io.os, "fsync") as flush:
+                durable_io.cache_write_json(path, {"ready": True})
+                flush.assert_not_called()
+                durable_io.atomic_write_json(path, {"state": True})
+                self.assertGreaterEqual(flush.call_count, 2)
+            with mock.patch.object(durable_io.os, "replace", side_effect=OSError("interrupted")):
+                with self.assertRaises(OSError):
+                    durable_io.cache_write_json(path, {"partial": True})
+            self.assertEqual(durable_io.load_json(path, {}), {"state": True})
+            self.assertFalse(list(Path(directory).glob(".*.cache.*")))
+
+    def test_incomplete_generated_images_are_discarded(self):
+        import tifffile
+        with tempfile.TemporaryDirectory() as directory:
+            tiff = Path(directory) / "preview.tif"
+            jpeg = Path(directory) / "before.jpg"
+            tifffile.imwrite(tiff, np.zeros((10, 20, 3), dtype=np.uint16))
+            Image.new("RGB", (20, 10)).save(jpeg)
+            self.assertTrue(server.valid_tiff_cache(tiff))
+            self.assertTrue(server.valid_jpeg_cache(jpeg))
+            tiff.write_bytes(tiff.read_bytes()[:-20])
+            jpeg.write_bytes(jpeg.read_bytes()[:-20])
+            self.assertFalse(server.valid_tiff_cache(tiff))
+            self.assertFalse(server.valid_jpeg_cache(jpeg))
+            self.assertFalse(tiff.exists())
+            self.assertFalse(jpeg.exists())
+
+    def test_warmup_executes_native_pipeline_and_removes_scratch_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            engine = server.RustEngineClient(Path("worker"))
+            with mock.patch.object(server, "CACHE", Path(directory)), mock.patch.object(engine, "render") as render:
+                engine.warm()
+            render.assert_called_once()
+            request = render.call_args.args[0]
+            self.assertIn("native_output", request)
+            self.assertNotIn("output", request)
+            self.assertNotIn("command", request)
+            self.assertFalse(Path(request["input"]).exists())
+
+    def test_catalog_lens_identity_avoids_metadata_process_until_correction_enabled(self):
+        cat = mock.Mock()
+        cat.image_row.return_value = {"camera_make": "Canon", "camera_model": "EOS R", "lens": "RF 50mm"}
+        with mock.patch.object(server, "catalog_handle", return_value=cat), mock.patch.object(server, "catalog_image_id", return_value=1), mock.patch.object(server, "exif_for", return_value={"FocalLength": "50 mm"}) as exif:
+            self.assertEqual(server.preview_lens_metadata("1:frame.cr3")["LensModel"], "RF 50mm")
+            exif.assert_not_called()
+            self.assertEqual(server.preview_lens_metadata("1:frame.cr3", {"profileEnabled": True})["FocalLength"], "50 mm")
+
+
+class BackgroundEngineTests(unittest.TestCase):
+    def test_export_probe_hit_does_not_decode_again(self):
+        engine = mock.Mock()
+        engine.probe_input.return_value = True
+        engine.render.return_value = {"width": 10, "height": 8}
+        with mock.patch.object(server, "BACKGROUND_ENGINE", engine), mock.patch.object(server, "is_raw", return_value=True), mock.patch.object(server, "file_key", return_value="source"), mock.patch.object(server, "raw_shared_input") as decode:
+            result = server._resident_render_full("frame.dng", {}, {})
+        decode.assert_not_called()
+        self.assertEqual(result["input_transport"], "resident-cache")
+        self.assertIn("input_cache_key", engine.render.call_args.args[0])
+
+    def test_background_request_runs_while_interactive_admission_is_held(self):
+        engine = server.RustEngineClient(Path("worker"), lock=server.BACKGROUND_RENDER_LOCK)
+        process = mock.Mock(stdin=io.StringIO(), stdout=io.StringIO())
+        done = threading.Event()
+        errors = []
+        def render():
+            try:
+                engine.render({})
+            except Exception as error:
+                errors.append(error)
+            finally:
+                done.set()
+        with mock.patch.object(engine, "_start", return_value=process), mock.patch.object(engine, "_readline", return_value='{"ok":true}'):
+            with server.RENDER_LOCK:
+                worker = threading.Thread(target=render)
+                worker.start()
+                self.assertTrue(done.wait(2), "export still shares interactive lock")
+            worker.join(2)
+        self.assertEqual(errors, [])
+
+    def test_keep_alive_reuses_the_same_http_connection(self):
+        class Handler(server.Handler):
+            def do_GET(self):
+                self._json({"ok": True})
+        httpd = server.LightTableServer(("127.0.0.1", 0), Handler)
+        worker = threading.Thread(target=httpd.serve_forever, daemon=True)
+        worker.start()
+        connection = http.client.HTTPConnection(*httpd.server_address, timeout=3)
+        try:
+            connection.request("GET", "/")
+            response = connection.getresponse()
+            self.assertEqual(response.version, 11)
+            response.read()
+            socket = connection.sock
+            connection.request("GET", "/")
+            self.assertEqual(connection.getresponse().read(), b'{"ok": true}')
+            self.assertIs(connection.sock, socket)
+        finally:
+            connection.close()
+            httpd.shutdown(); httpd.server_close(); worker.join(2)
+
+
+class DecodedViewportTests(unittest.TestCase):
+    def test_edge_clipping_uses_rotated_decoded_pixels_without_rescaling(self):
+        for quarters in range(4):
+            with self.subTest(quarters=quarters):
+                width, height = ((100, 60) if quarters % 2 == 0 else (60, 100))
+                requested = {"x": width - 20, "y": height - 10, "width": 40, "height": 30}
+                actual = server.clamp_decoded_viewport(requested, 100, 60, quarters)
+                self.assertEqual(actual, {"x": width - 20, "y": height - 10,
+                                          "width": 20, "height": 10})
+                self.assertEqual(requested["width"], 40, "cache identity input was mutated")
+                self.assertEqual(server.clamp_decoded_viewport(actual, 100, 60, quarters), actual)
+        self.assertEqual(server.clamp_decoded_viewport(
+            {"x": 1000, "y": 1000, "width": 40, "height": 30}, 100, 60, 0),
+            {"x": 99, "y": 59, "width": 1, "height": 1})
+
+    def test_resident_probe_supplies_dimensions_before_edge_render(self):
+        engine = mock.Mock()
+        engine.render.side_effect = [
+            {"input_cache_hit": True, "width": 10, "height": 6},
+            {"width": 2, "height": 2, "full_width": 10, "full_height": 6},
+        ]
+        requested = {"x": 8, "y": 4, "width": 8, "height": 6}
+        with mock.patch.object(server, "preview_engine", return_value=engine), \
+                mock.patch.object(server, "file_key", return_value="source"), \
+                mock.patch.object(server, "raw_shared_input") as decode:
+            result = server.render_viewport_rust("frame.dng", {}, None, Path("unused.rgba"), requested)
+        decode.assert_not_called()
+        self.assertEqual(engine.render.call_args_list[0].args[0]["command"], "probe_input")
+        request = engine.render.call_args_list[1].args[0]
+        self.assertEqual(request["viewport"], {"x": 8, "y": 4, "width": 2, "height": 2})
+        self.assertEqual(result["viewport"], request["viewport"])
+        self.assertNotIn("input", request)
+        self.assertEqual(requested["width"], 8)
+
+    def test_first_raw_decode_exposes_actual_dimensions_without_a_second_decode(self):
+        from contextlib import contextmanager
+        pixels = np.zeros((6, 10, 3), dtype=np.uint16)
+        @contextmanager
+        def shared_array(rgb, key):
+            self.assertEqual(rgb.shape, (6, 10, 3))
+            yield {"input_shm": "test-only", "input_shm_len": 376, "input_cache_key": key}
+        engine = mock.Mock()
+        engine.render.side_effect = [
+            {"input_cache_hit": False},
+            {"width": 2, "height": 2, "full_width": 6, "full_height": 10},
+        ]
+        with mock.patch.object(server, "preview_engine", return_value=engine), \
+                mock.patch.object(server, "file_key", return_value="source"), \
+                mock.patch.object(server, "src_path", return_value=Path("frame.dng")), \
+                mock.patch.object(server.color_pipeline, "decode_raw", return_value=pixels) as decode, \
+                mock.patch.object(server, "array_shared_input", side_effect=shared_array):
+            result = server.render_viewport_rust("frame.dng", {"rotate": 90}, None,
+                Path("unused.rgba"), {"x": 4, "y": 8, "width": 6, "height": 8})
+        decode.assert_called_once()
+        request = engine.render.call_args_list[1].args[0]
+        self.assertEqual(request["rotate_quarters_ccw"], 3)
+        self.assertEqual(request["viewport"], {"x": 4, "y": 8, "width": 2, "height": 2})
+        self.assertEqual(result["viewport"], request["viewport"])
+        self.assertNotIn("input_width", request, "Python metadata escaped into worker protocol")
+        self.assertNotIn("input_height", request)
+
+    def test_processed_tiff_header_clamps_first_rotated_edge_without_reading_pixels(self):
+        import tifffile as tf
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "decoded.tif"
+            tf.imwrite(path, np.zeros((6, 10, 3), dtype=np.uint16))
+            engine = mock.Mock()
+            engine.render.return_value = {"width": 2, "height": 2, "full_width": 6, "full_height": 10}
+            with mock.patch.object(server, "preview_engine", return_value=engine), \
+                    mock.patch.object(server, "tiff_for", return_value=path), \
+                    mock.patch.object(tf.TiffPage, "asarray", side_effect=AssertionError("full TIFF read")):
+                result = server.render_viewport_rust("frame.jpg", {"rotate": 270}, None,
+                    Path("unused.rgba"), {"x": 4, "y": 8, "width": 20, "height": 20})
+            request = engine.render.call_args.args[0]
+            self.assertEqual(request["rotate_quarters_ccw"], 1)
+            self.assertEqual(request["input"], str(path))
+            self.assertEqual(result["viewport"], {"x": 4, "y": 8, "width": 2, "height": 2})
+
+    def test_clipped_delivery_geometry_survives_render_cache_hit(self):
+        requested = {"x": 8, "y": 4, "width": 8, "height": 6}
+        actual = {"x": 8, "y": 4, "width": 2, "height": 2}
+        def render(name, params, width, output, native, viewport):
+            self.assertEqual(viewport, requested)
+            native.parent.mkdir(parents=True, exist_ok=True)
+            server.write_native_surface(native, np.zeros((2, 2, 3), dtype=np.uint8))
+            return {"mean": 0.5, "width": 2, "height": 2, "full_width": 10, "full_height": 6,
+                    "viewport": actual, "viewport_accelerated": True, "backend": "test"}
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(server, "CACHE", Path(directory)), \
+                mock.patch.object(server, "RUST_AVAILABLE", True), \
+                mock.patch.object(server, "file_key", return_value="source"), \
+                mock.patch.object(server, "prune_render_cache_throttled"), \
+                mock.patch.object(server, "render_rust", side_effect=render) as worker:
+            first = server._render_preview("frame.dng", {"profile_enabled": True}, 1100,
+                engine="rs", native=True, viewport=requested)
+            second = server._render_preview("frame.dng", {"profile_enabled": True}, 1100,
+                engine="rs", native=True, viewport=requested)
+        worker.assert_called_once()
+        self.assertFalse(first["cached"])
+        self.assertTrue(second["cached"])
+        self.assertEqual(first["native"]["viewport"], dict(actual, fullWidth=10, fullHeight=6))
+        self.assertEqual(second["native"]["viewport"], first["native"]["viewport"])
+        self.assertEqual(first["key"], second["key"])
+        self.assertEqual(requested, {"x": 8, "y": 4, "width": 8, "height": 6})

--- a/tests/test_scope_sampling.py
+++ b/tests/test_scope_sampling.py
@@ -1,0 +1,16 @@
+"""Run the scope and sampling-helper regressions in the Python CI suite."""
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+@unittest.skipUnless(shutil.which('node'), 'Node.js required')
+class ScopeSamplingTests(unittest.TestCase):
+    def test_scopes_and_sampling_helper(self):
+        test_file = Path(__file__).with_name('scope-sampling.test.mjs')
+        result = subprocess.run(
+            ['node', '--test', str(test_file)],
+            capture_output=True, text=True, timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/test_server_catalog.py
+++ b/tests/test_server_catalog.py
@@ -877,7 +877,8 @@ class PayloadAndCacheTests(CatalogServerTestCase):
         (cache / "tiff").mkdir(parents=True)
         target = cache / "tiff" / (
             f"v{server.INPUT_CACHE_VERSION}_key_romm.tif")
-        target.write_bytes(b"previous complete cache")
+        Image.new("RGB", (8, 6), (120, 90, 60)).save(target, "TIFF")
+        previous = target.read_bytes()
         os.utime(target, (1, 1))
 
         def fail_after_partial(_source, output, **_kwargs):
@@ -893,7 +894,7 @@ class PayloadAndCacheTests(CatalogServerTestCase):
             with self.assertRaises(OSError):
                 server.tiff_for(self.qualified("a.jpg"))
 
-        self.assertEqual(target.read_bytes(), b"previous complete cache")
+        self.assertEqual(target.read_bytes(), previous)
         self.assertEqual(list((cache / "tiff").glob(".*.decode.*")), [])
 
 

--- a/tests/test_thumbnail_warmup.py
+++ b/tests/test_thumbnail_warmup.py
@@ -1,0 +1,83 @@
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import catalog
+import catalog_scan
+from thumbnail_warmup import ThumbnailWarmup
+
+
+class ThumbnailWarmupTests(unittest.TestCase):
+    def test_scan_callback_observes_committed_rows_and_includes_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "photo.dng").write_bytes(b"test source")
+            cat = catalog.Catalog(root / "library.sqlite3")
+            self.addCleanup(cat.close)
+            source = cat.add_source(root)
+            seen = []
+
+            def queued(source_id, relpath):
+                self.assertFalse(cat.connection.in_transaction)
+                self.assertIsNotNone(cat.image_id_for(source_id, relpath))
+                seen.append(relpath)
+
+            for _ in range(2):
+                result = catalog_scan.scan_source(
+                    cat, source, read_metadata_for_new=False,
+                    on_local_file=queued)
+                self.assertTrue(result["complete"])
+            self.assertEqual(seen, ["photo.dng", "photo.dng"])
+
+    def test_busy_queue_is_bounded_deduplicated_and_cancellable(self):
+        built = mock.Mock()
+        worker = ThumbnailWarmup(built, busy=lambda: True,
+                                 capacity=2, interval=0.001)
+        self.addCleanup(worker.cancel)
+        self.assertTrue(worker.enqueue(1, "a.dng"))
+        self.assertFalse(worker.enqueue(1, "a.dng"))
+        self.assertTrue(worker.enqueue(1, "b.dng"))
+        self.assertFalse(worker.enqueue(1, "c.dng"))
+        thread = worker._thread
+        worker.cancel()
+        thread.join(1)
+        self.assertFalse(thread.is_alive())
+        built.assert_not_called()
+        self.assertFalse(worker.enqueue(1, "d.dng"))
+
+    def test_failed_decode_does_not_starve_following_thumbnail(self):
+        finished = threading.Event()
+        names = []
+
+        def build(name):
+            names.append(name)
+            if name.endswith("bad.dng"):
+                raise ValueError("bad image")
+            finished.set()
+
+        worker = ThumbnailWarmup(build, interval=0.005)
+        self.addCleanup(worker.cancel)
+        worker.enqueue(3, "bad.dng")
+        worker.enqueue(3, "good.dng")
+        self.assertTrue(finished.wait(1))
+        worker.cancel()
+        self.assertEqual(names, ["3:bad.dng", "3:good.dng"])
+
+    def test_busy_worker_expires(self):
+        built = mock.Mock()
+        worker = ThumbnailWarmup(built, busy=lambda: True,
+                                 interval=0.001, lifetime=0.01)
+        self.addCleanup(worker.cancel)
+        worker.enqueue(1, "a.dng")
+        thread = worker._thread
+        thread.join(1)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(list(worker._queue), [])
+        built.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -101,6 +101,54 @@ class WindowsSigningContractTests(unittest.TestCase):
         self.assertIn('authenticode_signed = [bool]$SigningEnabled', build)
 
 
+class WindowsRuntimeLaunchContractTests(unittest.TestCase):
+    """The embedded runtime's ``python313._pth`` implies isolated mode, so the
+    interpreter ignores every ``PYTHON*`` variable. Settings that matter must
+    travel as interpreter options, and nothing may write into the install tree
+    because the uninstaller removes only the files it shipped."""
+
+    def test_desktop_shell_launches_python_with_explicit_options(self):
+        shell = (ROOT / "windows-shell/src/main.rs").read_text()
+        self.assertIn('.arg("-u")', shell)
+        self.assertIn('.arg(format!("pycache_prefix={}", bytecode.display()))', shell)
+        self.assertNotIn("PYTHONDONTWRITEBYTECODE", shell)
+        self.assertIn('command.env("NUMBA_CACHE_DIR", paths.cache.join("compiled-runtime"))', shell)
+        self.assertIn('WebContext::new(Some(paths.support.join("WebView2")))', shell)
+        self.assertIn(".with_theme(Some(Theme::Dark))", shell)
+        self.assertIn(".with_background_color(BACKGROUND)", shell)
+
+    def test_desktop_shell_starts_servers_off_the_ui_thread_after_stopping_the_last(self):
+        shell = (ROOT / "windows-shell/src/main.rs").read_text()
+        begin = shell.index("fn begin_server(")
+        self.assertLess(shell.index("previous.stop();", begin),
+                        shell.index("ServerController::start(&paths, &folder)", begin))
+        self.assertIn("thread::spawn(move || {", shell[begin:])
+        self.assertIn("load_html(LOADING_PAGE)", shell[begin:])
+        self.assertIn("if generation != self.launch_generation {", shell)
+        self.assertIn("self.queued = Some(folder);", shell)
+
+    def test_explorer_and_default_application_launches_do_not_flash_consoles(self):
+        shell = (ROOT / "windows-shell/src/main.rs").read_text()
+        self.assertIn('.raw_arg(format!("/select,\\"{}\\"", path.display()))', shell)
+        self.assertNotIn('Command::new("explorer.exe")\n        .arg(format!("/select,{}"', shell)
+        self.assertIn('.args(["/C", "start", "", path])\n            .creation_flags(CREATE_NO_WINDOW)', shell)
+
+    def test_cli_wrapper_caches_bytecode_outside_the_installation(self):
+        wrapper = (ROOT / "scripts/windows/lighttable.cmd").read_text()
+        self.assertIn('-X "pycache_prefix=%LIGHTTABLE_BYTECODE%"', wrapper)
+        self.assertNotIn(" -B ", wrapper)
+        self.assertIn(r"%LOCALAPPDATA%\LightTable\python-bytecode", wrapper)
+
+    def test_resident_engine_reads_windows_named_file_mappings(self):
+        engine = (ROOT / "rust-engine/src/main.rs").read_text()
+        self.assertIn("#[cfg(windows)]\nfn load_shared_input", engine)
+        for symbol in ("OpenFileMappingW", "MapViewOfFile", "UnmapViewOfFile",
+                       "VirtualQuery", "CloseHandle"):
+            self.assertIn(symbol, engine)
+        self.assertIn("#[cfg(not(any(unix, windows)))]\nfn load_shared_input", engine)
+        self.assertIn("#[cfg(all(test, windows))]\nmod windows_shared_input_tests", engine)
+
+
 @unittest.skipUnless(shutil.which("pwsh") or shutil.which("powershell"), "PowerShell is required")
 class WindowsSigningGateTests(unittest.TestCase):
     def invoke(self, script, *arguments, certificate=None, password=None):

--- a/thumbnail_warmup.py
+++ b/thumbnail_warmup.py
@@ -1,0 +1,89 @@
+"""Bounded, disposable source-thumbnail work; never joins the catalog scan."""
+
+from __future__ import annotations
+
+from collections import deque
+import ctypes
+import sys
+import threading
+import time
+from typing import Callable
+
+
+class ThumbnailWarmup:
+    """One background decoder with a bounded queue and cooperative cancellation.
+
+    The on-demand thumbnail route remains authoritative. A full queue drops
+    speculative work, and an idle worker exits instead of retaining a thread.
+    Individual decodes cannot be interrupted; cancellation discards queued work.
+    """
+
+    def __init__(self, build: Callable[[str], object], *,
+                 busy: Callable[[], bool] = lambda: False,
+                 capacity: int = 256, interval: float = 0.05,
+                 lifetime: float = 1800):
+        self._build = build
+        self._busy = busy
+        self._capacity = max(1, int(capacity))
+        self._interval = max(0.001, float(interval))
+        self._lifetime = max(0.001, float(lifetime))
+        self._queue: deque[str] = deque()
+        self._pending: set[str] = set()
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def enqueue(self, source_id: int, relpath: str) -> bool:
+        name = f"{source_id}:{relpath}"
+        with self._lock:
+            if self._stop.is_set() or name in self._pending \
+                    or len(self._queue) >= self._capacity:
+                return False
+            self._queue.append(name)
+            self._pending.add(name)
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run, name="lighttable-thumbnail-warmup",
+                    daemon=True)
+                self._thread.start()
+        return True
+
+    def cancel(self) -> None:
+        """Permanently stop accepting work and discard queued thumbnails."""
+        self._stop.set()
+        with self._lock:
+            self._queue.clear()
+            self._pending.clear()
+
+    def _run(self) -> None:
+        if sys.platform == "darwin":
+            try:
+                # Apply QoS to this thread only; os.nice would demote the UI too.
+                set_qos = ctypes.CDLL(None).pthread_set_qos_class_self_np
+                set_qos.argtypes = [ctypes.c_uint, ctypes.c_int]
+                set_qos.restype = ctypes.c_int
+                set_qos(0x09, 0)  # QOS_CLASS_BACKGROUND
+            except (AttributeError, OSError):
+                pass
+        deadline = time.monotonic() + self._lifetime
+        while time.monotonic() < deadline and not self._stop.wait(self._interval):
+            if self._busy():
+                continue
+            with self._lock:
+                if not self._queue:
+                    self._thread = None
+                    return
+                name = self._queue.popleft()
+            try:
+                self._build(name)
+            except Exception:
+                # Unavailable/corrupt sources must not stop grid fill; an
+                # explicit request will report its normal source error later.
+                pass
+            finally:
+                with self._lock:
+                    self._pending.discard(name)
+        with self._lock:
+            self._queue.clear()
+            self._pending.clear()
+            self._thread = None

--- a/web/app.js
+++ b/web/app.js
@@ -32,6 +32,7 @@ import { createSurvey } from '/web/survey.js';
 import { createHistoryPanel } from '/web/history-panel.js';
 import { createMetadataPanel } from '/web/metadata-panel.js';
 import { createCatalogUI } from '/web/catalog-ui.js';
+import { installFirstRunSetup } from '/web/first-run.js';
 import { installRecovery } from '/web/recovery.js';
 import {
   initMidi, setMidiLearnTarget, toggleMidiLearn, resetMidiMappings,
@@ -45,6 +46,7 @@ let SURVEY = null;
 let HISTORY = null;
 let METADATA = null;
 let CATALOG_UI = null;
+let FIRST_RUN = null;
 let RECOVERY = null;
 let CAPTURE_TIME = null;
 let UI_BRIDGE = null;
@@ -6962,6 +6964,7 @@ async function initializeEditRecovery(data) {
 
 /* ------------------------------------------------------------------ boot */
 fetch('/api/images').then((r) => r.json()).then(async (d) => {
+  FIRST_RUN?.setLibrary(d);
   S.rootFolder = d.folder;
   S.catalogEnabled = !!d.catalog?.enabled;
   S.catalogTotal = Number.isFinite(+d.total) ? +d.total : 0;
@@ -10082,6 +10085,7 @@ async function savePrefs() {
 });
 fetch('/api/prefs').then((r) => r.json()).then((p) => {
   p = p && typeof p === 'object' ? p : {};
+  FIRST_RUN?.setPrefs(p);
   const migrated = {};
   if (!Object.prototype.hasOwnProperty.call(p, 'keyScheme') &&
       localStorage.getItem('lt.keyScheme')) {
@@ -10303,6 +10307,8 @@ CATALOG_UI = createCatalogUI({
   get: getJSON,
   toast,
   sendNative,
+  onCatalogImportCompleted: (result) => FIRST_RUN?.catalogCompleted(result),
+  onCatalogImportClosed: () => FIRST_RUN?.catalogClosed(),
   selection: () => (S.msel.size ? [...S.msel] : (cur() ? [cur().name] : [])),
   onLibraryChanged: () => { reloadLibrary(); },
   onWatchArrival: async (status) => {
@@ -10555,6 +10561,7 @@ if ($('enhanceRun')) {
 /* ------------------------------------------------------- native messages */
 const _origNativeEvent = window.lightTableNativeEvent;
 window.lightTableNativeEvent = function (message) {
+  FIRST_RUN?.nativeEvent(message);
   if (message && message.type === 'openLibraryHealth') {
     RECOVERY?.open();
     return;
@@ -10897,4 +10904,14 @@ installSettings({
       .map((image) => image.name);
   },
   toast,
+});
+
+FIRST_RUN = installFirstRunSetup({
+  el: $, post: api, sendNative, nativeBridge, reloadLibrary,
+  onComplete: () => {
+    S.includeSubfolders = true;
+    $('includeSubfolders').checked = true;
+    refreshFilteredView();
+  },
+  openCatalog: () => $('importCatalogBtn').click(),
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2927,8 +2927,10 @@ async function runNativeProductJourney(width, layer) {
 async function runEditRecoveryJourney() {
   const name = cur().name;
   const original = await getJSON(`/api/state?name=${encodeURIComponent(name)}`);
-  const pending = {state: {name, grade: {...GRADE_DEFAULTS,
-    ...(original.grade || {}), exposure: 0.321}}};
+  const originalGrade = {...GRADE_DEFAULTS, ...(original.grade || {})};
+  // Change only the tested edit. A state response also contains read-only
+  // provenance and unset film parameters that the server normalizes on write.
+  const pending = {state: {name, grade: {...originalGrade, exposure: 0.321}}};
   const originalFetch = window.fetch;
   let failedClose = false;
   try {
@@ -2958,7 +2960,7 @@ async function runEditRecoveryJourney() {
   if ((await editRecovery.list()).some(record => record.name === name)) {
     throw new Error('Acknowledged recovery was not removed');
   }
-  editSaveQueue.enqueue(name, {state: {name, grade: original.grade || GRADE_DEFAULTS}});
+  editSaveQueue.enqueue(name, {state: {name, grade: originalGrade}});
   if (!(await window.lightTablePrepareToClose())) throw new Error('Close did not flush the final edit');
   window.lightTableCancelClose();
   return {failedSaveBlockedClose: failedClose, nativeDraftRecovered: true,

--- a/web/app.js
+++ b/web/app.js
@@ -827,6 +827,8 @@ function syncGrade() {
 
 /* ------------------------------------------------------------------ view */
 function clampPan() {
+  // The crop view places the photo wherever the centred frame needs it.
+  if (S.cropping || S.cropTransition) return;
   if (S.zoom <= 1 && S.zoomMode === 'fit') { S.panX = 0; S.panY = 0; return; }
   const w = $('zoomwrap').getBoundingClientRect();
   const r = $('cmp').getBoundingClientRect();
@@ -839,8 +841,16 @@ function applyViewNow() {
   clampPan();
   syncPreviewDetailStatus();
   const cmp = $('cmp');
-  cmp.style.transform =
-    `translate(${S.panX}px,${S.panY}px) scale(${S.zoom})`;
+  const fit = cropViewState().fit;
+  if ((S.cropping || S.cropTransition) && fit) {
+    // Cropping zooms the frame itself; only the pan is a transform.
+    cmp.style.width = `${fit.width * S.zoom}px`;
+    cmp.style.height = `${fit.height * S.zoom}px`;
+    cmp.style.transform = `translate(${S.panX}px,${S.panY}px)`;
+  } else {
+    cmp.style.transform =
+      `translate(${S.panX}px,${S.panY}px) scale(${S.zoom})`;
+  }
 
   const cv = $('cv');
   const naturalW = displaySourcePixelWidth();
@@ -920,6 +930,11 @@ function zoomCentre(f) {
   zoomAt(f, w.left + w.width / 2, w.top + w.height / 2);
 }
 function zoomReset() {
+  if (S.cropping && !S.cropTransition) {
+    // Fit means the cropping view itself while the crop tool is open.
+    const target = cropViewTarget(S.crop);
+    if (target) { applyCropView(target, { immediate: true }); return; }
+  }
   S.zoomMode = 'fit';
   S.zoom = 1;
   S.panX = 0;
@@ -974,7 +989,10 @@ function requestedPreviewWidth() {
     const viewport = $('zoomwrap');
     return automaticPreviewWidth({ sourceWidth: +source.width, sourceHeight: +source.height,
       viewportWidth: viewport.clientWidth, viewportHeight: viewport.clientHeight,
-      deviceScale: window.devicePixelRatio || 1, zoom: S.zoom, crop: previewCrop(),
+      deviceScale: window.devicePixelRatio || 1,
+      // The cropping view's zoom is presentation only; re-rendering for it
+      // would swap textures under a drag.
+      zoom: S.cropping || S.cropTransition ? 1 : S.zoom, crop: previewCrop(),
       actualSize: S.zoomMode === '100' });
   }
   const selected = +$('pw').value || INTERACTIVE_PREVIEW_WIDTH;
@@ -3216,27 +3234,40 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
     const nextGeometryKey = previewGeometryKey(im.name, S.params.rotate);
     const preservePresentationGeometry = shouldPreservePresentationGeometry(
       phase, S.presentedGeometryKey, nextGeometryKey);
-    const imageTiming = await setBaseImage(m, my, {
-      preserveCanvasSize: preservePresentationGeometry,
-    });
-    if (my !== S.seq) return;
-    if (imageTiming.failed && remembered) {
-      presentationCache.delete(presentationKey);
-      return doRender(scheduledAt, { ...options, skipPresentationCache: true });
+    // A draft (embedded-camera) render only stands in while nothing accurate
+    // is on screen. When this photo is already presented accurately, keep
+    // those pixels and let the refinement replace them: swapping in a draft
+    // flashes a different rendering on every zoom, crop, or panel change.
+    const keepAccuratePixels = Boolean(m.refining) && S.renderState === 'ready' &&
+      S.presentedPhotoName === im.name;
+    let imageTiming = null;
+    if (!keepAccuratePixels) {
+      imageTiming = await setBaseImage(m, my, {
+        preserveCanvasSize: preservePresentationGeometry,
+      });
+      if (my !== S.seq) return;
+      if (imageTiming.failed && remembered) {
+        presentationCache.delete(presentationKey);
+        return doRender(scheduledAt, { ...options, skipPresentationCache: true });
+      }
+      if (imageTiming.failed) {
+        $('rstat').textContent = imageTiming.error || 'preview unavailable';
+        $('rstat').className = '';
+        setRenderPresentation('error', im.name, 'Could not display this photo');
+        return;
+      }
+      S.baseEditsBaked = Boolean(m.baseEditsBaked);
+      S.previewDetail = { name: im.name, refining: Boolean(m.refining), requested: requestedWidth,
+        delivered: Math.max(+(m.native?.width || S.baseImg?.naturalWidth || w),
+          +(m.native?.height || S.baseImg?.naturalHeight || 0)) };
+      setRenderPresentation('ready', im.name);
+      drawGrade();
     }
-    if (imageTiming.failed) {
-      $('rstat').textContent = imageTiming.error || 'preview unavailable';
-      $('rstat').className = '';
-      setRenderPresentation('error', im.name, 'Could not display this photo');
-      return;
-    }
-    S.baseEditsBaked = Boolean(m.baseEditsBaked);
-    S.previewDetail = { name: im.name, refining: Boolean(m.refining), requested: requestedWidth,
-      delivered: Math.max(+(m.native?.width || S.baseImg?.naturalWidth || w),
-        +(m.native?.height || S.baseImg?.naturalHeight || 0)) };
-    setRenderPresentation('ready', im.name);
-    drawGrade();
-    const paintedAt = imageTiming.presentedAt || await afterVisiblePaint();
+    const paintedAt = keepAccuratePixels ? performance.now()
+      : (imageTiming.presentedAt || await afterVisiblePaint());
+    imageTiming ||= {
+      decodeMs: 0, uploadMs: 0, uploadedAt: paintedAt, presentation: 'draft-skipped',
+    };
     const timing = {
       image: im.name,
       width: w,
@@ -5512,7 +5543,7 @@ function clampCrop(crop) {
 }
 
 function previewCrop() {
-  return S.crop && !S.cropping ? clampCrop(S.crop) : null;
+  return S.crop && !S.cropping && !S.cropTransition ? clampCrop(S.crop) : null;
 }
 
 function cropViewportSize(availableWidth, availableHeight, sourceWidth, sourceHeight, crop) {
@@ -5541,6 +5572,9 @@ function syncCropPresentationNow() {
   cmp.classList.toggle('preview-framed', framed);
   cmp.classList.toggle('crop-framed', S.cropping || !!crop);
   cmp.classList.toggle('crop-committed', !!crop);
+  // While cropping the frame is the whole photo under a zoom/pan transform, so
+  // its handles may reach past the frame edge and the workspace does the clipping.
+  cmp.classList.toggle('is-cropping', S.cropping || !!S.cropTransition);
   if (!framed) {
     cmp.style.removeProperty('width');
     cmp.style.removeProperty('height');
@@ -5557,8 +5591,12 @@ function syncCropPresentationNow() {
   const viewport = cropViewportSize(
     wrap.width, wrap.height, source.width, source.height, frameCrop);
   if (viewport) {
-    cmp.style.width = `${viewport.width}px`;
-    cmp.style.height = `${viewport.height}px`;
+    // The cropping view zooms by resizing this frame rather than transforming
+    // it, so the crop chrome keeps its screen size at any zoom.
+    const scale = S.cropping || S.cropTransition ? (S.zoom || 1) : 1;
+    cropViewState().fit = { width: viewport.width, height: viewport.height };
+    cmp.style.width = `${viewport.width * scale}px`;
+    cmp.style.height = `${viewport.height * scale}px`;
   }
   cmp.style.setProperty('--crop-source-left', `${-frameCrop.x / frameCrop.w * 100}%`);
   cmp.style.setProperty('--crop-source-top', `${-frameCrop.y / frameCrop.h * 100}%`);
@@ -5641,6 +5679,9 @@ function applyCropVisualNow() {
   r.style.top = (selection.y * 100) + '%';
   r.style.width = (selection.w * 100) + '%';
   r.style.height = (selection.h * 100) + '%';
+  // Keep the photo gliding under the frame: a move drag pans it 1:1, a drawn
+  // frame settles into view once the pointer lifts, everything else eases.
+  syncCropView({ immediate: cropInteractionKind === 'move', defer: cropInteractionKind === 'draw' });
   syncCropPanel();
 }
 const cropFrameScheduler = createFrameScheduler(() => applyCropVisualNow());
@@ -5651,16 +5692,220 @@ function setCropMode(on) {
   const next = Boolean(on);
   const changed = S.cropping !== next;
   S.cropping = next;
-  $('cropLayer').classList.toggle('on', next);
+  // Leaving glides the frame out to its committed framing before the source
+  // frame is swapped, so the transition is marked before the presentation sync.
+  if (changed && !next) cropViewTransition(false);
+  $('cropLayer').classList.toggle('on', next || S.cropTransition === 'exit');
   syncCropPresentationNow();
+  if (changed && next) cropViewTransition(true);
   applyCropVisual();
   // Crop editing needs the whole source; the committed result should fit the
   // crop itself. Resetting on either transition makes both states predictable.
-  if (changed) zoomReset();
-  else applyView();
+  if (changed && !next && !S.cropTransition) zoomReset();
+  else if (!changed) applyView();
   if (next) requestAnimationFrame(() => $('cropRect').focus({ preventScroll: true }));
   renderCompare();
   syncCompareControl();
+}
+
+/* ------------------------------------------------ crop view (Lightroom feel) */
+// While cropping, the crop frame stays centred in the workspace and the photo
+// zooms and pans underneath it. The on-screen frame is the geometric mean of
+// the crop's fitted size and the workspace (zoom bias 0.5), so a dragged handle
+// stays under the pointer while the rest of the frame glides toward the centre
+// and the photo swells to follow. Dragging inside moves the photo under the
+// frame. Entering and leaving ease between the committed framing and this view.
+let cropInteractionKind = null;
+let cropPointerRefresh = null;
+function cropViewState() {
+  return (cropViewState.value ||= {
+    bias: 0.5, dimAlpha: 0.62, tau: 90, transitionTau: 70, pad: 14,
+    target: null, dimTarget: null, dim: null, photo: null, fit: null,
+    running: false, lastAt: 0, onSettle: null,
+  });
+}
+function cropViewPrefersImmediate() {
+  return typeof matchMedia === 'function' &&
+    matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+function cropViewWrapKey() {
+  const rect = $('zoomwrap')?.getBoundingClientRect?.();
+  return rect ? `${Math.round(rect.width)}x${Math.round(rect.height)}` : '';
+}
+function cropViewFrame() {
+  const rect = $('zoomwrap')?.getBoundingClientRect?.();
+  const fit = cropViewState().fit;
+  const width = fit?.width || 0;
+  const height = fit?.height || 0;
+  if (!rect || !(rect.width > 0) || !(rect.height > 0) || !(width > 0) || !(height > 0)) return null;
+  return { wrapWidth: rect.width, wrapHeight: rect.height, width, height };
+}
+function cropFitScale(crop, frame) {
+  // How much the crop could grow, relative to the whole photo's fit, before it
+  // would leave the workspace. The whole photo is 1 by construction.
+  const full = Math.min(frame.wrapWidth / frame.width, frame.wrapHeight / frame.height);
+  const part = Math.min(frame.wrapWidth / (frame.width * crop.w),
+    frame.wrapHeight / (frame.height * crop.h));
+  return Math.max(1, part / full);
+}
+function cropViewTarget(crop, bias = cropViewState().bias) {
+  const frame = cropViewFrame();
+  if (!frame) return null;
+  const c = clampCrop(crop || { x: 0, y: 0, w: 1, h: 1 });
+  if (!(c.w > 0) || !(c.h > 0)) return null;
+  // The cropping view keeps a small margin so handles on the photo's edge
+  // stay inside the workspace; the committed framing (bias 1) uses none.
+  const pad = bias < 1 ? cropViewState().pad : 0;
+  const base = Math.min(1, (frame.wrapWidth - 2 * pad) / frame.width,
+    (frame.wrapHeight - 2 * pad) / frame.height);
+  const zoom = Math.pow(cropFitScale(c, frame), bias) * base;
+  return {
+    zoom,
+    panX: -frame.width * (c.x + c.w / 2 - 0.5) * zoom,
+    panY: -frame.height * (c.y + c.h / 2 - 0.5) * zoom,
+  };
+}
+function cropViewBackgroundRGB() {
+  let value = '';
+  if (typeof getComputedStyle === 'function' && typeof document !== 'undefined') {
+    value = getComputedStyle(document.documentElement).getPropertyValue('--viewer-bg').trim();
+  }
+  const hex = /^#([0-9a-f]{6})$/i.exec(value)?.[1] || '121212';
+  return [0, 2, 4].map((offset) => parseInt(hex.slice(offset, offset + 2), 16));
+}
+function cropViewDimStyle(mix, alpha) {
+  const layer = $('cropLayer');
+  if (!layer?.style?.setProperty) return;
+  const rgb = cropViewBackgroundRGB().map((channel) => Math.round(channel * mix));
+  layer.style.setProperty('--crop-dim-rgb', rgb.join(' '));
+  layer.style.setProperty('--crop-dim-alpha', alpha.toFixed(3));
+}
+function snapCropView() {
+  const state = cropViewState();
+  const target = state.target;
+  state.running = false;
+  if (!target) return;
+  S.zoom = target.zoom; S.panX = target.panX; S.panY = target.panY;
+  if (state.dimTarget) {
+    state.dim = { ...state.dimTarget };
+    cropViewDimStyle(state.dim.mix, state.dim.alpha);
+  }
+  applyViewNow();
+  const settle = state.onSettle;
+  state.onSettle = null;
+  if (settle) settle();
+}
+function stepCropView(now) {
+  const state = cropViewState();
+  const target = state.target;
+  if (!state.running || !target) { state.running = false; return; }
+  if (!S.cropping && S.cropTransition !== 'exit') { state.running = false; return; }
+  const dt = state.lastAt ? Math.min(64, now - state.lastAt) : 16;
+  state.lastAt = now;
+  const k = 1 - Math.exp(-dt / state.tau);
+  S.zoom += (target.zoom - S.zoom) * k;
+  S.panX += (target.panX - S.panX) * k;
+  S.panY += (target.panY - S.panY) * k;
+  let dimDone = true;
+  if (state.dimTarget) {
+    state.dim ||= { ...state.dimTarget };
+    state.dim.alpha += (state.dimTarget.alpha - state.dim.alpha) * k;
+    state.dim.mix += (state.dimTarget.mix - state.dim.mix) * k;
+    cropViewDimStyle(state.dim.mix, state.dim.alpha);
+    dimDone = Math.abs(state.dimTarget.alpha - state.dim.alpha) < 0.01 &&
+      Math.abs(state.dimTarget.mix - state.dim.mix) < 0.01;
+  }
+  const settled = dimDone && Math.abs(target.zoom - S.zoom) < 0.002 * target.zoom &&
+    Math.abs(target.panX - S.panX) < 0.5 && Math.abs(target.panY - S.panY) < 0.5;
+  if (settled) { snapCropView(); return; }
+  applyViewNow();
+  // A held handle stays under the pointer while the photo glides beneath it.
+  if (cropInteractionKind === 'resize' && cropPointerRefresh) cropPointerRefresh();
+  requestAnimationFrame(stepCropView);
+}
+function applyCropView(target, options = {}) {
+  const { immediate = false, dim = null, onSettle, tau = null, essential = false } = options;
+  const state = cropViewState();
+  if (!target) return;
+  state.target = target;
+  state.tau = tau || 90;
+  if (dim) state.dimTarget = dim;
+  // A re-target (a drag step, a workspace resize) keeps any pending completion.
+  if (onSettle !== undefined) state.onSettle = onSettle;
+  S.zoomMode = 'crop';
+  S.targetPixelScale = null;
+  // Reduced motion skips the decorative enter/leave glides; the short easing
+  // that follows a handle drag is direct-manipulation feedback and stays.
+  if (immediate || (!essential && cropViewPrefersImmediate())) { snapCropView(); return; }
+  if (state.running) return;
+  state.running = true;
+  state.lastAt = 0;
+  requestAnimationFrame(stepCropView);
+}
+function syncCropView({ immediate = false, defer = false } = {}) {
+  if (!S.cropping || S.cropTransition) return;
+  const state = cropViewState();
+  const photo = cur()?.name || null;
+  const changedPhoto = state.photo !== photo;
+  state.photo = photo;
+  if (defer) return;
+  const target = cropViewTarget(S.crop);
+  if (!target) return;
+  applyCropView(target, {
+    immediate: immediate || changedPhoto,
+    dim: { mix: 0, alpha: state.dimAlpha },
+    essential: true,
+  });
+}
+function finishCropViewExit() {
+  if (S.cropTransition !== 'exit') return;
+  S.cropTransition = null;
+  $('cropLayer').classList.remove('exiting');
+  if (!S.cropping) $('cropLayer').classList.remove('on');
+  syncCropPresentationNow();
+  applyCropVisual();
+  if (!S.cropping) zoomReset();
+}
+function cropViewTransition(entering) {
+  const state = cropViewState();
+  const layer = $('cropLayer');
+  state.onSettle = null;
+  state.running = false;
+  state.wrapKey = cropViewWrapKey();
+  layer.classList.remove('exiting');
+  if (entering) {
+    S.cropTransition = null;
+    state.photo = cur()?.name || null;
+    state.target = null;
+    const committed = S.crop ? clampCrop(S.crop) : null;
+    const start = committed ? cropViewTarget(committed, 1) : null;
+    S.zoomMode = 'crop';
+    S.targetPixelScale = null;
+    if (start) {
+      // Start exactly where the committed crop was framed; the crop visual
+      // then eases the photo out to the cropping view.
+      S.zoom = start.zoom; S.panX = start.panX; S.panY = start.panY;
+      state.dim = { mix: 1, alpha: 1 };
+    } else {
+      S.zoom = 1; S.panX = 0; S.panY = 0;
+      state.dim = { mix: 0, alpha: state.dimAlpha };
+    }
+    state.dimTarget = { ...state.dim };
+    cropViewDimStyle(state.dim.mix, state.dim.alpha);
+    // Paint the starting view in this frame; the crop visual eases from here.
+    applyViewNow();
+    return;
+  }
+  const target = S.crop ? cropViewTarget(clampCrop(S.crop), 1) : null;
+  if (!target || cropViewPrefersImmediate()) {
+    S.cropTransition = null;
+    return;
+  }
+  S.cropTransition = 'exit';
+  layer.classList.add('exiting');
+  applyCropView(target, {
+    dim: { mix: 1, alpha: 1 }, onSettle: finishCropViewExit, tau: state.transitionTau,
+  });
 }
 
 function restoreCropChoices(choices) {
@@ -8230,8 +8475,9 @@ function finishSpeedKey(key) {
   const layer = $('cropLayer');
   let interaction = null;
 
-  const pointInLayer = (event, rect = interaction?.rect ||
-      layer.getBoundingClientRect()) => {
+  // The frame moves and grows under the pointer while cropping, so map through
+  // its live rectangle rather than the one captured on pointer down.
+  const pointInLayer = (event, rect = layer.getBoundingClientRect()) => {
     return {
       x: clamp((event.clientX - rect.left) / rect.width, 0, 1),
       y: clamp((event.clientY - rect.top) / rect.height, 0, 1),
@@ -8323,7 +8569,7 @@ function finishSpeedKey(key) {
   };
 
   layer.addEventListener('pointerdown', (e) => {
-    if (e.button !== 0) return;
+    if (e.button !== 0 || S.cropTransition) return;
     const rect = layer.getBoundingClientRect();
     const point = pointInLayer(e, rect);
     const handle = e.target.closest('[data-crop-handle]')?.dataset.cropHandle;
@@ -8342,27 +8588,33 @@ function finishSpeedKey(key) {
       rect,
     };
     if (handle) layer.dataset.activeCropHandle = handle;
+    cropInteractionKind = interaction.action;
     layer.setPointerCapture(e.pointerId);
     e.preventDefault();
   });
   layer.addEventListener('pointermove', (e) => {
     if (!interaction) return;
-    const point = pointInLayer(e);
+    const layerRect = layer.getBoundingClientRect();
+    const point = pointInLayer(e, layerRect);
     if (Math.hypot(point.x - interaction.startPoint.x, point.y - interaction.startPoint.y) < 0.001) return;
     captureUndoOnce();
+    interaction.lastEvent = { clientX: e.clientX, clientY: e.clientY };
     const ratio = cropLayerRatio();
     if (interaction.action === 'move') {
+      // The frame stays put and the photo follows the pointer underneath it,
+      // so the crop travels the opposite way through the photo. The photo pans
+      // as the pointer moves, so measure against the rectangle from pointer down.
       const start = interaction.startCrop;
+      const moved = pointInLayer(e, interaction.rect);
       S.crop = {
-        x: clamp(start.x + point.x - interaction.startPoint.x, 0, 1 - start.w),
-        y: clamp(start.y + point.y - interaction.startPoint.y, 0, 1 - start.h),
+        x: clamp(start.x - (moved.x - interaction.startPoint.x), 0, 1 - start.w),
+        y: clamp(start.y - (moved.y - interaction.startPoint.y), 0, 1 - start.h),
         w: start.w,
         h: start.h,
       };
     } else if (interaction.action === 'resize') {
       S.crop = resizeCrop(
-        interaction.startCrop, interaction.handle, point, ratio,
-        interaction.rect);
+        interaction.startCrop, interaction.handle, point, ratio, layerRect);
     } else if (ratio) {
       S.crop = ratioBox(interaction.startPoint, point, ratio);
     } else {
@@ -8377,11 +8629,22 @@ function finishSpeedKey(key) {
     applyCropVisual();
     e.preventDefault();
   });
+  cropPointerRefresh = () => {
+    if (!interaction || interaction.action !== 'resize' || !interaction.lastEvent) return;
+    const layerRect = layer.getBoundingClientRect();
+    const point = pointInLayer(interaction.lastEvent, layerRect);
+    S.crop = resizeCrop(
+      interaction.startCrop, interaction.handle, point, cropLayerRatio(), layerRect);
+    applyCropVisualNow();
+  };
   const finishCropInteraction = () => {
     if (!interaction) return;
     const changed = interaction.historyCaptured;
+    const drawn = interaction.action === 'draw';
     interaction = null;
+    cropInteractionKind = null;
     delete layer.dataset.activeCropHandle;
+    if (drawn) syncCropView();
     if (changed) saveState();
   };
   layer.addEventListener('pointerup', finishCropInteraction);
@@ -9765,6 +10028,22 @@ function onViewportResize() {
   const baseW = S.zoom > 0 ? r.width / S.zoom : r.width;
   if (baseW <= 0) {
     scheduleNativeViewportLayout();
+    return;
+  }
+  if (S.cropping || S.cropTransition) {
+    // The observer also fires for the frame's own animated resizes; only a
+    // workspace change re-targets the cropping view.
+    const state = cropViewState();
+    const wrapKey = cropViewWrapKey();
+    if (wrapKey === state.wrapKey) {
+      scheduleNativeViewportLayout();
+      return;
+    }
+    state.wrapKey = wrapKey;
+    const target = cropViewTarget(S.crop, S.cropTransition ? 1 : state.bias);
+    if (target) applyCropView(target);
+    else applyViewNow();
+    scheduleAutomaticPreview();
     return;
   }
   if (S.zoomMode === '100') {

--- a/web/app.js
+++ b/web/app.js
@@ -3294,7 +3294,9 @@ function renderPhysicalPreview() {
 async function doRender(scheduledAt = performance.now(), options = {}) {
   clearTimeout(prefetchTimer);
   clearTimeout(refineTimer);
-  clearTimeout(nativeHelperTimer);
+  // A pending helper is left alone. Its own generation guard drops a
+  // superseded fetch, while the early return below happens before the
+  // generation is bumped, so cancelling here stranded the sampling surface.
   const im = cur();
   if (!im) return;
   readControls();
@@ -3643,8 +3645,9 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
   scheduleNativeViewportLayout();
 
   // Histogram, WB sampling, and reference matching retain a 256px WebGL
-  // helper, generated only after interaction settles.
-  if (!surface.viewport) scheduleNativeHelper(render.helper, generation);
+  // helper, generated only after interaction settles. A response without a
+  // helper still presents a JPEG surface, which seeds sampling just as well.
+  if (!surface.viewport) scheduleNativeHelper(render.helper || render.img, generation);
 
   return new Promise((resolve) => {
     nativePreviewPending.set(generation, { resolve });

--- a/web/app.js
+++ b/web/app.js
@@ -478,6 +478,7 @@ window.lightTableNativeEvent = (event) => {
       presentedAt,
       presentation: 'native-metal',
       nativeFetchMs: +timings.fetchMs || 0,
+      nativeSharedMemory: Boolean(timings.sharedMemory),
       nativeGpuMs: +timings.gpuMs || 0,
       nativeTotalMs: +timings.totalMs || 0,
       textureCacheHit: Boolean(timings.textureCacheHit),
@@ -884,6 +885,7 @@ function applyViewNow() {
   cmp.classList.toggle('is-zoomed', isZoomed);
 
   scheduleNativeViewportLayout();
+  scheduleViewportRegionRender();
 }
 const viewFrameScheduler = createFrameScheduler(() => applyViewNow());
 function applyView() {
@@ -975,6 +977,58 @@ function sourceLongEdge(image = cur()) {
 function displaySourcePixelWidth() {
   const width = +cropSourceSize().width;
   return width > 0 ? width : (+$('cv')?.width || 0);
+}
+
+function viewportRegionEnabled() {
+  return nativePreviewActive() && $('engine').value === 'rs' &&
+    S.zoomMode === '100' && S.params.profile_enabled !== false &&
+    S.presentedPhotoName === cur()?.name && !S.crop && !S.cropSession &&
+    !S.compareActive && !S.holdBefore && !S.wbPick && !S.pointColorPick && !S.maskColorPick &&
+    !S.reference?.active && !(S.heals || []).length && !(S.masks || []).length &&
+    !Object.keys(OPTICS_DEFAULTS).some((key) =>
+      (S.optics?.[key] ?? OPTICS_DEFAULTS[key]) !== OPTICS_DEFAULTS[key]);
+}
+
+function viewportPixelWindow(canvas, clip, width, height, margin = 96) {
+  if (!(canvas.width > 0 && canvas.height > 0 && width > 0 && height > 0)) return null;
+  const left = Math.max(canvas.left, clip.left), top = Math.max(canvas.top, clip.top);
+  const right = Math.min(canvas.right, clip.right), bottom = Math.min(canvas.bottom, clip.bottom);
+  if (right <= left || bottom <= top) return null;
+  const x = Math.max(0, Math.floor(((left - canvas.left) / canvas.width * width - margin) / 64) * 64);
+  const y = Math.max(0, Math.floor(((top - canvas.top) / canvas.height * height - margin) / 64) * 64);
+  const endX = Math.min(width, Math.ceil(((right - canvas.left) / canvas.width * width + margin) / 64) * 64);
+  const endY = Math.min(height, Math.ceil(((bottom - canvas.top) / canvas.height * height + margin) / 64) * 64);
+  return { x, y, width: endX - x, height: endY - y };
+}
+
+function viewportSourceGeometryKey() {
+  return JSON.stringify([cur()?.name, cur()?.fileKey || cur()?.mtime || null,
+    Math.abs(Math.round((+S.params.rotate || 0) / 90)) % 2]);
+}
+
+function requestedViewportRegion() {
+  if (!viewportRegionEnabled()) return null;
+  const decoded = S.viewportSourceGeometry?.key === viewportSourceGeometryKey()
+    ? S.viewportSourceGeometry : null;
+  let width = decoded?.width || +cur()?.width || 0;
+  let height = decoded?.height || +cur()?.height || 0;
+  if (!(width > 0 && height > 0)) return null;
+  if (!decoded && Math.abs(Math.round((+S.params.rotate || 0) / 90)) % 2) [width, height] = [height, width];
+  return viewportPixelWindow($('cv').getBoundingClientRect(),
+    $('zoomwrap').getBoundingClientRect(), width, height);
+}
+
+let viewportRegionTimer = null;
+let lastViewportRenderKey = null;
+function scheduleViewportRegionRender() {
+  const region = requestedViewportRegion();
+  if (!region && !S.nativeViewport) return;
+  const key = JSON.stringify([cur()?.name, region]);
+  if (key === lastViewportRenderKey) return;
+  clearTimeout(viewportRegionTimer);
+  viewportRegionTimer = setTimeout(() => {
+    doRender(performance.now(), { width: requestedPreviewWidth(), phase: 'settled' });
+  }, 45);
 }
 
 function requestedPreviewWidth() {
@@ -1655,6 +1709,7 @@ function nativeGradePayload(grade) {
 }
 
 function drawGradeNow(forceWebGL = false, refreshScope = true) {
+  scheduleViewportRegionRender();
   if (S.renderState === 'pending' && S.presentedPhotoName && S.presentedPhotoName !== cur()?.name) return;
   const activeGrade = S.holdBefore ? GRADE_DEFAULTS : S.grade;
   syncPreviewBackend();
@@ -2638,7 +2693,16 @@ let settleRenderTimer = null;
 let lastInteractiveRenderAt = -Infinity;
 let lastContinuousInputAt = -Infinity;
 const INTERACTIVE_PREVIEW_WIDTH = 1100;
-const INTERACTIVE_RENDER_INTERVAL_MS = 60;
+// Learn from real server round trips, excluding presentation-cache hits and
+// settled/refinement renders. One-frame minimum lets fast film parameters keep
+// pace with the display; slower ones naturally stop flooding the render queue.
+function adaptiveInteractiveInterval(previous, roundTripMs) {
+  if (!Number.isFinite(roundTripMs) || roundTripMs <= 0) return previous;
+  const sample = Math.max(1000 / 60, Math.min(250, roundTripMs));
+  return previous == null ? sample : previous * 0.7 + sample * 0.3;
+}
+let interactiveRenderIntervalMs = null;
+let interactiveRenderPhoto = null;
 const FULL_RESOLUTION_SETTLE_MS = 160;
 function markContinuousInput() {
   lastContinuousInputAt = performance.now();
@@ -2785,12 +2849,33 @@ const JOURNEY_RENDER_FIELDS = [
   'residentMs', 'gpuMs', 'imageDecodeMs', 'textureUploadMs',
   'paintAfterUploadMs', 'presentation', 'nativeFetchMs', 'nativeGpuMs',
   'nativeTotalMs', 'totalMs', 'textureCacheHit', 'presentationCacheHit', 'serverQueueMs',
+  'generation', 'viewport', 'nativeSharedMemory',
 ];
 
 function compactJourneyRender(render) {
   return Object.fromEntries(JOURNEY_RENDER_FIELDS
     .filter((key) => render?.[key] !== undefined)
     .map((key) => [key, render[key]]));
+}
+
+function waitForNativeViewportFrame(imageName, region, afterGeneration, previousRegion = null) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      window.removeEventListener('lighttable-rendered', onRender);
+      reject(new Error(`Timed out waiting for native ${region ? 'viewport' : 'full-frame'} presentation`));
+    }, 180000);
+    const onRender = ({ detail }) => {
+      if (detail.image !== imageName || detail.generation <= afterGeneration ||
+          detail.generation !== S.seq || detail.presentation !== 'native-metal' || detail.refining ||
+          Boolean(detail.viewport) !== region) return;
+      if (previousRegion && detail.viewport.x === previousRegion.x &&
+          detail.viewport.y === previousRegion.y) return;
+      clearTimeout(timer);
+      window.removeEventListener('lighttable-rendered', onRender);
+      resolve(detail);
+    };
+    window.addEventListener('lighttable-rendered', onRender);
+  });
 }
 
 async function waitForJourneyFrame() {
@@ -2842,7 +2927,7 @@ async function runNativeProductJourney(width, layer) {
 async function runEditRecoveryJourney() {
   const name = cur().name;
   const original = await getJSON(`/api/state?name=${encodeURIComponent(name)}`);
-  const pending = {state: {name, ...original, grade: {...GRADE_DEFAULTS,
+  const pending = {state: {name, grade: {...GRADE_DEFAULTS,
     ...(original.grade || {}), exposure: 0.321}}};
   const originalFetch = window.fetch;
   let failedClose = false;
@@ -2873,7 +2958,7 @@ async function runEditRecoveryJourney() {
   if ((await editRecovery.list()).some(record => record.name === name)) {
     throw new Error('Acknowledged recovery was not removed');
   }
-  editSaveQueue.enqueue(name, {state: {name, ...original}});
+  editSaveQueue.enqueue(name, {state: {name, grade: original.grade || GRADE_DEFAULTS}});
   if (!(await window.lightTablePrepareToClose())) throw new Error('Close did not flush the final edit');
   window.lightTableCancelClose();
   return {failedSaveBlockedClose: failedClose, nativeDraftRecovered: true,
@@ -2977,10 +3062,15 @@ async function runNativeSmokeJourney(width, layer = 'pr') {
     return { pointColor, maskColor };
   });
 
-  await renderStep('film-off', next.name, 'native-metal', () =>
-    executeUICommand('filmToggle'));
-  await renderStep('film-on', next.name, 'native-metal', () =>
-    executeUICommand('filmToggle'));
+  await renderStep('film-off', next.name, 'native-metal', () => {
+    if (S.params.profile_enabled !== false) return executeUICommand('filmToggle');
+    renderFilm(0);
+  });
+  await renderStep('film-on', next.name, 'native-metal', () => {
+    if (S.params.profile_enabled === false) return executeUICommand('filmToggle');
+    renderFilm(0);
+  });
+  if (S.params.profile_enabled === false) throw new Error('Film did not activate before slider/viewport proof');
   await renderStep('slider-adjustment', next.name, 'native-metal', () =>
     executeUICommand('slider', { key: 'print_exposure', value: 0.05 }));
 
@@ -2998,25 +3088,52 @@ async function runNativeSmokeJourney(width, layer = 'pr') {
     if (state.compare.active) throw new Error('Compare did not turn off');
     return state;
   });
-  await record('zoom-actual', async () => {
+  const actualRender = await record('zoom-actual', async () => {
     await executeUICommand('zoomIn');
     await waitForJourneyFrame();
+    const presented = waitForNativeViewportFrame(next.name, true, S.seq);
     for (let attempt = 0; attempt < 3; attempt++) {
       const state = await executeUICommand('zoomActual');
       if (state.zoomMode === '100') {
-        await waitForJourneyFrame();
-        return uiStateReport();
+        const result = await presented;
+        if (result.viewport.width * result.viewport.height >=
+            result.viewport.fullWidth * result.viewport.fullHeight) {
+          throw new Error('Actual-size proof rendered the entire source');
+        }
+        return result;
       }
       await waitForJourneyFrame();
     }
     throw new Error('Actual-size zoom did not activate');
   });
+  await record('viewport-pan', async () => {
+    const presented = waitForNativeViewportFrame(next.name, true, S.seq, actualRender.viewport);
+    const wrap = $('zoomwrap'), bounds = wrap.getBoundingClientRect();
+    const origin = { clientX: bounds.left + bounds.width / 2, clientY: bounds.top + bounds.height / 2 };
+    wrap.dispatchEvent(new PointerEvent('pointerdown', { ...origin, button: 0, pointerId: 997, bubbles: true }));
+    wrap.dispatchEvent(new PointerEvent('pointermove', { clientX: origin.clientX + 320,
+      clientY: origin.clientY + 160, button: 0, pointerId: 997, bubbles: true }));
+    wrap.dispatchEvent(new PointerEvent('pointerup', { clientX: origin.clientX + 320,
+      clientY: origin.clientY + 160, button: 0, pointerId: 997, bubbles: true }));
+    return presented;
+  });
+  await record('viewport-film-slider', async () => {
+    const presented = waitForNativeViewportFrame(next.name, true, S.seq);
+    const previous = +S.params.print_exposure;
+    await executeUICommand('slider', { key: 'print_exposure', value: previous === 1.37 ? 1.73 : 1.37 });
+    const result = await presented;
+    if (+S.params.print_exposure === previous || result.presentationCacheHit) {
+      throw new Error('Viewport film slider did not produce a distinct film render');
+    }
+    if (result.engine !== 'rs') throw new Error('Viewport film slider did not use the resident film engine');
+    return result;
+  });
   await record('zoom-fit', async () => {
+    const presented = waitForNativeViewportFrame(next.name, false, S.seq);
     await executeUICommand('zoomFit');
-    await waitForJourneyFrame();
-    const state = uiStateReport();
-    if (state.zoomMode !== 'fit') throw new Error('Fit zoom did not activate');
-    return state;
+    const result = await presented;
+    if (S.zoomMode !== 'fit' || S.nativeViewport) throw new Error('Fit zoom did not restore a full-frame surface');
+    return result;
   });
 
   const destination = window.__LIGHTTABLE_NATIVE_JOURNEY_EXPORT_DIR__;
@@ -3146,7 +3263,8 @@ async function runNativeRawJourney(width, layer) {
 function scheduleProgressiveRender(scheduledAt, firstDelay = 0) {
   clearTimeout(renderTimer);
   const requestedWidth = requestedPreviewWidth();
-  const width = Math.min(requestedWidth, INTERACTIVE_PREVIEW_WIDTH);
+  const width = viewportRegionEnabled() ? requestedWidth
+    : Math.min(requestedWidth, INTERACTIVE_PREVIEW_WIDTH);
   renderTimer = setTimeout(() => {
     lastInteractiveRenderAt = performance.now();
     doRender(scheduledAt, {
@@ -3167,7 +3285,7 @@ function renderPhysicalPreview() {
   markContinuousInput();
   const scheduledAt = performance.now();
   const delay = Math.max(0,
-    INTERACTIVE_RENDER_INTERVAL_MS - (scheduledAt - lastInteractiveRenderAt));
+    (interactiveRenderIntervalMs ?? 1000 / 60) - (scheduledAt - lastInteractiveRenderAt));
   scheduleProgressiveRender(scheduledAt, delay);
 }
 
@@ -3189,7 +3307,14 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       requestedWidth, phase,
     });
   }
+  if (interactiveRenderPhoto !== im.name) {
+    interactiveRenderPhoto = im.name;
+    interactiveRenderIntervalMs = null;
+  }
   const requestStartedAt = performance.now();
+  const viewport = w === requestedWidth ? requestedViewportRegion() : null;
+  const measureInteractiveRoundTrip = (viewport || w <= INTERACTIVE_PREVIEW_WIDTH) &&
+    requestStartedAt - lastContinuousInputAt < FULL_RESOLUTION_SETTLE_MS;
   $('rstat').textContent = 'rendering…';
   $('rstat').className = 'busy';
   spin(true);
@@ -3199,13 +3324,21 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       optics: S.optics, heals: S.heals,
       client: CLIENT_ID, generation: my, priority: 'interactive',
       native: nativePreviewActive(),
+      ...(viewport ? { viewport } : {}),
     };
+    clearTimeout(viewportRegionTimer);
+    lastViewportRenderKey = JSON.stringify([im.name, viewport]);
     const presentationKey = renderRequestKey(im, request);
     const remembered = options.skipPresentationCache ? null : presentationCache.get(presentationKey);
     const m = remembered ? { ...remembered, cached: true }
       : await api('/api/render', request);
     presentationCache.set(presentationKey, m);
     const responseAt = performance.now();
+    if (measureInteractiveRoundTrip && !remembered && !m.cached && !m.error &&
+        !m.cancelled && interactiveRenderPhoto === im.name) {
+      interactiveRenderIntervalMs = adaptiveInteractiveInterval(
+        interactiveRenderIntervalMs, responseAt - requestStartedAt);
+    }
     if (window.__LIGHTTABLE_NATIVE_BENCHMARK_ITERATIONS__) {
       postNative('nativeBenchmarkProgress', {
         stage: 'render-response', generation: my, currentGeneration: S.seq,
@@ -3223,7 +3356,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       }
       return;
     }
-    S.matchFactor = m.match || 1;
+    if (Number.isFinite(m.match) && m.match > 0) S.matchFactor = m.match;
     if (Object.prototype.hasOwnProperty.call(m, 'lens_profile')) {
       S.lensProfile = m.lens_profile;
       syncOpticsPanel();
@@ -3270,6 +3403,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
     };
     const timing = {
       image: im.name,
+      generation: my,
       width: w,
       requestedWidth,
       phase,
@@ -3277,6 +3411,8 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       refining: Boolean(m.refining),
       engine: m.engine,
       backend: m.backend || null,
+      viewport: m.native?.viewport || null,
+      nativeSharedMemory: imageTiming.nativeSharedMemory || false,
       queueMs: requestStartedAt - scheduledAt,
       requestMs: responseAt - requestStartedAt,
       serverMs: !m.cached && Number.isFinite(+m.ms) ? +m.ms : null,
@@ -3488,11 +3624,16 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
     failed: true, error: 'Native preview data is missing',
   });
 
-  if (surface.width > 0 && surface.height > 0 && !preserveCanvasSize) {
-    if ($('cv').width !== surface.width || $('cv').height !== surface.height) {
+  S.nativeViewport = surface.viewport || null;
+  if (surface.viewport) S.viewportSourceGeometry = { key: viewportSourceGeometryKey(),
+    width: surface.viewport.fullWidth, height: surface.viewport.fullHeight };
+  const canvasWidth = surface.viewport?.fullWidth || surface.width;
+  const canvasHeight = surface.viewport?.fullHeight || surface.height;
+  if (canvasWidth > 0 && canvasHeight > 0 && !preserveCanvasSize) {
+    if ($('cv').width !== canvasWidth || $('cv').height !== canvasHeight) {
       S.maskTextureDirty = true;
-      $('cv').width = surface.width;
-      $('cv').height = surface.height;
+      $('cv').width = canvasWidth;
+      $('cv').height = canvasHeight;
     }
     applyCropVisual();
     if (S.maskTextureDirty) drawGrade();
@@ -3501,7 +3642,7 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
 
   // Histogram, WB sampling, and reference matching retain a 256px WebGL
   // helper, generated only after interaction settles.
-  scheduleNativeHelper(render.helper, generation);
+  if (!surface.viewport) scheduleNativeHelper(render.helper, generation);
 
   return new Promise((resolve) => {
     nativePreviewPending.set(generation, { resolve });

--- a/web/app.js
+++ b/web/app.js
@@ -61,6 +61,7 @@ import { createPresetBrowser } from '/web/preset-browser.js';
 import { installNativeWindowChrome } from '/web/window-chrome.js';
 import { installUIBridge } from '/web/ui-bridge.js';
 import { installSettings } from '/web/settings.js';
+import { HELP_SECTION_TOPICS } from '/web/help-search.js';
 import { createInteractionRecorder } from '/web/interaction-perf.js';
 import { createPresentationCache, renderRequestKey } from '/web/presentation-cache.js';
 import { createGridLayout, visibleGridPositions, automaticPreviewWidth, createSummaryCache } from '/web/view-performance.js';
@@ -304,6 +305,8 @@ function setAllPhotoSelection(selected) {
 }
 
 function performNativeMenuCommand(command) {
+  if (command === 'help') { window.LightTableHelp?.open(); return; }
+  if (window.LightTableHelp?.isOpen()) return;
   let result;
   if (command.startsWith('flag:')) {
     setStatus(command.slice('flag:'.length));
@@ -1215,14 +1218,23 @@ for (const section of document.querySelectorAll('#editPane .sec, #filmPane .sec'
   if (!summary) continue;
   const hints = [...section.querySelectorAll('.hint:not([id])')]
     .filter((hint) => hint.closest('.sec') === section);
-  if (!hints.length) continue;
+  const topicCategory = section.closest('#filmPane') ? 'Film' : 'Editing';
+  const topicLabel = summary.querySelector('span')?.textContent.trim() || '';
+  const topicId = HELP_SECTION_TOPICS[topicCategory]?.[topicLabel];
+  if (!hints.length && !topicId) continue;
   const help = document.createElement('button');
   help.type = 'button';
   help.className = 'section-help';
   help.textContent = '?';
-  help.title = hints.map((hint) => hint.textContent.trim()).join(' ');
+  help.title = hints.map((hint) => hint.textContent.trim()).join(' ') || `Read help for ${topicLabel}`;
   help.setAttribute('aria-label', `Help: ${summary.querySelector('span')?.textContent || 'section'}`);
-  help.onclick = (event) => event.stopPropagation();
+  help.onclick = (event) => {
+    event.preventDefault(); event.stopPropagation();
+    window.LightTableHelp?.open({
+      article: topicId, query: topicId ? '' : topicLabel,
+      category: topicId ? '' : topicCategory,
+    });
+  };
   hints.forEach((hint) => { hint.hidden = true; });
   summary.appendChild(help);
 }

--- a/web/catalog-ui.js
+++ b/web/catalog-ui.js
@@ -205,7 +205,7 @@ export function createCatalogUI(ctx) {
     const options = el('importOptions'), run = el('importRun');
     const preview = el('importPreview'), trial = el('importTrial');
     if (!open || !dialog) return;
-    let inspected = '', previewed = '', busy = false, inspection = 0;
+    let inspected = '', previewed = '', busy = false, inspection = 0, inspectTimer = null;
     const requestBody = () => ({path: pathInput.value.trim(),
       addSources: el('impAddSources').checked, options: {
       metadata: el('impMetadata').checked, keywords: el('impKeywords').checked,
@@ -274,6 +274,8 @@ export function createCatalogUI(ctx) {
     }
 
     async function inspect() {
+      clearTimeout(inspectTimer);
+      if (busy) return;
       const path = pathInput.value.trim(), ticket = ++inspection;
       inspected = previewed = '';
       controls();
@@ -292,7 +294,11 @@ export function createCatalogUI(ctx) {
       controls();
     }
     pathInput.addEventListener('change', inspect);
-    pathInput.addEventListener('input', () => { ++inspection; inspected = previewed = ''; options.hidden = true; controls(); });
+    pathInput.addEventListener('input', () => {
+      ++inspection; inspected = previewed = ''; options.hidden = true; controls();
+      clearTimeout(inspectTimer);
+      inspectTimer = setTimeout(inspect, 300);
+    });
     options.addEventListener('change', controls);
     function showReport(result) {
       const prefix = result.previewOnly ? 'Compatibility preview' : result.trial ? 'Trial variants created' : 'Import complete';

--- a/web/catalog-ui.js
+++ b/web/catalog-ui.js
@@ -206,7 +206,8 @@ export function createCatalogUI(ctx) {
     const preview = el('importPreview'), trial = el('importTrial');
     if (!open || !dialog) return;
     let inspected = '', previewed = '', busy = false, inspection = 0;
-    const requestBody = () => ({path: pathInput.value.trim(), options: {
+    const requestBody = () => ({path: pathInput.value.trim(),
+      addSources: el('impAddSources').checked, options: {
       metadata: el('impMetadata').checked, keywords: el('impKeywords').checked,
       collections: el('impCollections').checked, stacks: el('impStacks').checked,
       develop: el('impDevelop').checked, history: el('impHistory').checked,
@@ -220,19 +221,58 @@ export function createCatalogUI(ctx) {
       el('importChoose').disabled = busy;
       options.querySelectorAll('input, select').forEach(control => { control.disabled = busy; });
     }
-    const show = visible => {
-      dialog.setAttribute('aria-hidden', String(!visible));
+
+    const background = new Map();
+    let returnFocus = null;
+    const show = (visible) => {
+      const wasVisible = dialog.classList.contains('on');
+      dialog.setAttribute('aria-hidden', visible ? 'false' : 'true');
       dialog.classList.toggle('on', visible);
+      if (visible && !wasVisible) {
+        returnFocus = document.activeElement;
+        for (const node of document.body.children) {
+          if (node === dialog || node.tagName === 'SCRIPT') continue;
+          background.set(node, node.inert);
+          node.inert = true;
+        }
+        pathInput.focus();
+      } else if (!visible && wasVisible) {
+        for (const [node, inert] of background) node.inert = inert;
+        background.clear();
+        returnFocus?.focus?.();
+        ctx.onCatalogImportClosed?.();
+      }
     };
-    open.addEventListener('click', () => show(true));
-    el('importCancel').addEventListener('click', () => show(false));
-    dialog.addEventListener('keydown', event => {
+    dialog.addEventListener('keydown', (event) => {
+      if (!dialog.classList.contains('on')) return;
       event.stopPropagation();
-      if (event.key === 'Escape') { event.preventDefault(); show(false); }
+      if (event.key === 'Escape') {
+        event.preventDefault(); show(false);
+      } else if (event.key === 'Tab') {
+        const targets = [...dialog.querySelectorAll('button, input, select')]
+          .filter((node) => !node.disabled && node.getClientRects().length);
+        const index = targets.indexOf(document.activeElement);
+        if (event.shiftKey && index <= 0) {
+          event.preventDefault(); targets.at(-1)?.focus();
+        } else if (!event.shiftKey && (index < 0 || index === targets.length - 1)) {
+          event.preventDefault(); targets[0]?.focus();
+        }
+      }
     });
-    el('importChoose')?.addEventListener('click', () => {
-      if (!sendNative('chooseCatalogFile', {})) toast('Paste the catalog file path to continue');
-    });
+
+    open.addEventListener('click', () => { show(true); });
+    const cancel = el('importCancel');
+    if (cancel) cancel.addEventListener('click', () => show(false));
+
+    const choose = el('importChoose');
+    if (choose) {
+      choose.addEventListener('click', () => {
+        if (!sendNative('chooseCatalogFile', {})) {
+          toast('Choosing a file needs the desktop app; paste a path instead');
+        }
+      });
+    }
+
     async function inspect() {
       const path = pathInput.value.trim(), ticket = ++inspection;
       inspected = previewed = '';
@@ -252,6 +292,7 @@ export function createCatalogUI(ctx) {
       controls();
     }
     pathInput.addEventListener('change', inspect);
+    pathInput.addEventListener('input', () => { ++inspection; inspected = previewed = ''; options.hidden = true; controls(); });
     options.addEventListener('change', controls);
     function showReport(result) {
       const prefix = result.previewOnly ? 'Compatibility preview' : result.trial ? 'Trial variants created' : 'Import complete';
@@ -292,6 +333,7 @@ export function createCatalogUI(ctx) {
             if (mode === 'preview') previewed = signature;
             showReport(result);
             if (mode !== 'preview') {
+              ctx.onCatalogImportCompleted?.(result);
               await refresh();
               if (ctx.onLibraryChanged) ctx.onLibraryChanged();
             }

--- a/web/first-run.css
+++ b/web/first-run.css
@@ -1,0 +1,53 @@
+/* A calm introduction, using the same surfaces and accent as the editor. */
+.setup-backdrop { z-index:1200; padding:24px; background:rgba(12,12,12,.88); backdrop-filter:blur(12px); }
+.setup-window { width:600px; max-width:100%; max-height:calc(100dvh - 48px); overflow:auto; border:1px solid var(--line-strong); border-radius:16px; background:#222; box-shadow:0 24px 90px #0006; padding:38px 40px 22px; color:var(--ink); font:14px/1.55 var(--ui); }
+.setup-backdrop.on .setup-window { animation:setup-enter .22s ease-out; }
+.setup-brand { display:flex; align-items:center; gap:11px; font-size:18px; font-weight:600; letter-spacing:-.4px; margin-bottom:30px; }
+.setup-mark { width:30px; height:30px; color:var(--accent); }
+.setup-window h1,.setup-window h2 { margin:0 0 9px; font-size:28px; line-height:1.2; letter-spacing:-.8px; font-weight:600; color:#f3f3f3; outline:none; }
+.setup-window h2 { font-size:26px; }
+.setup-intro { color:#adadad; margin:0 0 26px; font-size:14px; line-height:1.6; }
+.setup-options { display:flex; flex-direction:column; border-top:1px solid var(--line); margin:0 0 22px; }
+.setup-option { border:0; border-bottom:1px solid var(--line); border-radius:0; background:transparent; box-shadow:none; color:var(--ink); height:auto; min-height:90px; padding:20px 10px; display:flex; align-items:center; gap:18px; text-align:left; width:100%; transition:background .15s, padding .15s; }
+.setup-option:hover { background:#2b2b2b; padding-left:16px; }
+.setup-option-icon { width:38px; height:38px; flex-shrink:0; color:#c5c5c5; display:grid; place-items:center; }
+.setup-option-icon svg { width:29px; height:29px; }
+.setup-option-icon.setup-lr { font-size:23px; font-weight:500; letter-spacing:-1px; }
+.setup-option strong { font:500 15px/1.4 var(--ui); display:block; margin-bottom:4px; }
+.setup-option small { display:block; color:#a5a5a5; font:12px/1.5 var(--ui); }
+.setup-arrow { margin-left:auto; color:#818181; font-size:21px; font-weight:300; transition:transform .15s, color .15s; }
+.setup-option:hover .setup-arrow { transform:translateX(3px); color:var(--accent); }
+.setup-window button:focus-visible,.setup-window input:focus-visible { outline:2px solid var(--accent); outline-offset:3px; }
+.setup-caption { font-size:12px; color:var(--muted); margin:0; }
+.setup-footer { display:flex; justify-content:space-between; align-items:center; min-height:40px; margin-top:20px; border-top:1px solid var(--line); padding-top:16px; }
+.setup-footer button { border:0; background:transparent; box-shadow:none; color:#bdbdbd; font-size:12px; padding:5px 0; height:auto; }
+.setup-footer button:hover { color:white; }
+.setup-footer #setupLater { margin-left:auto; }
+.setup-detail { min-height:305px; }
+.setup-detail p { color:#b4b4b4; }
+.setup-facts { padding-left:18px; margin:20px 0 26px; color:#b4b4b4; font-size:13px; }
+.setup-facts li { padding-left:3px; margin:10px 0; }
+.setup-detail .accent-btn { height:auto; min-height:36px; padding:8px 17px; font-size:13px; border-radius:6px; }
+.setup-detail .quiet { margin-left:10px; min-height:36px; font-size:12px; }
+.setup-detail .field { margin:20px 0; }
+.setup-detail .field input { width:100%; height:36px; }
+.setup-availability { font-size:12px; color:var(--muted); }
+.setup-error { color:#edb59e; font-size:12px; line-height:1.6; margin:16px 0 0; }
+.setup-error:empty { display:none; }
+.setup-progress { width:100%; height:5px; accent-color:var(--accent); margin:20px 0 10px; }
+.setup-result-icon { width:40px; height:40px; color:var(--accent); margin-bottom:20px; }
+.setup-backdrop [data-setup-page]:not([hidden]) { animation:setup-page .16s ease-out; }
+@keyframes setup-enter { from { opacity:0; transform:translateY(8px) scale(.99); } to { opacity:1; transform:none; } }
+@keyframes setup-page { from { opacity:.3; transform:translateY(4px); } to { opacity:1; transform:none; } }
+@media (max-width:620px), (max-height:650px) {
+  .setup-backdrop { padding:16px; }
+  .setup-window { padding:24px; max-height:calc(100dvh - 32px); }
+  .setup-brand { margin-bottom:22px; }
+  .setup-window h1 { font-size:25px; }
+  .setup-option { min-height:82px; padding:16px 4px; gap:12px; }
+  .setup-option small { font-size:11px; }
+  .setup-detail { min-height:0; }
+}
+@media (prefers-reduced-motion:reduce) {
+  .setup-backdrop *, .setup-backdrop.on .setup-window { animation:none !important; transition:none !important; }
+}

--- a/web/first-run.js
+++ b/web/first-run.js
@@ -1,0 +1,258 @@
+/* First-run orientation. Completion is durable; opening a picker is not. */
+export function shouldShowSetup(prefs, library, nativeFirstRun = null) {
+  if (!prefs || !library || prefs.firstRunSetup?.version >= 1) return false;
+  if (nativeFirstRun !== null) return nativeFirstRun;
+  return Number(library.total || library.images?.length || 0) === 0
+    && !(library.catalog?.sources || []).some((source) => source.count > 0);
+}
+
+export function installFirstRunSetup({ el, post, sendNative, nativeBridge,
+  openCatalog, reloadLibrary, onComplete }) {
+  const dialog = el('firstRunDialog');
+  let prefs = null, library = null, nativeFirstRun = null;
+  let nativeSetup = false, photosAvailable = false;
+  let page = 'choices', busy = false, catalogPending = false;
+  let catalogResult = null;
+  let resultSource = null, returnFocus = null;
+  const inertElements = new Map();
+  const isOpen = () => dialog.classList.contains('on');
+
+  function show(visible) {
+    if (visible === isOpen()) return;
+    dialog.classList.toggle('on', visible);
+    dialog.setAttribute('aria-hidden', String(!visible));
+    document.body.classList.toggle('setup-open', visible);
+    if (visible) {
+      returnFocus = document.activeElement;
+      for (const node of document.body.children) {
+        if (node === dialog || node.tagName === 'SCRIPT') continue;
+        inertElements.set(node, node.inert);
+        node.inert = true;
+      }
+      focusPage();
+    } else {
+      for (const [node, wasInert] of inertElements) node.inert = wasInert;
+      inertElements.clear();
+      returnFocus?.focus?.({ preventScroll: true });
+    }
+  }
+
+  function focusPage() {
+    requestAnimationFrame(() => {
+      if (isOpen()) (page === 'choices' ? el('setupWelcome')
+        : dialog.querySelector(`[data-setup-page="${page}"] h2`))?.focus();
+    });
+  }
+
+  function setPage(next) {
+    page = next;
+    el('setupPanel').setAttribute('aria-labelledby', next === 'choices' ? 'setupWelcome' : `setupHeading-${next}`);
+    for (const node of dialog.querySelectorAll('[data-setup-page]')) {
+      node.hidden = node.dataset.setupPage !== next;
+    }
+    el('setupBack').hidden = next === 'choices' || busy;
+    el('setupLater').hidden = busy || next === 'result';
+    el('setupError').textContent = '';
+    focusPage();
+  }
+
+  function maybeShow() {
+    // The Mac shell knows whether this is a new installation, even before a
+    // large existing catalog has completed its first background scan.
+    if (nativeBridge() && window.__LIGHTTABLE_PLATFORM__ !== 'windows'
+        && nativeFirstRun === null) return;
+    if (shouldShowSetup(prefs, library, nativeFirstRun) && !catalogPending) show(true);
+  }
+
+  function capabilities() {
+    el('setupPhotosAll').disabled = !photosAvailable;
+    el('setupPhotosSelected').hidden = !nativeBridge()
+      || window.__LIGHTTABLE_PLATFORM__ === 'windows';
+    el('setupPhotosAvailability').hidden = photosAvailable;
+    el('setupFolderPathField').hidden = nativeSetup;
+    el('setupFolderChoose').textContent = nativeSetup ? 'Choose folder…' : 'Add folder';
+  }
+
+  async function finish(status = 'completed', source = resultSource) {
+    if (busy) return;
+    busy = true;
+    el('setupDone').disabled = el('setupLater').disabled = true;
+    try {
+      const value = { version: 1, status, source: source || null };
+      const patch = { firstRunSetup: value };
+      // Folder archives and Photos originals can live entirely in subfolders.
+      if (status === 'completed') patch.includeSubfolders = true;
+      const result = await post('/api/prefs', patch);
+      if (!result?.ok || result.error) throw new Error(result?.error || 'Could not save setup.');
+      prefs = { ...prefs, firstRunSetup: value };
+      sendNative('completeFirstRun');
+      if (status === 'completed') onComplete?.();
+      show(false);
+    } catch (error) {
+      el('setupError').textContent = `${error.message} Please try again.`;
+    } finally {
+      busy = false;
+      el('setupDone').disabled = el('setupLater').disabled = false;
+    }
+  }
+
+  function showResult(source, title, message) {
+    busy = false;
+    resultSource = source;
+    el('setupHeading-result').textContent = title;
+    el('setupResultMessage').textContent = message;
+    setPage('result');
+    show(true);
+  }
+
+  function photosEvent(event) {
+    const running = event.state === 'running';
+    if (running) {
+      busy = true;
+      setPage('photos-progress');
+      show(true);
+      el('setupPhotosProgress').max = Math.max(1, event.total || 1);
+      el('setupPhotosProgress').value = event.completed || 0;
+      el('setupPhotosProgressText').textContent = (event.message || 'Importing originals…')
+        + (event.total ? ` ${event.completed || 0} of ${event.total} originals` : '');
+      el('setupPhotosCancel').disabled = false;
+      return;
+    }
+    busy = false;
+    if (event.state === 'completed' && event.failures > 0
+        && !(event.imported > 0 || event.existing > 0)) {
+      setPage('photos'); show(true);
+      el('setupError').textContent = `None of the ${event.failures} originals could be imported. Check your connection and available disk space, then try again.`;
+    } else if (event.state === 'completed') {
+      showResult('photos', event.failures ? 'Your Photos import is ready to review' : 'Your photos are ready',
+        `${event.imported || 0} originals imported · ${event.existing || 0} already added`
+        + (event.failures ? ` · ${event.failures} could not be imported. Run this import again to retry.` : '.')
+        + ' Add new photos later by running this import again.');
+    } else if (event.state === 'cancelled') {
+      setPage('photos'); show(true);
+      el('setupError').textContent = event.message || 'Import stopped. Any completed copies are kept; you can resume by importing again.';
+    } else if (event.state === 'error') {
+      setPage('photos'); show(true);
+      el('setupError').textContent = event.message || 'Photos could not be imported. Try again or choose a folder.';
+    }
+  }
+
+  el('setupLightroom').onclick = () => setPage('lightroom');
+  el('setupPhotos').onclick = () => { capabilities(); setPage('photos'); };
+  el('setupFolder').onclick = () => { capabilities(); setPage('folder'); };
+  el('setupBack').onclick = () => { if (!busy) setPage('choices'); };
+  el('setupLater').onclick = () => finish('skipped', null);
+  el('setupDone').onclick = () => finish();
+  el('setupCatalogChoose').onclick = () => {
+    catalogPending = true;
+    catalogResult = null;
+    show(false);
+    openCatalog();
+  };
+  el('setupPhotosAll').onclick = () => {
+    el('setupError').textContent = '';
+    if (!photosAvailable || !sendNative('importApplePhotosLibrary')) return;
+    busy = true;
+    setPage('photos-progress');
+    el('setupPhotosProgress').removeAttribute('value');
+    el('setupPhotosProgressText').textContent = 'Waiting for access to Photos…';
+  };
+  el('setupPhotosCancel').onclick = () => {
+    sendNative('cancelApplePhotosLibraryImport');
+    el('setupPhotosCancel').disabled = true;
+    el('setupPhotosProgressText').textContent = 'Stopping import…';
+  };
+  el('setupPhotosSelected').onclick = () => sendNative('importApplePhotos');
+  el('setupFolderChoose').onclick = async () => {
+    if (nativeSetup) { sendNative('setupChooseFolder'); return; }
+    const path = el('setupFolderPath').value.trim();
+    if (!path) { el('setupFolderPath').focus(); return; }
+    el('setupFolderChoose').disabled = true;
+    try {
+      const result = await post('/api/catalog/sources', { action: 'add', path });
+      if (!result?.ok || result.error) throw new Error(result?.error || 'Could not add that folder.');
+      await reloadLibrary();
+      showResult('folder', 'Your folder is ready', 'Photos stay in their current folder. You can add more folders whenever you like.');
+    } catch (error) { el('setupError').textContent = error.message; }
+    finally { el('setupFolderChoose').disabled = false; }
+  };
+  el('setupReopen').onclick = () => {
+    window.LightTableSettings?.close();
+    capabilities(); setPage('choices'); show(true);
+  };
+  // Capture before editor shortcuts; Tab stays in the active setup page.
+  document.addEventListener('keydown', (event) => {
+    if (!isOpen()) return;
+    event.stopImmediatePropagation();
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (!busy) page === 'choices' ? finish('skipped', null) : setPage('choices');
+    } else if (event.key === 'Tab') {
+      const targets = [...dialog.querySelectorAll('button, input, [tabindex="0"]')]
+        .filter((node) => !node.disabled && node.getClientRects().length);
+      const index = targets.indexOf(document.activeElement);
+      if (event.shiftKey && index <= 0) { event.preventDefault(); targets.at(-1)?.focus(); }
+      else if (!event.shiftKey && (index < 0 || index === targets.length - 1)) {
+        event.preventDefault(); targets[0]?.focus();
+      }
+    }
+  }, true);
+  capabilities();
+  return {
+    setPrefs(value) { prefs = value; maybeShow(); },
+    setLibrary(value) { library = value; maybeShow(); },
+    catalogCompleted(result) {
+      if (!catalogPending) return;
+      if (!(result.matched > 0)) {
+        setPage('lightroom');
+        el('setupError').textContent = result.images
+          ? 'No originals could be found. Reconnect the photo folders and import the catalog again.'
+          : 'This catalog has no photos. Choose another catalog or start with a folder.';
+        return;
+      }
+      catalogResult = result;
+      resultSource = 'lightroom';
+      el('setupHeading-result').textContent = 'Your Lightroom catalog is imported';
+      el('setupResultMessage').textContent = `${result.matched || 0} photos added. Your original catalog is unchanged.`
+        + (result.unmatched ? ` ${result.unmatched} originals could not be found; reconnect their folders to edit them.` : '');
+      setPage('result');
+    },
+    catalogClosed() {
+      if (!catalogPending) return;
+      catalogPending = false;
+      if (catalogResult && nativeSetup) {
+        sendNative('setupCatalogImported', { paths: catalogResult.sourceFolders || [],
+          matched: catalogResult.matched, unmatched: catalogResult.unmatched });
+        catalogResult = null;
+        return;
+      }
+      show(true);
+    },
+    nativeEvent(event) {
+      if (event?.type === 'sources') {
+        if (typeof event.firstRun === 'boolean') nativeFirstRun = event.firstRun;
+        else if (nativeFirstRun === null) nativeFirstRun = false;
+        nativeSetup = typeof event.firstRun === 'boolean';
+        photosAvailable = event.photosLibraryImportAvailable === true;
+        capabilities();
+        if (prefs?.firstRunSetup?.version >= 1 && nativeFirstRun) sendNative('completeFirstRun');
+        maybeShow();
+      } else if (event?.type === 'photosLibraryImport') photosEvent(event);
+      else if (event?.type === 'setupFolderSelected') {
+        showResult('folder', 'Your folder is ready', 'Photos stay in their current folder. You can add more folders whenever you like.');
+      } else if (event?.type === 'setupCatalogImported') {
+        showResult('lightroom', 'Your Lightroom catalog is imported',
+          `${event.matched || 0} photos added. Your original catalog is unchanged.`
+          + (event.unmatched ? ` ${event.unmatched} originals could not be found; reconnect their folders to edit them.` : ''));
+      } else if (event?.type === 'setupFolderCancelled') {
+        setPage('folder'); show(true);
+      } else if (event?.type === 'photosImported' && event.count > 0
+          && (isOpen() || nativeFirstRun)) {
+        showResult('photos', 'Your photos are ready', `${event.count} photos imported.`
+          + (event.failures ? ` ${event.failures} could not be imported.` : ''));
+      } else if (event?.type === 'error' && isOpen()) {
+        el('setupError').textContent = event.message || 'Something went wrong. Please try again.';
+      }
+    },
+  };
+}

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -17,6 +17,18 @@
       ],
       "sections": [
         {
+          "title": "Choose a starting point",
+          "paragraphs": [
+            "On a new library, setup offers a local folder, Lightroom migration, or Apple Photos. You can skip setup and add photos later.",
+            "Apple Photos whole-library import requires the macOS app and permission to read Photos. It copies original photos, including RAW files, into Pictures / LightTable Imports / Apple Photos. Your Photos library stays unchanged. iCloud originals download during import, so allow time and disk space. Albums, videos, and Photos edits are not transferred.",
+            "Stop import keeps completed copies. Running it again skips those copies and retries unfinished originals."
+          ],
+          "steps": [
+            "Choose a folder to browse originals in place, or select one of the migration options.",
+            "Review the import result, then continue into the library."
+          ]
+        },
+        {
           "title": "Open a local folder",
           "paragraphs": [
             "In the desktop app, Add Photos opens a picker for photos and folders. LightTable keeps the originals in their current location. Selecting an individual photo adds its containing folder, so other supported photos in that folder can appear too."
@@ -62,15 +74,15 @@
         {
           "title": "Prepare and inspect",
           "paragraphs": [
-            "The importer reads a temporary copy of a Lightroom Classic .lrcat catalog. It matches photos already added to LightTable; it does not automatically add missing source folders or copy original photos."
+            "The importer reads a temporary copy of a Lightroom Classic .lrcat catalog. Add the photo folders used by this catalog lets the import register referenced originals and their containing folders. It leaves originals in place. Clear that option to match only photos already in LightTable.",
+            "Preview compatibility reports matches in the current library without changing it. Photos not yet added may show as unmatched in the preview; importing with Add the photo folders enabled registers available originals before matching again."
           ],
           "steps": [
-            "Add the folders containing the Lightroom originals to LightTable and let them scan.",
-            "Open Local ••• → Import catalog….",
-            "Choose the .lrcat file, or enter its path, then review the photo counts, folder roots, and warnings.",
-            "Choose which categories to import: metadata, keywords, collections, stacks, approximate develop settings, and optional edit history.",
-            "For photos with existing edits, choose Keep mine or Replace with imported.",
-            "Click Import and review the final matched, not found, and skipped counts."
+            "Open Local ••• → Import catalog…, or choose the Lightroom Classic catalog option in setup.",
+            "Choose the .lrcat file and review its counts and warnings.",
+            "Choose the categories to import, the policy for existing edits, and whether to add the referenced photo folders.",
+            "Click Preview compatibility and review mapped and skipped settings. Try 20 variants creates separate trial edits before a larger import.",
+            "Click Import after reviewing compatibility, then read the report and matched, not found, and skipped counts. LightTable creates a catalog backup before a trial or import."
           ]
         },
         {
@@ -1159,7 +1171,7 @@
           ],
           "steps": [
             "Choose an aspect ratio. Use Custom to enter your own width-to-height proportion, and the swap button to change orientation.",
-            "Drag a handle to resize the crop or drag inside the frame to move it. Drag outside the existing frame to draw a new crop.",
+            "Drag a handle to resize the crop; the photo zooms to keep the frame centred. Drag inside the frame to move the photo under it, or outside it to draw a new crop.",
             "Use arrow keys to nudge the selection; hold Shift for larger steps.",
             "Click Done or press Enter to accept. Click Cancel or press Escape to restore the frame from when you opened Crop."
           ],
@@ -2495,7 +2507,7 @@
         {
           "title": "Back up and inspect",
           "paragraphs": [
-            "Settings → Catalog shows the catalog location and backup preferences. These backups cover the catalog database; keep a separate backup of your original photo files."
+            "Settings → Catalog shows the catalog location and backup preferences. Backups include catalog organization, edits, stored masks, history, and variants. Back up original photos, external presets and profiles, and preferences separately."
           ],
           "steps": [
             "Choose an Automatic backup interval and Backup location.",

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -1,0 +1,2576 @@
+{
+  "version": 1,
+  "articles": [
+    {
+      "id": "add-photos",
+      "title": "Add photos and start browsing",
+      "category": "Getting started",
+      "summary": "Open photos or folders in place, then choose a folder and start reviewing.",
+      "keywords": [
+        "start",
+        "open",
+        "browse",
+        "add folder",
+        "originals",
+        "import",
+        "new library"
+      ],
+      "sections": [
+        {
+          "title": "Open a local folder",
+          "paragraphs": [
+            "In the desktop app, Add Photos opens a picker for photos and folders. LightTable keeps the originals in their current location. Selecting an individual photo adds its containing folder, so other supported photos in that folder can appear too."
+          ],
+          "steps": [
+            "Click Add Photos at the upper left and choose one or more photos or folders.",
+            "Choose the folder under Local in the left sidebar. Turn on Include subfolders to browse photos in its child folders.",
+            "Choose Photo Grid, Culling Grid, or Detail at the top. Click a photo to make it active."
+          ],
+          "tips": [
+            "If the sidebar is hidden, use Show or hide library at the upper left."
+          ]
+        },
+        {
+          "title": "Bring new files into an existing folder",
+          "paragraphs": [
+            "Use the Local ••• menu and Rescan folders after adding files outside LightTable. To copy photos from a card into a destination folder, use Import from card… in that menu."
+          ]
+        }
+      ],
+      "related": [
+        "browse-folders",
+        "import-from-card",
+        "views-and-selection"
+      ]
+    },
+    {
+      "id": "import-lightroom-catalog",
+      "title": "Bring a Lightroom Classic catalog into LightTable",
+      "category": "Getting started",
+      "summary": "Import supported metadata and approximate edits, then review the conversion report.",
+      "keywords": [
+        "Lightroom",
+        "Lightroom Classic",
+        "migrate",
+        "migration",
+        "catalog import",
+        "lrcat",
+        "sidecars",
+        "XMP"
+      ],
+      "sections": [
+        {
+          "title": "Prepare and inspect",
+          "paragraphs": [
+            "The importer reads a temporary copy of a Lightroom Classic .lrcat catalog. It matches photos already added to LightTable; it does not automatically add missing source folders or copy original photos."
+          ],
+          "steps": [
+            "Add the folders containing the Lightroom originals to LightTable and let them scan.",
+            "Open Local ••• → Import catalog….",
+            "Choose the .lrcat file, or enter its path, then review the photo counts, folder roots, and warnings.",
+            "Choose which categories to import: metadata, keywords, collections, stacks, approximate develop settings, and optional edit history.",
+            "For photos with existing edits, choose Keep mine or Replace with imported.",
+            "Click Import and review the final matched, not found, and skipped counts."
+          ]
+        },
+        {
+          "title": "Review translated edits",
+          "paragraphs": [
+            "Develop settings are approximate and cannot promise Lightroom’s rendered appearance. Unsupported local masks, camera profiles, .lrcat-data AI masks or LUT payloads, and unsupported smart-collection rules are reported as skipped. Imported develop settings turn Film off.",
+            "Local ••• → Import sidecars… is a separate action for reading supported metadata from adjacent sidecars. That action does not apply develop settings or crop."
+          ]
+        }
+      ],
+      "related": [
+        "add-photos",
+        "collections",
+        "metadata-and-keywords"
+      ]
+    },
+    {
+      "id": "shortcut-schemes",
+      "title": "Choose LightTable or Classic shortcuts",
+      "category": "Getting started",
+      "summary": "Choose the keyboard layout that fits your editing habits.",
+      "keywords": [
+        "keyboard",
+        "shortcuts",
+        "classic",
+        "Lightroom",
+        "crop key",
+        "detail key",
+        "before after"
+      ],
+      "sections": [
+        {
+          "title": "Choose a scheme",
+          "paragraphs": [
+            "Open Settings → Shortcuts & Hardware and choose Shortcut scheme. LightTable and Classic share most culling shortcuts, but differ for Detail, Crop, and before/after Compare."
+          ],
+          "steps": [
+            "Choose LightTable for D = Detail, C = Crop, and backslash (\\) = before/after Compare.",
+            "Choose Classic for E = Detail, R = Crop, and C = before/after Compare."
+          ],
+          "tips": [
+            "Both schemes use G for Photo Grid, Shift+G for Culling Grid, N for Survey, P/X/U for flags, and 0–5 for stars.",
+            "Hold B to show the original while inspecting an edit. Slash (/) focuses photo search.",
+            "Photo shortcuts are ignored while typing in text, number, or selection fields. Leave the field before using a photo command."
+          ]
+        }
+      ],
+      "related": [
+        "views-and-selection",
+        "flags-and-ratings",
+        "colour-labels",
+        "survey-photos"
+      ]
+    },
+    {
+      "id": "import-from-card",
+      "title": "Import photos from a card",
+      "category": "Getting started",
+      "summary": "Copy selected photos into dated folders, with verification and an optional second copy.",
+      "keywords": [
+        "ingest",
+        "memory card",
+        "camera card",
+        "copy",
+        "backup",
+        "duplicates",
+        "import photos"
+      ],
+      "sections": [
+        {
+          "title": "Plan the copy",
+          "paragraphs": [
+            "Import from card copies files into the destination you choose. The card originals stay in place."
+          ],
+          "steps": [
+            "Open Local ••• → Import from card….",
+            "Choose the Source and Destination. Set Folder template and Rename to before scanning. The defaults keep filenames and organize copies as year/year-month-day.",
+            "Choose verification: Full hash, Size only, or None. Set Duplicates to Skip or Copy anyway, and optionally choose Second copy to.",
+            "Click Scan. Review the destination preview and the checked files, then click Import.",
+            "Wait for the copied count and check whether any files failed."
+          ],
+          "tips": [
+            "Template tokens include {filename}, {sequence}, {custom}, {camera}, {yyyy}, {mm}, and {dd}. Start at controls the four-digit sequence.",
+            "The selection list currently shows up to 200 files per scan. Only checked entries in that list are submitted. Check the completed count when working with a larger card.",
+            "If files are reported as cloud-only, download them locally and scan again."
+          ]
+        },
+        {
+          "title": "Refresh the plan when settings change",
+          "paragraphs": [
+            "Scan again after changing the destination or naming templates so you can review the updated paths before importing."
+          ]
+        }
+      ],
+      "related": [
+        "add-photos",
+        "rename-photos"
+      ]
+    },
+    {
+      "id": "views-and-selection",
+      "title": "Switch views and select photos",
+      "category": "Getting started",
+      "summary": "Use the grids to choose a set and Detail to inspect an individual photo.",
+      "keywords": [
+        "grid",
+        "detail",
+        "filmstrip",
+        "select multiple",
+        "shift click",
+        "command click",
+        "control click",
+        "navigation",
+        "zoom"
+      ],
+      "sections": [
+        {
+          "title": "Move between views",
+          "paragraphs": [
+            "Photo Grid presents photos as a visual overview. Culling Grid adds room for selection and rating information. Detail opens the active photo for close inspection."
+          ],
+          "steps": [
+            "Use the three Photo view buttons at the top. In the LightTable shortcut scheme, G opens Photo Grid, Shift+G opens Culling Grid, and D opens Detail.",
+            "In a grid, use the Size slider to change thumbnail size.",
+            "Use the left and right arrow keys to move between photos. In Detail, Space toggles Fit and 1:1 when the photo area has focus."
+          ]
+        },
+        {
+          "title": "Build a selection",
+          "paragraphs": [
+            "Click selects a single active photo. Shift-click selects a contiguous range. Command-click on Mac or Control-click adds or removes individual photos.",
+            "In a grid, flag, rating, and colour-label actions apply to the selected set. In Detail, those marking actions apply to the active photo. In Survey, they apply to the active survey cell. Check the marking toolbar’s context before a batch action."
+          ]
+        }
+      ],
+      "related": [
+        "flags-and-ratings",
+        "survey-photos",
+        "shortcut-schemes"
+      ]
+    },
+    {
+      "id": "metadata-and-keywords",
+      "title": "Add keywords, captions, and rights information",
+      "category": "Library",
+      "summary": "Make photos easier to find and prepare descriptive metadata for export.",
+      "keywords": [
+        "metadata",
+        "IPTC",
+        "EXIF",
+        "keywords",
+        "caption",
+        "title",
+        "copyright",
+        "creator",
+        "location",
+        "GPS"
+      ],
+      "sections": [
+        {
+          "title": "Add searchable keywords",
+          "paragraphs": [
+            "Open Info on the active photo. Enter keywords in Add keywords and click Add or press Enter. Commas separate keywords; Settings → Files & Metadata can also enable semicolon separators and catalog keyword suggestions.",
+            "Use a hierarchical path such as Places > Boston to keep related terms together. The Keyword tree lists catalog terms; click a term to search, or double-click it to rename that catalog keyword."
+          ],
+          "tips": [
+            "The keyword entry acts on the active photo, rather than every selected grid photo. Link pair metadata can also update its RAW or JPEG companion."
+          ]
+        },
+        {
+          "title": "Describe the photo",
+          "paragraphs": [
+            "In Info, expand Description for title, caption, and headline; Rights for creator, copyright, and credit; or Place for location and coordinates. Changes save to the catalog as you type.",
+            "Apply to selection copies the current metadata form to selected photos, including its blank fields. Review the whole form first. Metadata is included in exports according to the export recipe; editing these fields does not rewrite the original image file."
+          ]
+        }
+      ],
+      "related": [
+        "search-filter-sort",
+        "raw-jpeg-pairs",
+        "capture-time"
+      ]
+    },
+    {
+      "id": "browse-folders",
+      "title": "Browse folders and save favorites",
+      "category": "Library",
+      "summary": "Choose the folder scope, include subfolders, and keep frequent folders close at hand.",
+      "keywords": [
+        "favorites",
+        "local",
+        "folders",
+        "sidebar",
+        "missing photos",
+        "rescan",
+        "synchronize"
+      ],
+      "sections": [
+        {
+          "title": "Choose what is in view",
+          "paragraphs": [
+            "Local → Browse lists your added folders. Include subfolders controls whether a selected folder also shows its descendants. Other library filters still apply."
+          ],
+          "steps": [
+            "Click a folder under Local.",
+            "Turn Include subfolders on to include child folders, or off to view only that folder.",
+            "Click the star beside a folder, or open its ••• menu and choose Add as Favorite.",
+            "Use Local → Favorites to return to your saved folders."
+          ]
+        },
+        {
+          "title": "Folder actions",
+          "paragraphs": [
+            "A folder’s ••• menu includes Show in Finder on Mac or Show in File Explorer on Windows. For the current folder, Synchronize Folder refreshes the view. Local ••• → Rescan folders scans the catalog sources.",
+            "Remove from LightTable removes an added root from the app’s source list; it does not move the original files to the Trash. The action is offered when more than one source is available."
+          ]
+        }
+      ],
+      "related": [
+        "add-photos",
+        "search-filter-sort",
+        "trash-rejected"
+      ]
+    },
+    {
+      "id": "survey-photos",
+      "title": "Compare several photos in Survey",
+      "category": "Library",
+      "summary": "Review a group together, mark the active frame, and narrow a set of candidates.",
+      "keywords": [
+        "survey",
+        "compare photos",
+        "compare frames",
+        "burst",
+        "side by side",
+        "keeper",
+        "make select"
+      ],
+      "sections": [
+        {
+          "title": "Review a group",
+          "paragraphs": [
+            "Survey displays original previews for choosing between photos. It shows up to 16 selected photos. If there is no explicit selection, it uses up to six nearby photos in the current view."
+          ],
+          "steps": [
+            "Select candidates in a grid and press N, or open Info → Survey selection.",
+            "Click a photo to make that survey cell active. Use left and right arrows to move between cells.",
+            "Use the marking toolbar or flag, rating, and label shortcuts on the active cell.",
+            "Click × on a cell to remove it from the survey without deleting or rejecting it. Double-click a cell to open that photo in Detail.",
+            "Click Close or press Escape to leave Survey."
+          ]
+        },
+        {
+          "title": "Choose one keeper",
+          "paragraphs": [
+            "Make select picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.",
+            "To judge an edit against its original, use before/after Compare in Detail; Survey is for choosing among different frames."
+          ]
+        }
+      ],
+      "related": [
+        "views-and-selection",
+        "flags-and-ratings",
+        "raw-jpeg-pairs",
+        "shortcut-schemes"
+      ]
+    },
+    {
+      "id": "capture-time",
+      "title": "Correct a camera clock or time zone",
+      "category": "Library",
+      "summary": "Preview a shared clock correction while preserving the intervals between photos.",
+      "keywords": [
+        "capture time",
+        "date",
+        "camera clock",
+        "time zone",
+        "timezone",
+        "daylight saving",
+        "sort date",
+        "timestamp"
+      ],
+      "sections": [
+        {
+          "title": "Preview the correction",
+          "paragraphs": [
+            "Capture-time corrections change catalog dates used for capture-date sorting and exported metadata. Original image files and filesystem dates stay unchanged."
+          ],
+          "steps": [
+            "Select the affected photos and open Info → Correct capture time.",
+            "Enter Shift clock by hours, such as -1 or 5.5.",
+            "Optionally enter Assign time zone as an offset such as -04:00 or +05:30. Leave it blank to keep the existing zone, or enter remove to clear it.",
+            "Choose whether to Include RAW + JPEG companions.",
+            "Click Preview selection and review the before-and-after times and any skipped photos.",
+            "Click Apply previewed changes. If you change the selection or correction controls, preview again first."
+          ]
+        },
+        {
+          "title": "Restore a correction",
+          "paragraphs": [
+            "Assigning a time zone does not also shift the camera clock. Use the shift field when the displayed time itself is wrong.",
+            "Undo last correction reverses the most recent correction held in this window. Restore camera times… previews removing catalog corrections; review the preview and apply it to restore original camera times. Capture-time steps are also available in History."
+          ]
+        }
+      ],
+      "related": [
+        "search-filter-sort",
+        "metadata-and-keywords",
+        "raw-jpeg-pairs"
+      ]
+    },
+    {
+      "id": "search-filter-sort",
+      "title": "Find photos with search, filters, and sorting",
+      "category": "Library",
+      "summary": "Narrow the current folder or collection by text, flags, stars, colour, and file kind.",
+      "keywords": [
+        "find",
+        "search",
+        "keywords",
+        "rating filter",
+        "sort",
+        "capture date",
+        "no results",
+        "unrated"
+      ],
+      "sections": [
+        {
+          "title": "Search the current view",
+          "paragraphs": [
+            "The search box matches text in filenames, display names, keywords, and available photo-index metadata. It searches within the current folder or collection and combines with the other active filters."
+          ],
+          "steps": [
+            "Click Search photos and keywords, or press / when you are not typing in a field.",
+            "Type a word or phrase from the filename or keywords.",
+            "Use All Photos, Unflagged, Picked, Rejected, or Rated in the sidebar to choose a flag or rating group.",
+            "Expand Filter for workflow state, minimum rating, colour label, and file kind.",
+            "Choose File name, Rating, Flag, Capture date, or Colour label in Sort."
+          ]
+        },
+        {
+          "title": "When a photo seems missing",
+          "paragraphs": [
+            "Clear the search text and reset Filter choices, then check the selected folder, Include subfolders, and any active collection. Paired-file preferences and collapsed stacks can also hide a companion or stack member.",
+            "Capture date sorts from earlier to later; Rating sorts higher ratings first."
+          ]
+        }
+      ],
+      "related": [
+        "browse-folders",
+        "smart-collections",
+        "raw-jpeg-pairs",
+        "virtual-copies-and-stacks"
+      ]
+    },
+    {
+      "id": "collections",
+      "title": "Group photos into collections",
+      "category": "Library",
+      "summary": "Create named groups without moving the original files.",
+      "keywords": [
+        "collection",
+        "album",
+        "organize",
+        "group",
+        "selected",
+        "delete collection"
+      ],
+      "sections": [
+        {
+          "title": "Create and add photos",
+          "paragraphs": [
+            "A regular collection stores a chosen set of photos. It is separate from the folder arrangement on disk."
+          ],
+          "steps": [
+            "Select the photos you want to group.",
+            "Click Create collection or the + beside Collections, enter a name, and save. The current selection is included.",
+            "Click a collection to view it. Clicking the active collection again leaves it.",
+            "With a regular collection active, choose photos to add and click Add selected to collection."
+          ]
+        },
+        {
+          "title": "Delete a collection",
+          "paragraphs": [
+            "The × beside a collection deletes the collection. This removes the grouping rather than moving original files to the Trash. Search and filters can further narrow the photos shown inside a collection."
+          ]
+        }
+      ],
+      "related": [
+        "smart-collections",
+        "views-and-selection",
+        "browse-folders"
+      ]
+    },
+    {
+      "id": "trash-rejected",
+      "title": "Move rejected photos to the Trash",
+      "category": "Library",
+      "summary": "Review the current view carefully before moving rejected originals and sidecars.",
+      "keywords": [
+        "delete",
+        "trash",
+        "rejected",
+        "restore",
+        "recover",
+        "remove originals",
+        "recycle bin"
+      ],
+      "sections": [
+        {
+          "title": "Review and move rejected files",
+          "paragraphs": [
+            "Rejecting a photo only changes its flag. Move Rejected Photos to Trash is a separate desktop action that affects rejected photos in the current view, not just the active photo."
+          ],
+          "steps": [
+            "Choose the folder or collection and filters that define the photos you want to review.",
+            "Inspect the rejected photos. Check paired-file settings and expand any stacks if you expect to include their other members.",
+            "On Mac, choose Photo → Move Rejected Photos to Trash…, or press Command+Delete.",
+            "Read the photo count in the confirmation and confirm only when it matches your intended set."
+          ],
+          "tips": [
+            "Adjacent XMP sidecars move with the originals. Hidden RAW or JPEG companions stay in the library; choose Both files in paired-capture settings to include them.",
+            "A virtual copy shares its original file. Deleting a virtual copy should use Photo actions → Delete virtual copy; moving its source to the Trash affects every edit that uses that original."
+          ]
+        },
+        {
+          "title": "Recover a mistaken removal on Mac",
+          "paragraphs": [
+            "Use Finder’s Trash to put the original and its sidecars back in their previous folder, then rescan the folder in LightTable. The app does not have an in-app Trash browser."
+          ]
+        }
+      ],
+      "related": [
+        "flags-and-ratings",
+        "raw-jpeg-pairs",
+        "browse-folders",
+        "virtual-copies-and-stacks"
+      ]
+    },
+    {
+      "id": "colour-labels",
+      "title": "Organize a workflow with colour labels",
+      "category": "Library",
+      "summary": "Use five colours independently of picks and star ratings.",
+      "keywords": [
+        "color",
+        "colour",
+        "labels",
+        "red",
+        "yellow",
+        "green",
+        "blue",
+        "purple",
+        "workflow"
+      ],
+      "sections": [
+        {
+          "title": "Apply and filter a label",
+          "paragraphs": [
+            "Colour labels are yours to assign meaning to—for example, red for retouching or green for delivery. They do not change star ratings or pick/reject status."
+          ],
+          "steps": [
+            "Select a photo, or a set in a grid, and open Info.",
+            "Under Colour label, choose Red, Yellow, Green, Blue, or Purple. Choose No label to clear it.",
+            "Use 6 for Red, 7 for Yellow, 8 for Green, and 9 for Blue. Purple is available from the colour controls.",
+            "Expand Filter in the library sidebar and use Colour label to find a particular colour, any colour, or unlabelled photos."
+          ],
+          "tips": [
+            "Applying the same label again clears it. Colour-label actions do not auto-advance."
+          ]
+        }
+      ],
+      "related": [
+        "flags-and-ratings",
+        "search-filter-sort",
+        "shortcut-schemes"
+      ]
+    },
+    {
+      "id": "flags-and-ratings",
+      "title": "Pick, reject, and rate photos",
+      "category": "Library",
+      "summary": "Mark keepers and rejects, give star ratings, and control automatic advance.",
+      "keywords": [
+        "cull",
+        "pick",
+        "reject",
+        "flag",
+        "unflag",
+        "stars",
+        "rating",
+        "auto advance",
+        "keeper"
+      ],
+      "sections": [
+        {
+          "title": "Mark the active photo or grid selection",
+          "paragraphs": [
+            "Flags and stars are separate: a photo can be Picked and have any star rating. Reject marks a photo for review; it does not delete it."
+          ],
+          "steps": [
+            "Use Pick, Reject, and Unflag in the marking toolbar or Info. The P, X, and U keys perform the same actions.",
+            "Click a star or press 1–5 to rate. Press 0 to clear the rating.",
+            "To clear an existing pick, reject, or rating, apply that same mark again.",
+            "Use the sidebar’s Picked, Rejected, and Rated views to review your decisions."
+          ]
+        },
+        {
+          "title": "Control what happens next",
+          "paragraphs": [
+            "Turn Auto-advance on to move to the next photo after picking, rejecting, or rating a single photo. Unflagging does not advance.",
+            "When multiple photos are selected in a grid, marks apply to that set without advancing. If Link pair metadata is on, marking also updates recognized RAW and JPEG companions."
+          ]
+        }
+      ],
+      "related": [
+        "views-and-selection",
+        "colour-labels",
+        "raw-jpeg-pairs",
+        "trash-rejected"
+      ]
+    },
+    {
+      "id": "rename-photos",
+      "title": "Rename photos with a preview",
+      "category": "Library",
+      "summary": "Apply a consistent filename template to selected originals and their sidecars.",
+      "keywords": [
+        "rename",
+        "filename",
+        "sequence",
+        "batch",
+        "custom text",
+        "date tokens",
+        "sidecars"
+      ],
+      "sections": [
+        {
+          "title": "Preview and apply",
+          "paragraphs": [
+            "Rename changes filenames on disk and keeps the catalog records with the files. It also handles adjacent XMP sidecars. This is different from naming a virtual copy."
+          ],
+          "steps": [
+            "Select the photos to rename.",
+            "Open Info → Rename… (or Photo → Rename… in the Mac menu).",
+            "Enter a Template such as {custom}_{sequence}. Set Custom text and Start at as needed.",
+            "Review the before-and-after filenames in the preview.",
+            "Click Rename to apply."
+          ],
+          "tips": [
+            "Available tokens include {filename}, {camera}, {sequence}, {custom}, {yyyy}, {yy}, {mm}, {dd}, {hh}, {min}, and {ss}. Sequence numbers use four digits.",
+            "The original extension is retained. A naming collision receives a numeric suffix. Rename templates cannot create folders.",
+            "A virtual copy shares its source file: including one in a rename targets that original. The interface does not provide a dedicated rename-undo button."
+          ]
+        }
+      ],
+      "related": [
+        "import-from-card",
+        "virtual-copies-and-stacks",
+        "views-and-selection"
+      ]
+    },
+    {
+      "id": "smart-collections",
+      "title": "Save a search as a smart collection",
+      "category": "Library",
+      "summary": "Keep a named group that updates from supported rules as photo metadata changes.",
+      "keywords": [
+        "smart collection",
+        "saved search",
+        "dynamic",
+        "filter rules",
+        "automatically",
+        "minimum rating"
+      ],
+      "sections": [
+        {
+          "title": "Save supported rules",
+          "paragraphs": [
+            "A smart collection finds photos that match its saved rules. Supported rules are pick/reject/unflag status, minimum star rating, file kind, and search text."
+          ],
+          "steps": [
+            "Set the search text, desired flag group, minimum rating, and file kind in the library.",
+            "Click the ✦ beside Collections, labelled Save filters as smart collection.",
+            "Name the collection and save.",
+            "Click its name to view matching photos. Changing a photo’s relevant metadata changes whether it matches."
+          ]
+        },
+        {
+          "title": "Know what is saved",
+          "paragraphs": [
+            "Colour-label filters, the selected folder, and Include subfolders are not saved in the smart collection rules. Edited and Unrated only are not supported smart-collection rules. Use supported flag and minimum-rating choices when creating one.",
+            "You cannot manually add photos with Add selected to collection while a smart collection is active. Current search and sidebar filters can still narrow the collection view."
+          ]
+        }
+      ],
+      "related": [
+        "collections",
+        "search-filter-sort",
+        "flags-and-ratings"
+      ]
+    },
+    {
+      "id": "virtual-copies-and-stacks",
+      "title": "Try virtual copies and group photos in stacks",
+      "category": "Library",
+      "summary": "Keep alternate edits of one original and collapse related photos in the grid.",
+      "keywords": [
+        "virtual copy",
+        "version",
+        "alternate edit",
+        "stack",
+        "unstack",
+        "duplicate",
+        "copy"
+      ],
+      "sections": [
+        {
+          "title": "Create an alternate edit",
+          "paragraphs": [
+            "A virtual copy refers to the same original file and keeps an independent edit state. It does not create a second original on disk."
+          ],
+          "steps": [
+            "Make the source photo active.",
+            "Open the Photo actions ••• menu beside Sort and Size, then choose Create virtual copy.",
+            "Name the copy and save. The new copy becomes active.",
+            "Edit the copy. Use Filter → Workflow state → Virtual copies to find copies later."
+          ],
+          "tips": [
+            "Delete virtual copy in Photo actions removes the active virtual copy. For a real second file on disk, export a rendered image."
+          ]
+        },
+        {
+          "title": "Collapse a group",
+          "paragraphs": [
+            "Select at least two photos, then choose Photo actions ••• → Stack selected photos and enter a name. The stack’s grid badge shows the member count; click it to expand or collapse. Unstack selected photos removes the grouping."
+          ]
+        }
+      ],
+      "related": [
+        "views-and-selection",
+        "search-filter-sort",
+        "collections"
+      ]
+    },
+    {
+      "id": "raw-jpeg-pairs",
+      "title": "Work with RAW and JPEG pairs",
+      "category": "Library",
+      "summary": "Choose which companion to show and whether new metadata changes affect both.",
+      "keywords": [
+        "raw",
+        "jpeg",
+        "jpg",
+        "pair",
+        "companion",
+        "linked metadata",
+        "hidden jpeg"
+      ],
+      "sections": [
+        {
+          "title": "Choose the visible companion",
+          "paragraphs": [
+            "LightTable recognizes a pair when one RAW and one JPEG share the same base filename in the same source and folder. Each file keeps its own edits; virtual copies remain independent."
+          ],
+          "steps": [
+            "Open Settings → Files & Metadata and turn on Pair RAW and JPEG captures.",
+            "Set Show paired captures to Both files, Prefer RAW, or Prefer JPEG.",
+            "When viewing a paired photo, use RAW → JPEG or JPEG → RAW near the top to switch to its companion."
+          ]
+        },
+        {
+          "title": "Link new metadata changes",
+          "paragraphs": [
+            "Turn on Link pair metadata to link new ratings, flags, labels, and keyword changes. It does not combine the photo edits.",
+            "Exports and Trash use the files you choose or include in the current view. They do not automatically include a hidden companion. Choose Both files and review the selection when you need both originals. Capture-time correction has its own Include RAW + JPEG companions checkbox."
+          ]
+        }
+      ],
+      "related": [
+        "flags-and-ratings",
+        "metadata-and-keywords",
+        "capture-time",
+        "trash-rejected"
+      ]
+    },
+    {
+      "id": "editing-effects",
+      "title": "Adjust Texture, Clarity, Dehaze, and Vignette",
+      "category": "Editing",
+      "summary": "Refine surface detail, local contrast, haze, and edge brightness from the Effects section.",
+      "keywords": [
+        "effects",
+        "texture",
+        "clarity",
+        "dehaze",
+        "haze",
+        "vignette",
+        "soften",
+        "detail",
+        "local contrast",
+        "dark edges",
+        "bright edges"
+      ],
+      "sections": [
+        {
+          "title": "Refine detail and contrast",
+          "paragraphs": [
+            "Expand Effects in Edit. Texture changes fine local detail, while Clarity applies local contrast with greater emphasis on midtones. Positive values strengthen these effects; negative values soften them."
+          ],
+          "steps": [
+            "Adjust Texture while looking at a textured part of the photo, such as fabric, foliage, or skin.",
+            "Adjust Clarity while checking contrast around the subject and edges.",
+            "Inspect at 1:1 and then return to Fit to judge the overall result."
+          ],
+          "tips": [
+            "For a localized treatment, use a mask’s Texture and Clarity controls."
+          ]
+        },
+        {
+          "title": "Change haze and edge brightness",
+          "paragraphs": [
+            "Dehaze changes the image’s haze-like tonal and color treatment. Vignette changes edge brightness: positive values darken the edges and negative values brighten them."
+          ],
+          "steps": [
+            "Increase Dehaze to strengthen a hazy image, or try a negative value for a softer treatment. Check both contrast and color as you adjust it.",
+            "Set Vignette for the edge treatment you want and inspect the corners.",
+            "Hold B to compare with the original, or use Effects’ Reset to reset Texture, Clarity, Dehaze, and Vignette together."
+          ],
+          "tips": [
+            "Effects’ Vignette is a creative edge treatment. Use Lens corrections when you want to correct lens shading."
+          ]
+        }
+      ],
+      "related": [
+        "editing-detail-effects-enhance",
+        "editing-lens-corrections",
+        "editing-masks-brush-gradients",
+        "editing-tone"
+      ]
+    },
+    {
+      "id": "editing-tone",
+      "title": "Adjust exposure, contrast, and tonal range",
+      "category": "Editing",
+      "summary": "Use Light controls and the histogram to set brightness and contrast, then check the result against the original.",
+      "keywords": [
+        "exposure",
+        "brightness",
+        "light",
+        "tone",
+        "contrast",
+        "highlights",
+        "shadows",
+        "whites",
+        "blacks",
+        "auto",
+        "histogram",
+        "clipping",
+        "before"
+      ],
+      "sections": [
+        {
+          "title": "Start with Light",
+          "paragraphs": [
+            "Open Edit and expand Light. Exposure changes overall brightness; Highlights and Shadows let you target bright and dark regions. Whites and Blacks adjust the ends of the tonal range. Contrast changes their separation."
+          ],
+          "steps": [
+            "Set Exposure for the main subject.",
+            "Adjust Highlights and Shadows to balance bright and dark regions, then refine Whites, Blacks, and Contrast.",
+            "Use the Clipping warning button beside the histogram to inspect clipping.",
+            "Compare your result with the original using the before control, or hold B while the photo is active."
+          ],
+          "tips": [
+            "Light’s Reset resets that group. Use Undo when you want to reverse just your latest adjustment."
+          ]
+        },
+        {
+          "title": "Use Auto as a starting point",
+          "paragraphs": [
+            "Auto in the Light heading analyzes the available image preview and sets Exposure, Blacks, and Whites. It does not set every editing control."
+          ],
+          "steps": [
+            "Wait until the photo preview appears, then click Auto.",
+            "Review the result and refine the sliders for the photograph."
+          ],
+          "tips": [
+            "If Auto says it is waiting for the image preview, let the preview load and try again.",
+            "The scope menu also offers Waveform, RGB Parade, and Vectorscope for inspecting tone and color."
+          ]
+        }
+      ],
+      "related": [
+        "editing-white-balance",
+        "editing-curves",
+        "editing-history-snapshots"
+      ]
+    },
+    {
+      "id": "editing-lens-corrections",
+      "title": "Apply lens and chromatic-aberration corrections",
+      "category": "Editing",
+      "summary": "Use a matched or manually selected lens profile, or make manual corrections when an exact profile is unavailable.",
+      "keywords": [
+        "lens",
+        "profile",
+        "distortion",
+        "vignette",
+        "shading",
+        "chromatic aberration",
+        "fringing",
+        "red cyan",
+        "blue yellow",
+        "optics"
+      ],
+      "sections": [
+        {
+          "title": "Choose and verify a correction",
+          "paragraphs": [
+            "Expand Lens corrections in Edit. The profile card explains the automatic camera/lens match and whether a usable profile is available."
+          ],
+          "steps": [
+            "Read the profile name and match explanation.",
+            "Enable Use matched lens profile when a profile is available, then choose Correct distortion and Correct lens shading as needed.",
+            "If necessary, choose a different entry in Lens profile and compare the correction against the original.",
+            "Refine the manual Distortion and Vignette controls. For color fringes, adjust Red / Cyan and Blue / Yellow under Chromatic aberration."
+          ],
+          "tips": [
+            "No exact lens profile found leaves manual distortion and perspective controls available.",
+            "Profile distortion and shading checkboxes are enabled only when the selected profile supplies that correction and the profile is enabled.",
+            "A manually selected profile needs visual checking; the selection does not establish that it is an exact match.",
+            "Lens and fringe corrections remain non-destructive through export."
+          ]
+        }
+      ],
+      "related": [
+        "editing-crop-geometry",
+        "editing-detail-effects-enhance"
+      ]
+    },
+    {
+      "id": "editing-presets",
+      "title": "Apply, save, and import editing presets",
+      "category": "Editing",
+      "summary": "Reuse editing recipes and inspect conversion coverage when importing Lightroom, Camera Raw, or Capture One presets.",
+      "keywords": [
+        "preset",
+        "presets",
+        "Lightroom",
+        "Camera Raw",
+        "Capture One",
+        "xmp",
+        "lrtemplate",
+        "costyle",
+        "ltpreset",
+        "import preset",
+        "save look",
+        "replace adjustments"
+      ],
+      "sections": [
+        {
+          "title": "Apply an existing recipe",
+          "paragraphs": [
+            "Open Presets in the editing toolbar. Manage presets provides the selected preset’s source and conversion coverage, along with explicit application controls."
+          ],
+          "steps": [
+            "Choose a preset and review its summary, especially if it came from another editor.",
+            "Use Apply mapped adjustments to apply the settings the preset supplies.",
+            "Use Replace adjustment settings only when you want to reset adjustments, masks, Remove corrections, and geometry before applying the preset.",
+            "Inspect the photo and use Undo if you want to restore the previous edit."
+          ],
+          "tips": [
+            "Replace keeps your crop. It keeps Film unless the preset includes Film settings or you enable Turn Film off for the actions below.",
+            "Presets from other editors are converted approximately because their processing differs. Read skipped settings and conversion notes; matching controls do not promise identical pixels."
+          ]
+        },
+        {
+          "title": "Save or import a preset",
+          "paragraphs": [
+            "Manage presets can save the current look or import LightTable recipes, Lightroom/Camera Raw presets, and Capture One styles."
+          ],
+          "steps": [
+            "To save, select All adjustment settings or Changed settings only under Save current look, choose whether to include Film settings, and click Save new….",
+            "To import, click Import… and choose the preset files. The Mac app also supports choosing a whole preset folder.",
+            "Review the import result and the new preset’s conversion coverage before applying it.",
+            "To share a selected preset, choose an Export format and click Export…."
+          ],
+          "tips": [
+            "LightTable export is lossless for its preset format. Lightroom XMP and Capture One style exports are approximate.",
+            "Supported file choices include .ltpreset, .xmp, .lrtemplate, .costyle, .costylepack, .zip, and .json. An accepted extension does not guarantee that every setting inside can be converted."
+          ]
+        }
+      ],
+      "related": [
+        "editing-history-snapshots",
+        "editing-copy-paste-match-exposure",
+        "editing-curves"
+      ]
+    },
+    {
+      "id": "editing-color-mixer-point-color",
+      "title": "Change individual colors with Color Mixer and Point Color",
+      "category": "Editing",
+      "summary": "Adjust a broad color band or sample a specific hue and refine its range, brightness, and uniformity.",
+      "keywords": [
+        "hsl",
+        "color mixer",
+        "colour mixer",
+        "point color",
+        "sample",
+        "hue",
+        "uniformity",
+        "luminance",
+        "saturation",
+        "range"
+      ],
+      "sections": [
+        {
+          "title": "Adjust a color band",
+          "paragraphs": [
+            "Color Mixer sits inside Edit → Color. It changes colors within the selected band throughout the photo."
+          ],
+          "steps": [
+            "Choose one of the colored band buttons in Color Mixer.",
+            "Adjust Hue to shift that band, Saturation to change its color intensity, and Luminance to change its brightness.",
+            "Select another band to continue, or use Color Mixer’s Reset to clear the mixer adjustments."
+          ]
+        },
+        {
+          "title": "Sample a particular color",
+          "paragraphs": [
+            "Point Color gives a sampled hue its own controls. It affects matching colors throughout the photo; use a local mask when you also need to restrict the area."
+          ],
+          "steps": [
+            "Click Sample color under Point Color, then click a colorful patch in the photo.",
+            "Adjust Range to narrow or widen the hues affected, then refine Hue shift, Saturation, and Luminance.",
+            "Use Uniform hue, Uniform saturation, or Uniform luminance to make colors in the range more like the sampled patch.",
+            "Choose a saved point in the selector to edit it, or use Delete point to remove it."
+          ],
+          "tips": [
+            "Neutral gray patches cannot provide a useful hue sample; choose a more colorful area when prompted.",
+            "Point Color keeps up to eight sampled points. If you sample again when eight already exist, the eighth point is replaced.",
+            "Point Color’s Reset clears the sampled points without requiring a full Color reset."
+          ]
+        }
+      ],
+      "related": [
+        "editing-white-balance",
+        "editing-color-grading",
+        "editing-masks-ranges-refinements"
+      ]
+    },
+    {
+      "id": "editing-color-grading",
+      "title": "Color grade shadows, midtones, and highlights",
+      "category": "Editing",
+      "summary": "Give tonal regions different color treatments and control how those treatments blend.",
+      "keywords": [
+        "color grading",
+        "colour grading",
+        "split toning",
+        "shadows",
+        "midtones",
+        "highlights",
+        "global grade",
+        "blending",
+        "balance"
+      ],
+      "sections": [
+        {
+          "title": "Build a grade",
+          "paragraphs": [
+            "Color Grading in Edit provides separate Shadows, Midtones, and Highlights selections, plus a global grade. Each has Hue, Saturation, and Luminance controls."
+          ],
+          "steps": [
+            "Expand Color Grading and select Shadows, Midtones, or Highlights.",
+            "Choose a Hue, then increase Saturation to make the color treatment visible. Adjust Luminance for that tonal region if needed.",
+            "Repeat for the other regions, or click Edit global grade to change the global treatment.",
+            "Refine Blending and Balance, comparing the photo as you adjust them.",
+            "Use Color Grading’s Reset to clear the grade."
+          ],
+          "tips": [
+            "Changing Hue with Saturation at zero does not add visible color. Start with a modest saturation value.",
+            "Use Color Mixer or Point Color when you want to target an existing hue, and a mask when you want to target a location in the photo."
+          ]
+        }
+      ],
+      "related": [
+        "editing-color-mixer-point-color",
+        "editing-curves",
+        "editing-masks-brush-gradients"
+      ]
+    },
+    {
+      "id": "editing-copy-paste-match-exposure",
+      "title": "Copy edits to selected photos and match exposure",
+      "category": "Editing",
+      "summary": "Choose which settings to transfer, review mask-specific limits, or match a group to an active exposure reference.",
+      "keywords": [
+        "copy settings",
+        "paste settings",
+        "batch edit",
+        "sync",
+        "auto sync",
+        "synchronize",
+        "multiple photos",
+        "match total exposure",
+        "selection",
+        "clipboard"
+      ],
+      "sections": [
+        {
+          "title": "Transfer selected settings",
+          "paragraphs": [
+            "Copy and Paste transfer the groups you explicitly select. Settings in unchecked groups stay as they are on each destination. This is an explicit copy/paste workflow: later edits to the source do not automatically synchronize to the destinations."
+          ],
+          "steps": [
+            "Open the source photo and click Copy edit settings, or press Command-Shift-C on Mac or Ctrl-Shift-C on Windows.",
+            "Check the groups you want to transfer, then click Copy settings.",
+            "Select the destination photo or photos in the library and click Paste edit settings, or use Command-Shift-V / Ctrl-Shift-V.",
+            "Read the completion message. For a batch, Stop ends processing after the current photo; completed photos retain the pasted edits."
+          ],
+          "tips": [
+            "Crop and geometry, Local masks, and Healing are separate choices and are not included by default.",
+            "Healing copies spot positions and should only be transferred between photos with matching framing."
+          ]
+        },
+        {
+          "title": "Review transferred masks",
+          "paragraphs": [
+            "Selected Local masks replace destination masks. Smart selections are detected again for each different photo. Manual mask shapes are copied, so their placement still needs checking."
+          ],
+          "tips": [
+            "Object selections need a new object choice on the destination. Smart masks with painted refinements also need manual recreation; these cause the destination paste to be refused rather than silently copying a source-specific selection.",
+            "If masks cannot be transferred, copy again with Local masks unchecked to apply the other groups.",
+            "Inspect the completion report for failed photos. A batch can finish with some photos changed and others left unchanged."
+          ]
+        },
+        {
+          "title": "Match total exposure",
+          "paragraphs": [
+            "Match total exposure uses the active photo as its reference. When capture exposure metadata is available, it compares that information; otherwise it falls back to average image brightness. Review the result when scenes or lighting differ."
+          ],
+          "steps": [
+            "Select at least two photos and make the intended reference photo active.",
+            "Let the reference edits finish saving.",
+            "Choose Match total exposure in Photo actions, or Library → Match Total Exposure in the Mac menu.",
+            "Inspect each result. The operation updates the relevant exposure control and limits the resulting adjustment to the supported range."
+          ],
+          "tips": [
+            "The reference photo is excluded from the target updates. Matching is a starting point, especially when the photos contain different subjects or framing."
+          ]
+        }
+      ],
+      "related": [
+        "editing-tone",
+        "editing-presets",
+        "editing-masks-ai",
+        "editing-remove-heal"
+      ]
+    },
+    {
+      "id": "editing-crop-geometry",
+      "title": "Crop, straighten, rotate, and correct perspective",
+      "category": "Editing",
+      "summary": "Set a frame and aspect ratio, adjust orientation and perspective, then accept or cancel the crop session.",
+      "keywords": [
+        "crop",
+        "aspect ratio",
+        "straighten",
+        "rotate",
+        "flip",
+        "perspective",
+        "geometry",
+        "upright",
+        "level",
+        "portrait",
+        "landscape",
+        "resize"
+      ],
+      "sections": [
+        {
+          "title": "Set the frame",
+          "paragraphs": [
+            "Open Crop in the editing toolbar. Aspect ratio offers Free, Original, standard proportions, and Custom. The crop readout shows the frame and the amount retained."
+          ],
+          "steps": [
+            "Choose an aspect ratio. Use Custom to enter your own width-to-height proportion, and the swap button to change orientation.",
+            "Drag a handle to resize the crop or drag inside the frame to move it. Drag outside the existing frame to draw a new crop.",
+            "Use arrow keys to nudge the selection; hold Shift for larger steps.",
+            "Click Done or press Enter to accept. Click Cancel or press Escape to restore the frame from when you opened Crop."
+          ],
+          "tips": [
+            "The ratio Lock control lets you keep the current aspect ratio while resizing."
+          ]
+        },
+        {
+          "title": "Refine geometry",
+          "paragraphs": [
+            "Crop & Rotate also contains Straighten, 90-degree rotation, horizontal and vertical flips, and Perspective controls."
+          ],
+          "steps": [
+            "Try Auto level for a tilted horizon, then refine Straighten if needed.",
+            "Use Rotate left, Rotate right, or the flip buttons for orientation changes.",
+            "Expand Perspective and try Auto upright, or adjust Vertical, Horizontal, and Scale manually.",
+            "Inspect the edges and final framing, then click Done."
+          ],
+          "tips": [
+            "Auto level uses lines it can find; inspect the result instead of assuming the detected angle suits the photograph.",
+            "Crop’s Reset resets the crop, rotation, flips, and perspective together."
+          ]
+        }
+      ],
+      "related": [
+        "editing-lens-corrections",
+        "editing-history-snapshots"
+      ]
+    },
+    {
+      "id": "editing-masks-brush-gradients",
+      "title": "Make local adjustments with Brush, Linear, and Radial masks",
+      "category": "Editing",
+      "summary": "Paint or draw a mask, inspect its overlay, and adjust only the selected area.",
+      "keywords": [
+        "mask",
+        "masking",
+        "local adjustment",
+        "brush",
+        "linear gradient",
+        "radial gradient",
+        "feather",
+        "flow",
+        "overlay",
+        "dodge",
+        "burn"
+      ],
+      "sections": [
+        {
+          "title": "Create a manual mask",
+          "paragraphs": [
+            "Open Mask in the editing toolbar and choose a tool under Create New Mask. Each mask has its own Light and Color adjustments."
+          ],
+          "steps": [
+            "Choose Brush to paint, Linear for a graduated adjustment, or Radial for a round adjustment.",
+            "For Brush, choose Size, Feather, and Flow, then paint over the photo. For Linear or Radial, drag on the photo to set the shape.",
+            "Keep Show Overlay enabled while checking the selected area, then turn it off to judge the photo.",
+            "Adjust the selected mask’s Light or Color sliders. Use Amount in Range to reduce its overall strength.",
+            "Rename the mask using its ••• button so its purpose is easy to recognize later."
+          ],
+          "tips": [
+            "Add, Subtract, and Intersect put you in painting refinement modes. For a Linear or Radial mask, choose Edit Shape to return to manipulating its shape.",
+            "Enable temporarily switches a mask’s effect off or on. Invert reverses its selection.",
+            "The editor allows up to sixteen local masks. Delete Mask removes the selected mask; Clear All removes the photo’s masks."
+          ]
+        }
+      ],
+      "related": [
+        "editing-masks-ai",
+        "editing-masks-ranges-refinements",
+        "editing-history-snapshots"
+      ]
+    },
+    {
+      "id": "editing-photo-merge",
+      "title": "Merge HDR brackets, panoramas, and focus stacks",
+      "category": "Editing",
+      "summary": "Combine a sequence of distinct originals into a new 16-bit TIFF, then edit the merged result.",
+      "keywords": [
+        "photo merge",
+        "merge",
+        "hdr",
+        "high dynamic range",
+        "exposure fusion",
+        "bracket",
+        "panorama",
+        "pano",
+        "stitch",
+        "focus stack",
+        "focus stacking",
+        "tiff",
+        "alignment"
+      ],
+      "sections": [
+        {
+          "title": "Start a merge in the Mac app",
+          "paragraphs": [
+            "Photo Merge uses a neutral render of each original and creates a new 16-bit TIFF in LightTable Merges. Apply your final look, crop, and local adjustments to the merged result. The source originals remain available."
+          ],
+          "steps": [
+            "Select at least two distinct originals in the library. Multiple virtual copies of one original count as one source.",
+            "Choose Photo → Photo Merge… in the Mac menu.",
+            "Choose HDR · exposure fusion, Panorama · feature aligned, or Focus stack · sharpness fused.",
+            "Optionally enter a Result name, then click Merge.",
+            "Watch the preparation, alignment, blending, and saving progress. When the app reports completion and refreshes the library, open the TIFF in LightTable Merges and inspect it."
+          ],
+          "tips": [
+            "Only one merge can run at a time. An existing filename is preserved; a new merge with the same name receives a numbered suffix.",
+            "Merge normally processes each input at up to 6,000 pixels on its long edge. The merged result may therefore have less detail than the full-resolution source sequence.",
+            "If a merge reports an error, read the specific message and correct the input selection before trying again."
+          ]
+        },
+        {
+          "title": "Choose suitable inputs",
+          "paragraphs": [
+            "HDR accepts 2–9 exposure-bracketed photos with matching dimensions. It aligns and exposure-fuses display-rendered frames to balance useful tones. Review moving subjects and edges for blending artifacts.",
+            "Panorama accepts 2–20 overlapping frames. Select neighboring frames in sequence so adjacent inputs share visual detail. The app aligns features and blends overlaps; featureless areas or insufficient overlap can prevent a reliable stitch. Panorama canvases are limited to 120 megapixels.",
+            "Focus stack accepts 2–60 focus-bracketed photos with matching dimensions. Use a tripod or focus-rail sequence with shared framing. The app aligns the frames, combines sharp regions, and crops to their common aligned area."
+          ],
+          "steps": [
+            "For HDR, inspect highlights, shadows, and anything that moved between exposures.",
+            "For Panorama, inspect seams and the outer boundary, then crop the result as needed.",
+            "For Focus stack, inspect transitions between sharp regions, foreground edges, and the final crop at 1:1."
+          ],
+          "tips": [
+            "HDR here is exposure fusion into a rendered TIFF. It does not produce a scene-linear RAW or DNG master.",
+            "An alignment failure can mean the frames lack enough overlap or a common area. Try a more consistent sequence rather than adding unrelated frames."
+          ]
+        }
+      ],
+      "related": [
+        "editing-crop-geometry",
+        "editing-tone",
+        "editing-detail-effects-enhance"
+      ]
+    },
+    {
+      "id": "editing-masks-ranges-refinements",
+      "title": "Refine masks with painting, ranges, and combined selections",
+      "category": "Editing",
+      "summary": "Add, subtract, or intersect areas, then limit an adjustment by luminance or sampled color.",
+      "keywords": [
+        "mask refinement",
+        "add",
+        "subtract",
+        "intersect",
+        "component",
+        "luminance range",
+        "color range",
+        "colour range",
+        "sample colour",
+        "opacity",
+        "amount",
+        "invert"
+      ],
+      "sections": [
+        {
+          "title": "Refine by painting",
+          "paragraphs": [
+            "Select the mask in the mask list before refining it. Add expands the selection; Subtract removes painted areas; Intersect keeps only the painted area of the existing selection."
+          ],
+          "steps": [
+            "Choose Add, Subtract, or Intersect beneath Selected Mask.",
+            "Set Size, Feather, and Flow, then paint while watching the overlay.",
+            "While using Add, hold Option on Mac to subtract temporarily.",
+            "Turn the overlay off and inspect the adjustment. Use Undo for a refinement you want to reverse."
+          ]
+        },
+        {
+          "title": "Combine a smart selection",
+          "paragraphs": [
+            "Smart selection action controls whether the next smart selection becomes a new mask or combines with the currently selected mask."
+          ],
+          "steps": [
+            "Select an existing mask, then expand Create New Mask.",
+            "Choose Add to selected mask, Subtract from selected mask, or Intersect with selected mask in Smart selection action.",
+            "Choose the smart tool, such as Subject or Sky, and inspect the combined result."
+          ],
+          "tips": [
+            "Set Smart selection action back to Create new mask when you want the next smart selection to have independent adjustments.",
+            "A mask has a component limit; the panel reports when another smart component cannot be added."
+          ]
+        },
+        {
+          "title": "Limit by brightness or color",
+          "paragraphs": [
+            "Range narrows a selected mask further. Luminance Low and High restrict brightness values. Colour range targets a hue, and Amount controls the whole mask’s strength."
+          ],
+          "steps": [
+            "Expand Range for the selected mask and adjust Luminance Low and Luminance High while checking the overlay.",
+            "Enable Colour range, then click Sample colour and sample a colorful point, or hold Shift and drag over an area to average it.",
+            "Refine Hue, Range, and Colour amount, then use Amount for the overall adjustment strength."
+          ],
+          "tips": [
+            "A nearly neutral area does not provide a useful hue sample. Choose a more colorful area when prompted."
+          ]
+        }
+      ],
+      "related": [
+        "editing-masks-brush-gradients",
+        "editing-masks-ai",
+        "editing-color-mixer-point-color"
+      ]
+    },
+    {
+      "id": "editing-remove-heal",
+      "title": "Remove spots and refine Heal or Clone corrections",
+      "category": "Editing",
+      "summary": "Paint over distractions, inspect spot visibility, and move the source or target of a correction.",
+      "keywords": [
+        "remove",
+        "heal",
+        "healing",
+        "clone",
+        "retouch",
+        "dust",
+        "spot removal",
+        "visualize spots",
+        "source",
+        "target",
+        "distraction"
+      ],
+      "sections": [
+        {
+          "title": "Create a correction",
+          "paragraphs": [
+            "Open Remove in the editing toolbar. Remove, Heal, and Clone are separate modes. Heal and Clone choose an initial source automatically; inspect that source instead of assuming it is suitable."
+          ],
+          "steps": [
+            "Choose Remove, Heal, or Clone, then set Size, Feather, and Opacity.",
+            "Click a spot or drag over a distraction in the photo.",
+            "For small dust spots, enable Visualize Spots and adjust Threshold to make edges easier to inspect.",
+            "Turn Visualize Spots off and inspect the corrected photograph."
+          ],
+          "tips": [
+            "Selecting a correction and choosing a different mode changes that correction’s mode."
+          ]
+        },
+        {
+          "title": "Refine an existing correction",
+          "paragraphs": [
+            "Select a correction in the list to show its controls. The on-image circles indicate the editable target and, for Heal and Clone, the source."
+          ],
+          "steps": [
+            "Drag the target circle to reposition the correction, or choose Move Target and click its new position.",
+            "For Heal or Clone, drag the source circle to a better area. Refresh Source tries a different source position.",
+            "Adjust Feather or Opacity if the correction’s edge or strength needs refinement.",
+            "Toggle Enable this correction to compare, or use Delete correction to remove it."
+          ],
+          "tips": [
+            "Remove does not expose a source circle or Refresh Source. Those source controls apply to Heal and Clone.",
+            "Clear All removes the photo’s Remove, Heal, and Clone corrections. Use Undo to reverse an accidental editing change."
+          ]
+        }
+      ],
+      "related": [
+        "editing-detail-effects-enhance",
+        "editing-history-snapshots",
+        "editing-copy-paste-match-exposure"
+      ]
+    },
+    {
+      "id": "editing-save-recovery",
+      "title": "Save edits and recover unsaved changes",
+      "category": "Editing",
+      "summary": "Edits save automatically. Check the save status, retry a failed save, or choose which edits to recover after reopening.",
+      "keywords": [
+        "save",
+        "autosave",
+        "unsaved",
+        "recovery",
+        "crash",
+        "original",
+        "non-destructive",
+        "retry",
+        "saving"
+      ],
+      "sections": [
+        {
+          "title": "Check that your work is saved",
+          "paragraphs": [
+            "Adjustments are stored as edit settings for the photo. The editor saves changes automatically as you finish interactions; you do not need a separate Save command for each adjustment."
+          ],
+          "steps": [
+            "Make your adjustment, then check the save status in the app.",
+            "Wait for Saving… to change to Saved. Saving also includes pending edit-history writes.",
+            "If the status says Edits not saved, use Retry save. Keep the window open while a save is failing."
+          ],
+          "tips": [
+            "Saved · recovery needs attention means the save completed but the local recovery system reported a problem. Use the available retry control and read the status message."
+          ]
+        },
+        {
+          "title": "Choose recovered or saved edits",
+          "paragraphs": [
+            "If local recovery finds outstanding changes when the library opens, Recover unsaved edits? lists the affected photos. Restore edits replaces their saved settings with the recovered settings. Keep saved edits keeps the catalog version and discards those recovery drafts."
+          ],
+          "steps": [
+            "Read the affected photo names and choose Restore edits or Keep saved edits.",
+            "If you restore, wait for saving to complete before closing the app."
+          ],
+          "tips": [
+            "Recovery may be unavailable if local storage or the desktop recovery journal fails. The app reports that condition; it is not a guarantee that every unsaved edit can be recovered.",
+            "If an original is unavailable or has changed, its recovery record is kept instead of being applied to a potentially different photo."
+          ]
+        }
+      ],
+      "related": [
+        "editing-history-snapshots"
+      ]
+    },
+    {
+      "id": "editing-masks-ai",
+      "title": "Select Subject, Sky, Object, Depth, or People",
+      "category": "Editing",
+      "summary": "Create local selections on the device, inspect their accuracy, and refine the result before applying adjustments.",
+      "keywords": [
+        "ai mask",
+        "subject",
+        "sky",
+        "object",
+        "depth",
+        "people",
+        "person",
+        "face",
+        "skin",
+        "hair",
+        "eyes",
+        "teeth",
+        "portrait",
+        "select background"
+      ],
+      "sections": [
+        {
+          "title": "Create a smart selection",
+          "paragraphs": [
+            "Mask offers Subject, Sky, Object, Depth, and People selections. These run locally; available methods depend on the selection type and platform."
+          ],
+          "steps": [
+            "Open Mask and expand Create New Mask.",
+            "Choose Subject or Sky for an automatic selection. For Object, click Object and then click the object in the photo.",
+            "Choose Depth to make a selection from relative distance, then open Range and adjust Far limit and Near limit. Depth runs from far to near.",
+            "Inspect Show Overlay and refine missed or extra areas before adjusting Light or Color."
+          ],
+          "tips": [
+            "Subject, Sky, and Object can use local image-based estimates. They can miss edges or select the wrong region, especially where subject and background look alike.",
+            "Depth uses embedded capture depth when available, otherwise a local estimate. Estimated depth is relative and can be inaccurate.",
+            "Use Invert if you want to adjust the area outside the resulting selection."
+          ]
+        },
+        {
+          "title": "Select people or facial regions",
+          "paragraphs": [
+            "People offers Person, Face skin, Eyes, Eyebrows, Lips, Teeth, Hair, and Soften skin. People masks require the Vision helper on macOS 14 or later. Face skin and hair are estimated, and no identity is inferred."
+          ],
+          "steps": [
+            "Choose People, then the part you want to adjust.",
+            "Inspect the overlay and use painted refinements around boundaries as needed.",
+            "For Soften skin, review the automatically applied Texture and Clarity reduction, then adjust it to suit the portrait."
+          ],
+          "tips": [
+            "Read any availability or detection error in the mask panel. A tool appearing in the menu does not guarantee that the required helper or a usable selection is available."
+          ]
+        }
+      ],
+      "related": [
+        "editing-masks-brush-gradients",
+        "editing-masks-ranges-refinements",
+        "editing-copy-paste-match-exposure"
+      ]
+    },
+    {
+      "id": "editing-white-balance",
+      "title": "Set white balance and overall color",
+      "category": "Editing",
+      "summary": "Use Temp and Tint or sample a neutral area, then adjust Vibrance and Saturation.",
+      "keywords": [
+        "white balance",
+        "wb",
+        "temperature",
+        "temp",
+        "tint",
+        "neutral",
+        "eyedropper",
+        "color cast",
+        "vibrance",
+        "saturation"
+      ],
+      "sections": [
+        {
+          "title": "Neutralize a color cast",
+          "paragraphs": [
+            "The Color section in Edit contains Temp and Tint, plus a white-balance eyedropper beside Temp. These are the Edit panel’s finishing controls."
+          ],
+          "steps": [
+            "Open Edit and expand Color.",
+            "Click the white-balance eyedropper beside Temp, then click an area in the photo that should be neutral gray.",
+            "Refine Temp and Tint by eye if the sampled result is too warm, cool, green, or magenta.",
+            "Adjust Vibrance and Saturation to control the overall intensity of color."
+          ],
+          "tips": [
+            "Choose a visible neutral patch. A nearly black sample produces Too dark to sample; an unavailable preview produces a waiting message.",
+            "Click the eyedropper again to leave sampling mode without choosing a point.",
+            "Color’s Reset also resets its associated color adjustments, including Color Mixer, Point Color, and Color Grading. Use a tool’s own Reset for a narrower change."
+          ]
+        }
+      ],
+      "related": [
+        "editing-tone",
+        "editing-color-mixer-point-color",
+        "editing-color-grading"
+      ]
+    },
+    {
+      "id": "editing-curves",
+      "title": "Shape contrast and color with curves",
+      "category": "Editing",
+      "summary": "Add and move curve points for the combined RGB channel or individual red, green, and blue channels.",
+      "keywords": [
+        "curve",
+        "curves",
+        "tone curve",
+        "rgb",
+        "red",
+        "green",
+        "blue",
+        "contrast",
+        "control point",
+        "s curve"
+      ],
+      "sections": [
+        {
+          "title": "Edit a curve",
+          "paragraphs": [
+            "In the Curve graph, the horizontal direction runs from darker input tones to brighter input tones. Moving a point up raises its output; moving it down lowers it. RGB adjusts the combined curve, while R, G, and B affect individual channels."
+          ],
+          "steps": [
+            "Open Edit and expand Curve.",
+            "Choose RGB, R, G, or B.",
+            "Click the graph to add a point, then drag it to shape the curve. Drag an existing handle to move it.",
+            "Double-click an interior point to remove it. The two endpoint handles remain.",
+            "Use Curve’s Reset to reset the curves, or Undo to reverse the latest change."
+          ],
+          "tips": [
+            "Use a few points and compare the photo as you work; channel curves can introduce strong color casts.",
+            "A stored or imported curve retains its exact saved table until you edit it. The app rebuilds representative handles for editing, so the first adjustment can reshape an imported curve beyond the point you move."
+          ]
+        }
+      ],
+      "related": [
+        "editing-tone",
+        "editing-color-grading",
+        "editing-presets"
+      ]
+    },
+    {
+      "id": "editing-detail-effects-enhance",
+      "title": "Sharpen, reduce noise, and use Enhance",
+      "category": "Editing",
+      "summary": "Inspect detail at 1:1, apply ordinary detail controls, or run local learned denoise when available.",
+      "keywords": [
+        "detail",
+        "sharpening",
+        "noise",
+        "denoise",
+        "noise reduction",
+        "enhance",
+        "super resolution",
+        "upscale",
+        "texture",
+        "clarity",
+        "dehaze",
+        "vignette",
+        "sensor"
+      ],
+      "sections": [
+        {
+          "title": "Judge detail at 1:1",
+          "paragraphs": [
+            "The Detail section includes Sharpening, Radius, Detail, Masking, Luminance NR, and Color NR. Effects contains Texture, Clarity, Dehaze, and Vignette."
+          ],
+          "steps": [
+            "Open a photo and use Space to switch between Fit and 1:1.",
+            "Expand Detail in Edit. Adjust noise reduction and sharpening while looking at both textured and smooth areas.",
+            "Use Effects for texture, local contrast, haze, or edge shading, then check the whole photo at Fit.",
+            "Use the relevant section’s Reset if you want to start that group again."
+          ],
+          "tips": [
+            "Detail controls work in both Film and Develop modes. Avoid judging sharpening from a small Fit preview alone."
+          ]
+        },
+        {
+          "title": "Run learned denoise on a RAW photo",
+          "paragraphs": [
+            "RAW photos can show Sensor noise reduction and Learned denoise controls. Learned denoise runs locally when you press Apply denoise; moving Strength does not run it live."
+          ],
+          "steps": [
+            "Select a RAW photo and expand Detail.",
+            "Check that Apply denoise is available, choose Strength, and click Apply denoise.",
+            "Watch the progress message. Use Cancel if you need to stop the job.",
+            "Inspect the completed preview at 1:1."
+          ],
+          "tips": [
+            "Availability depends on the local model, helper, and supported platform. Development builds may lack the model, and the app reports this instead of pretending denoise succeeded."
+          ]
+        },
+        {
+          "title": "Create an enhanced derivative in the Mac app",
+          "paragraphs": [
+            "Photo → Enhance Photo… offers Denoise and Super resolution and writes a new 16-bit master when the selected operation succeeds. The original remains untouched."
+          ],
+          "steps": [
+            "Select the photo, choose Photo → Enhance Photo…, and read the availability message.",
+            "Choose the enhancement and click Enhance if available.",
+            "After completion, find the new result in the refreshed library and inspect it."
+          ],
+          "tips": [
+            "Super resolution has no bundled model and requires a compatible local model. A listed option alone does not mean that operation is available.",
+            "Enhancement can generate detail; evaluate the output before treating it as a faithful record of fine texture."
+          ]
+        }
+      ],
+      "related": [
+        "editing-tone",
+        "editing-effects",
+        "editing-history-snapshots"
+      ]
+    },
+    {
+      "id": "editing-history-snapshots",
+      "title": "Undo edits, restore History, and save snapshots",
+      "category": "Editing",
+      "summary": "Use Undo for recent work, History for stored editing steps, and named snapshots for looks you want to revisit.",
+      "keywords": [
+        "undo",
+        "redo",
+        "history",
+        "snapshot",
+        "version",
+        "restore",
+        "revert",
+        "reset"
+      ],
+      "sections": [
+        {
+          "title": "Undo or restore an earlier step",
+          "paragraphs": [
+            "Undo and redo follow each photo during the current session. In catalog libraries, History persists after quitting. Nearby adjustments can be combined into a history step, so the list is not a record of every slider position."
+          ],
+          "steps": [
+            "Use Command-Z on Mac or Ctrl-Z on Windows to undo. Add Shift to redo.",
+            "Open History in the editing toolbar to see the current photo’s stored steps, newest first.",
+            "Click a step to restore its settings. Restoring a step is itself an undoable edit."
+          ],
+          "tips": [
+            "Persistent History requires a catalog library. Folder-only use still supports session Undo and Redo.",
+            "Clear removes the photo’s stored history steps; it is not an adjustment-reset command."
+          ]
+        },
+        {
+          "title": "Keep a named look",
+          "paragraphs": [
+            "A snapshot stores the photo’s current adjustment settings, crop, masks, Remove corrections, and optics. It is a saved editing state for this photo."
+          ],
+          "steps": [
+            "Open History, expand Snapshots, and click Create snapshot.",
+            "Enter a useful name, such as Soft portrait or Before retouching.",
+            "Click the snapshot’s name to apply it later. Use Undo if you want to return to the state you just replaced."
+          ],
+          "tips": [
+            "The photo keeps up to 50 snapshots; creating another beyond that limit drops the oldest snapshot from the list.",
+            "The × beside a snapshot deletes that named snapshot, not the original photo."
+          ]
+        }
+      ],
+      "related": [
+        "editing-save-recovery",
+        "editing-presets"
+      ]
+    },
+    {
+      "id": "film-grain-and-format",
+      "title": "Adjust film grain and format",
+      "category": "Film",
+      "summary": "Control grain relative to the stock and choose the simulated film size.",
+      "keywords": [
+        "grain",
+        "size",
+        "texture",
+        "35mm",
+        "medium format",
+        "645",
+        "6x6",
+        "6x7",
+        "4x5",
+        "particle",
+        "noise"
+      ],
+      "sections": [
+        {
+          "title": "Set the format and grain",
+          "paragraphs": [
+            "Film format sets the physical long edge used by the simulation. The choices are 35 mm, 645, 6 × 6, 6 × 7, and 4 × 5; this setting is separate from cropping the photo.",
+            "Grain size multiplies the chosen stock’s baseline particle area. The readout shows the resulting area in µm², so the same multiplier can show a different area after you change stocks."
+          ],
+          "steps": [
+            "In Film profile, choose Film format.",
+            "Expand Physical film stages.",
+            "Enable Grain size and adjust its slider, or clear its checkbox to disable grain.",
+            "Inspect the image at 1:1 and wait for preview detail to finish before judging texture."
+          ]
+        },
+        {
+          "title": "What the number represents",
+          "paragraphs": [
+            "The per-stock grain baselines are derived from film speed as visual starting points. They are not laboratory granularity measurements for each emulsion.",
+            "The Grain size setting belongs to the film simulation. Detail sharpening and noise reduction in Edit are separate adjustments."
+          ]
+        }
+      ],
+      "related": [
+        "film-getting-started",
+        "performance-previews"
+      ]
+    },
+    {
+      "id": "film-halation-diffusion-scan",
+      "title": "Adjust halation, diffusion, and scan character",
+      "category": "Film",
+      "summary": "Refine the film’s physical effects and the selected output recipe.",
+      "keywords": [
+        "halation",
+        "glow",
+        "bloom",
+        "diffusion",
+        "couplers",
+        "glare",
+        "scan",
+        "sharpness",
+        "softness",
+        "scanner",
+        "preflash"
+      ],
+      "sections": [
+        {
+          "title": "Physical film stages",
+          "paragraphs": [
+            "Open Film → Physical film stages while Film is enabled. Couplers, Halation, Grain size, and Print glare each have an enable checkbox and an amount control. Turning off a stage disables its amount slider.",
+            "Capture diffusion changes the modeled camera stage. Print glare and Print preflash belong to the print stage and are unavailable for direct slide scans."
+          ],
+          "steps": [
+            "Choose the stock and Output recipe before refining the stage controls.",
+            "Change one stage at a time and compare the result.",
+            "Use each stage’s checkbox to compare its contribution without replacing the selected stock."
+          ]
+        },
+        {
+          "title": "Scan controls",
+          "paragraphs": [
+            "Scan softness adds lens blur to the selected output recipe. Scan sharpness scales that recipe’s sharpening; Scan sharpening enables or disables it.",
+            "These are adjustments to modeled output recipes, not selections of measured scanner brands. Evaluate fine texture and sharpness with completed 1:1 preview detail."
+          ]
+        }
+      ],
+      "related": [
+        "film-negative-paper-and-slides",
+        "film-grain-and-format",
+        "performance-previews"
+      ]
+    },
+    {
+      "id": "film-getting-started",
+      "title": "Choose and preview a film stock",
+      "category": "Film",
+      "summary": "Turn on the physical film workflow and compare stocks using your own photo.",
+      "keywords": [
+        "film",
+        "stock",
+        "simulation",
+        "negative",
+        "slide",
+        "browse",
+        "preview",
+        "preset",
+        "film off"
+      ],
+      "sections": [
+        {
+          "title": "Start with a stock",
+          "paragraphs": [
+            "Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."
+          ],
+          "steps": [
+            "Open a still photo and select Film in the tool rail.",
+            "Turn the Film profile switch on.",
+            "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.",
+            "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."
+          ]
+        },
+        {
+          "title": "What the previews include",
+          "paragraphs": [
+            "Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.",
+            "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file."
+          ],
+          "tips": [
+            "If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."
+          ]
+        }
+      ],
+      "related": [
+        "film-exposure-and-processing",
+        "film-negative-paper-and-slides",
+        "film-grain-and-format"
+      ]
+    },
+    {
+      "id": "film-reference-match",
+      "title": "Compare with a reference image",
+      "category": "Film",
+      "summary": "Align a scan or other reference, measure the difference, and apply a starting match.",
+      "keywords": [
+        "reference",
+        "match",
+        "scan",
+        "calibration",
+        "overlay",
+        "split",
+        "opacity",
+        "measure",
+        "color match"
+      ],
+      "sections": [
+        {
+          "title": "Load and align",
+          "paragraphs": [
+            "Reference Match is in the Film panel. Use a reference with corresponding image content so alignment and comparison are meaningful."
+          ],
+          "steps": [
+            "Expand Reference Match and choose a Reference image.",
+            "Choose Overlay or Split, then set Opacity / split.",
+            "Use Scale, Horizontal, and Vertical to align the reference with your photo.",
+            "Click Measure to inspect the comparison, or Starting match to apply an initial adjustment."
+          ]
+        },
+        {
+          "title": "What Starting match changes",
+          "paragraphs": [
+            "Starting match turns off automatic scene metering and adjusts Camera EV. For RAW photos it also sets custom capture white balance; for processed photos it adjusts yellow and magenta print filtration.",
+            "This is a starting adjustment based on measured image statistics, not a guarantee of an exact film or color match. Review the image after applying it and use Undo if needed. Clear removes the reference overlay."
+          ],
+          "tips": [
+            "The Calibration target button downloads an image you can use in a reference workflow."
+          ]
+        }
+      ],
+      "related": [
+        "film-exposure-and-processing",
+        "film-negative-paper-and-slides"
+      ]
+    },
+    {
+      "id": "film-exposure-and-processing",
+      "title": "Set film exposure and development",
+      "category": "Film",
+      "summary": "Understand Camera EV, capture white balance, metering, and development controls.",
+      "keywords": [
+        "exposure",
+        "camera ev",
+        "meter",
+        "white balance",
+        "temperature",
+        "tint",
+        "development",
+        "contrast",
+        "authentic",
+        "creative"
+      ],
+      "sections": [
+        {
+          "title": "Capture controls and finishing controls",
+          "paragraphs": [
+            "Camera EV and Capture white balance act before film exposure. Exposure and Temp/Tint in the Edit panel are finishing adjustments later in the workflow.",
+            "Capture white balance requires a RAW original. For a JPEG, HEIF, TIFF, or another processed file, use Edit Temp/Tint."
+          ],
+          "steps": [
+            "Turn on Film, choose a stock, and adjust Camera EV.",
+            "Keep Meter scene automatically enabled for automatic scene metering, or turn it off to set the capture exposure yourself.",
+            "Expand Capture & processing to choose As shot, Daylight, Tungsten, or Custom capture white balance for a RAW photo.",
+            "For Custom, adjust Temperature and Capture tint."
+          ]
+        },
+        {
+          "title": "Development and linked defaults",
+          "paragraphs": [
+            "Development appears only when the chosen film profile supplies development times. Print development depends on the selected paper and is hidden for slide film. Development contrast is a separate film control.",
+            "Authentic uses linked physical defaults, including the stock’s recommended paper when paper is unlocked. Creative preserves paper overrides when compatible. Changing stocks can still select that stock’s default development time and exposure; compare the result after changing a stock."
+          ]
+        }
+      ],
+      "related": [
+        "film-getting-started",
+        "film-negative-paper-and-slides",
+        "film-reference-match"
+      ]
+    },
+    {
+      "id": "film-negative-paper-and-slides",
+      "title": "Work with negative film, paper, and slides",
+      "category": "Film",
+      "summary": "Choose a print process for negatives and understand why print controls disappear for slide film.",
+      "keywords": [
+        "negative",
+        "positive",
+        "reversal",
+        "slide",
+        "transparency",
+        "paper",
+        "print",
+        "output",
+        "lock paper",
+        "filtration",
+        "preflash"
+      ],
+      "sections": [
+        {
+          "title": "Negative film and paper",
+          "paragraphs": [
+            "Negative stocks use a film-to-print process. Paper choices are restricted to profiles compatible with the selected film’s color or monochrome channel model.",
+            "Use Print exposure to adjust the print stage. In Capture & processing, choose Paper and enable Lock paper when stock changes if you want to keep a compatible paper while trying other stocks. An incompatible paper still has to be replaced."
+          ],
+          "steps": [
+            "Choose a negative stock in Film.",
+            "Choose an Output recipe: Clean scan, Neutral print scan, or Soft optical print.",
+            "Expand Capture & processing to choose Paper and any available Print development time.",
+            "Expand Physical film stages for Print glare, Print preflash, Yellow filter, and Magenta filter."
+          ]
+        },
+        {
+          "title": "Slide film is scanned directly",
+          "paragraphs": [
+            "Positive or reversal stocks use a direct transparency scan with no negative-to-paper stage. Paper, print exposure, print development, and other print-only controls are hidden for these stocks.",
+            "Output recipes are modeled starting points for scan softness, sharpening, and print effects where applicable. They are not measured emulations of particular commercial scanners."
+          ]
+        }
+      ],
+      "related": [
+        "film-exposure-and-processing",
+        "film-halation-diffusion-scan"
+      ]
+    },
+    {
+      "id": "export-format-color-space",
+      "title": "Choose export size, format, and color space",
+      "category": "Export",
+      "summary": "Use export presets and understand bit depth, resizing, and the current color-gamut limits.",
+      "keywords": [
+        "jpeg",
+        "jpg",
+        "png",
+        "heif",
+        "heic",
+        "tiff",
+        "16 bit",
+        "srgb",
+        "p3",
+        "prophoto",
+        "icc",
+        "quality",
+        "full size",
+        "resolution",
+        "preset"
+      ],
+      "sections": [
+        {
+          "title": "Formats and presets",
+          "paragraphs": [
+            "The export dialog offers JPEG, HEIF, PNG, and 16-bit TIFF. HEIF is an 8-bit output option on macOS. The quality slider applies to JPEG and HEIF.",
+            "JPG (Large) uses full-size JPEG at quality 92 in sRGB. JPG (Small) uses a 2048-pixel long edge at quality 90 in sRGB. 16-bit TIFF uses full size and ProPhoto RGB. Changing these settings selects Custom."
+          ],
+          "steps": [
+            "Open Export and choose a preset across the top.",
+            "Set Dimensions to Full size or a long-edge limit.",
+            "Check Output preview: the exported size reflects rotation and crop, and a long-edge limit downsizes larger images without enlarging smaller ones."
+          ]
+        },
+        {
+          "title": "Color space limits",
+          "paragraphs": [
+            "Every export embeds the selected ICC profile. Choose sRGB, Display P3, or ProPhoto RGB in Colour space.",
+            "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors. Encoding one of those results in P3 or ProPhoto does not restore colors already limited by rendering."
+          ]
+        }
+      ],
+      "related": [
+        "export-photos",
+        "soft-proof",
+        "external-editor"
+      ]
+    },
+    {
+      "id": "export-metadata-sidecars",
+      "title": "Control export metadata, sidecars, and timestamps",
+      "category": "Export",
+      "summary": "Choose metadata privacy, optional recipe files, and capture-time handling.",
+      "keywords": [
+        "metadata",
+        "privacy",
+        "gps",
+        "location",
+        "copyright",
+        "sidecar",
+        "recipe",
+        "timestamp",
+        "date",
+        "timezone",
+        "capture time"
+      ],
+      "sections": [
+        {
+          "title": "Metadata and recipe files",
+          "paragraphs": [
+            "Export → Advanced offers All except location, All metadata, Copyright only, and No metadata. The initial metadata choice is All except location.",
+            "Recipe sidecar controls whether LightTable writes a recipe beside the rendered export. This is separate from the portable edits and XMP sidecar preferences for originals in Settings → Files & Metadata."
+          ],
+          "steps": [
+            "Expand Advanced in Export.",
+            "Choose the Metadata policy appropriate for the files you will share.",
+            "Choose whether to write a Recipe sidecar beside each exported photo."
+          ]
+        },
+        {
+          "title": "File timestamps",
+          "paragraphs": [
+            "File timestamp can use the time of export or the original capture time. If capture timezone is missing, the default is to keep export time and report a warning. You can instead choose to interpret it in this computer’s local timezone.",
+            "Missing or invalid capture time can also leave the export timestamp unchanged. Check Export details for the reported warning. A file’s filesystem timestamp is separate from the metadata policy selected above."
+          ]
+        }
+      ],
+      "related": [
+        "export-photos",
+        "export-filenames-and-folders",
+        "settings-and-defaults"
+      ]
+    },
+    {
+      "id": "external-editor",
+      "title": "Edit a photo in another application",
+      "category": "Export",
+      "summary": "Send an adjusted TIFF to another editor and set the format and stacking defaults.",
+      "keywords": [
+        "external",
+        "editor",
+        "photoshop",
+        "affinity",
+        "edit in",
+        "tiff",
+        "round trip",
+        "derivative",
+        "stack"
+      ],
+      "sections": [
+        {
+          "title": "Open an external editor",
+          "paragraphs": [
+            "Use Edit in… to prepare photos for another pixel editor. The adjusted TIFF is written beside its original, and can be stacked with it in the catalog."
+          ],
+          "steps": [
+            "Select a photo and press Command/Ctrl+E to open Edit in another app.",
+            "Choose Application.",
+            "Choose TIFF with current adjustments, then set TIFF colour space and TIFF bit depth.",
+            "Choose whether to Stack rendered file with original.",
+            "Click Edit and wait for rendering to finish before working in the other app."
+          ]
+        },
+        {
+          "title": "RAW files and defaults",
+          "paragraphs": [
+            "RAW originals must be rendered as adjusted TIFFs. Processed original is unavailable if the selection contains a RAW file. For processed photos, that option opens the original rather than preparing an adjusted TIFF.",
+            "Set the default application, color space, bit depth, and stacking behavior in Settings → External Editing. Adjusted TIFFs can use 16 or 8 bits and ProPhoto RGB, Display P3, or sRGB."
+          ]
+        }
+      ],
+      "related": [
+        "export-format-color-space",
+        "settings-and-defaults"
+      ]
+    },
+    {
+      "id": "export-photos",
+      "title": "Export selected photos",
+      "category": "Export",
+      "summary": "Choose exactly which photos to export, preview the output, and monitor progress.",
+      "keywords": [
+        "export",
+        "save",
+        "jpeg",
+        "jpg",
+        "download",
+        "selection",
+        "picked",
+        "rated",
+        "batch",
+        "cancel",
+        "progress"
+      ],
+      "sections": [
+        {
+          "title": "Make an export",
+          "paragraphs": [
+            "Export creates rendered output files from your photo edits. Use Selected photos when you want the export limited to a specific selection."
+          ],
+          "steps": [
+            "Select the photos you want, then click the Export photos button in the top bar. Command/Ctrl+Shift+E also opens Export.",
+            "Check the Photos field. Choose Selected photos, Picked only, Rated 1+, or All except rejected.",
+            "Choose an export preset or set file type, dimensions, quality, and color space.",
+            "Set the destination and inspect Output preview for the filename, dimensions, and path.",
+            "Click Export and follow the progress in the top bar."
+          ]
+        },
+        {
+          "title": "Check the scope and result",
+          "paragraphs": [
+            "Picked only, Rated 1+, and All except rejected select matching still photos from the active catalog, and can include photos outside the displayed collection or filter. Selected photos provides explicit control over the set.",
+            "Use Cancel export to request a stop. Export details reports completed, skipped, and cancelled counts, plus warnings and errors; a warning can occur after a photo was successfully written. Video clips are not rendered by the still-photo export workflow."
+          ]
+        }
+      ],
+      "related": [
+        "export-format-color-space",
+        "export-filenames-and-folders",
+        "export-metadata-sidecars"
+      ]
+    },
+    {
+      "id": "soft-proof",
+      "title": "Preview an output with soft proofing",
+      "category": "Export",
+      "summary": "View a display or modeled paper preview without making it part of the exported photo.",
+      "keywords": [
+        "soft proof",
+        "proofing",
+        "gamut",
+        "paper",
+        "ink",
+        "matte",
+        "gloss",
+        "print",
+        "p3",
+        "srgb"
+      ],
+      "sections": [
+        {
+          "title": "Turn on soft proof",
+          "paragraphs": [
+            "Soft-proof controls are in the viewer’s View options (•••). They let you inspect an output preview while editing."
+          ],
+          "steps": [
+            "Open View options (•••) below the viewer.",
+            "Enable Preview output profile.",
+            "Choose sRGB display, Display P3 display, Matte paper, or Gloss paper.",
+            "For paper targets, choose whether to Simulate paper and ink. Toggle Show out-of-gamut warning as needed.",
+            "Use the Soft Proof on button in the viewer toolbar to turn the preview off."
+          ]
+        },
+        {
+          "title": "Interpret the preview",
+          "paragraphs": [
+            "Matte and Gloss in this interface are modeled paper previews; they are not a selection of your printer’s measured ICC profile. Treat the preview as guidance when comparing contrast and color.",
+            "Soft proof is a viewing state. Choose the file’s actual Colour space separately in Export."
+          ]
+        }
+      ],
+      "related": [
+        "export-format-color-space",
+        "export-photos"
+      ]
+    },
+    {
+      "id": "export-filenames-and-folders",
+      "title": "Set export folders and filenames",
+      "category": "Export",
+      "summary": "Choose a destination layout and decide what happens when a filename already exists.",
+      "keywords": [
+        "destination",
+        "folder",
+        "path",
+        "filename",
+        "rename",
+        "overwrite",
+        "skip",
+        "collision",
+        "hierarchy",
+        "sequence",
+        "template"
+      ],
+      "sections": [
+        {
+          "title": "Destination layout",
+          "paragraphs": [
+            "One destination folder sends exports to the chosen folder. Subfolder beside each original uses a relative subfolder name for each source photo. Keep source folder hierarchy preserves source-folder organization beneath the export destination."
+          ],
+          "steps": [
+            "Open Export and choose Destination layout.",
+            "Use Choose… for a destination folder, or enter a subfolder name such as film-exports for Subfolder beside each original.",
+            "Expand Advanced and edit Filename template.",
+            "Check the filename and destination shown in Output preview before exporting."
+          ]
+        },
+        {
+          "title": "Names and existing files",
+          "paragraphs": [
+            "Filename templates support {filename}, {stock}, {date}, {rating}, and {sequence}. For example, {filename}_{stock} includes the source name and film stock.",
+            "Keep both · add a number creates another filename, such as a name ending in -2. Skip existing leaves occupied names alone. Overwrite replaces existing output at the chosen path. Use the output preview to confirm the destination before choosing Overwrite."
+          ]
+        }
+      ],
+      "related": [
+        "export-photos",
+        "export-metadata-sidecars"
+      ]
+    },
+    {
+      "id": "settings-and-defaults",
+      "title": "Change preferences and new-photo defaults",
+      "category": "Settings",
+      "summary": "Adjust the interface, culling behavior, portable edits, and starting edits for new photos.",
+      "keywords": [
+        "settings",
+        "preferences",
+        "defaults",
+        "camera",
+        "raw",
+        "serial",
+        "iso",
+        "font",
+        "background",
+        "lights out",
+        "notifications",
+        "xmp",
+        "portable"
+      ],
+      "sections": [
+        {
+          "title": "Interface and behavior",
+          "paragraphs": [
+            "Settings changes save automatically. General controls Auto-advance after picking, rejecting, or rating, completion notifications, and update checks.",
+            "Interface controls the viewer background, font scale, Lights Out, loupe information overlay, and crop guides. These preferences change the workspace appearance without changing exported pixels.",
+            "Files & Metadata controls portable LightTable edits beside originals, automatic XMP writing, RAW/JPEG pairing, and keyword entry. Complete portable edits use .lighttable-state.json; XMP carries compatible edits and metadata."
+          ]
+        },
+        {
+          "title": "Defaults for unedited photos",
+          "paragraphs": [
+            "Develop Defaults apply only to photos that do not already have saved edits. They can start Film enabled, choose a workflow and neutral Develop profile, and apply a default preset."
+          ],
+          "steps": [
+            "Open Settings → Develop Defaults.",
+            "Choose the starting Film, workflow, profile, and preset settings.",
+            "To set camera-specific RAW defaults, open a RAW photo and adjust its RAW settings.",
+            "Choose matching by camera model, serial number, or camera and ISO, then click Use current RAW settings.",
+            "Use Reset in the Current camera area to remove that camera default."
+          ]
+        }
+      ],
+      "related": [
+        "keyboard-midi",
+        "photo-index",
+        "performance-previews",
+        "catalog-health-recovery"
+      ]
+    },
+    {
+      "id": "photo-index",
+      "title": "Enable private photo-content search",
+      "category": "Settings",
+      "summary": "Build an on-device index of objects, scenes, visible text, and faces.",
+      "keywords": [
+        "ai",
+        "search",
+        "index",
+        "contents",
+        "objects",
+        "scenes",
+        "ocr",
+        "text",
+        "faces",
+        "privacy",
+        "local",
+        "description"
+      ],
+      "sections": [
+        {
+          "title": "Build the index",
+          "paragraphs": [
+            "The Photo Index is off by default. Analysis stays on this Mac and does not modify photo folders. Apple Vision provides the core analysis; richer Foundation Models descriptions appear only when that capability is available."
+          ],
+          "steps": [
+            "Open Settings → Photo Index.",
+            "Check the On-device capabilities status and turn on Photo contents index.",
+            "Wait for indexing progress to complete. Photos can gain results as they are indexed.",
+            "Use the library search field to search photo contents, visible text, or faces alongside filenames and keywords.",
+            "Open Info → On-device description to inspect the current photo’s generated tags, visible text, and face count."
+          ]
+        },
+        {
+          "title": "Pause, rebuild, or delete",
+          "paragraphs": [
+            "Turning the index off pauses analysis and removes generated results from the active search view; existing index data remains local until deleted. Rebuild index reruns indexing when the feature is enabled.",
+            "Delete index removes generated index data after confirmation. Originals and saved edits are unchanged. If Apple Vision says Build required, the current installation lacks the required local analyzer. Foundation Models may be unavailable while basic Vision indexing remains usable."
+          ]
+        }
+      ],
+      "related": [
+        "assisted-culling",
+        "settings-and-defaults"
+      ]
+    },
+    {
+      "id": "assisted-culling",
+      "title": "Review assisted culling suggestions",
+      "category": "Settings",
+      "summary": "Review local analysis signals and apply pick or reject flags only when you choose.",
+      "keywords": [
+        "cull",
+        "culling",
+        "ai",
+        "selects",
+        "rejects",
+        "sharpness",
+        "eyes",
+        "misfire",
+        "documents",
+        "review",
+        "flags"
+      ],
+      "sections": [
+        {
+          "title": "Review signals",
+          "paragraphs": [
+            "Assisted culling uses the private Photo Index. It does not flag photos until you ask it to. A photo matches a group if any of your chosen criteria returns yes; not judged means that signal has no usable verdict."
+          ],
+          "steps": [
+            "Enable Photo Index in Settings and wait for photos to be scored.",
+            "Expand Assisted culling in the library sidebar.",
+            "Choose Select criteria such as Subject sharpness, Eye sharpness, or Eyes open, or Reject criteria such as Exposure issues, Misfires, or Documents.",
+            "Use Selects, Rejects, or All to review the matching photos.",
+            "Inspect the suggestions, then use Pick selects or Reject rejects if you want to apply those flags."
+          ]
+        },
+        {
+          "title": "Applying flags",
+          "paragraphs": [
+            "The confirmation shows the affected count and warns that existing flags on matching photos will be replaced. Linked RAW/JPEG metadata can also include the paired file when that preference is enabled.",
+            "These are analysis signals for your review, not final judgments about which photographs to keep. Rejecting sets a flag; it does not itself move originals to Trash."
+          ]
+        }
+      ],
+      "related": [
+        "photo-index",
+        "settings-and-defaults"
+      ]
+    },
+    {
+      "id": "keyboard-midi",
+      "title": "Use keyboard shortcuts and MIDI controls",
+      "category": "Settings",
+      "summary": "Find shortcuts, choose a keyboard scheme, and map a hardware controller where Web MIDI is available.",
+      "keywords": [
+        "keyboard",
+        "shortcut",
+        "hotkey",
+        "midi",
+        "knob",
+        "fader",
+        "controller",
+        "speed keys",
+        "automation",
+        "classic",
+        "lighttable"
+      ],
+      "sections": [
+        {
+          "title": "Keyboard preferences",
+          "paragraphs": [
+            "Settings → Shortcuts & Hardware contains the shortcut scheme and a keyboard reference under Keyboard and MIDI controls. The desktop Help menu also has Keyboard Shortcuts.",
+            "Choose LightTable or Classic; the scheme applies after a reload. Hold-key slider control lets you hold a mapped key while scrolling or using arrow keys. Allow automation controls whether approved local tools can control the window with history and Undo."
+          ],
+          "tips": [
+            "Command/Ctrl+Shift+E opens Export; Command/Ctrl+E opens external editing. Text fields keep ordinary typing behavior, so leave a text field before using unmodified editing shortcuts."
+          ]
+        },
+        {
+          "title": "MIDI mapping",
+          "paragraphs": [
+            "MIDI support depends on the Web MIDI API in the current runtime. The status can show Unavailable, Off, No devices, or a connected device count. Unavailable means this runtime cannot use the MIDI controls."
+          ],
+          "steps": [
+            "Connect a MIDI controller that sends Control Change messages.",
+            "When MIDI is available, open Keyboard and MIDI controls and choose MIDI Learn.",
+            "Click the adjustment slider you want to map, then turn a knob or move a fader.",
+            "Check the mapping message, then use the hardware control to adjust the slider.",
+            "Use Reset MIDI to restore the default mappings."
+          ]
+        }
+      ],
+      "related": [
+        "settings-and-defaults",
+        "export-photos",
+        "external-editor"
+      ]
+    },
+    {
+      "id": "catalog-health-recovery",
+      "title": "Back up the catalog and troubleshoot recovery",
+      "category": "Troubleshooting",
+      "summary": "Use verified catalog backups, Library Health, and desktop diagnostics when something goes wrong.",
+      "keywords": [
+        "catalog",
+        "backup",
+        "restore",
+        "recovery",
+        "damaged",
+        "corrupt",
+        "crash",
+        "missing",
+        "safe mode",
+        "diagnostics",
+        "log",
+        "repair"
+      ],
+      "sections": [
+        {
+          "title": "Back up and inspect",
+          "paragraphs": [
+            "Settings → Catalog shows the catalog location and backup preferences. These backups cover the catalog database; keep a separate backup of your original photo files."
+          ],
+          "steps": [
+            "Choose an Automatic backup interval and Backup location.",
+            "Click Back up now and check for a Verified backup result.",
+            "Open Library Health… to check catalog structure, missing files, and recovery information.",
+            "Use Check now to run the available catalog checks. Missing-file entries are kept with their edits."
+          ]
+        },
+        {
+          "title": "Understand recovery choices",
+          "paragraphs": [
+            "Restoring a backup returns catalog data to that backup’s state, so later edits are not in it. When a working catalog is restored, the current catalog is backed up first.",
+            "For a damaged catalog, Library Health may offer salvage, restore, or a fresh catalog. Salvage copies readable rows but loses rows on damaged pages. Starting fresh does not carry over ratings, edits, collections, or history. The current damaged catalog file is preserved in Recovery."
+          ]
+        },
+        {
+          "title": "Desktop diagnostics",
+          "paragraphs": [
+            "On macOS, Help → Diagnostics offers Reload Interface, Restart Rendering Service, Show Server Log, Library Health…, and Restart in Safe Mode.",
+            "Safe Mode turns off scanning, watched folders, local AI, and engine warm-up. Use Restart Rendering Service to return to normal operation. If an issue persists, include the visible error and relevant server-log details when reporting it."
+          ]
+        }
+      ],
+      "related": [
+        "settings-and-defaults",
+        "performance-previews"
+      ]
+    },
+    {
+      "id": "performance-previews",
+      "title": "Improve preview speed and check image detail",
+      "category": "Troubleshooting",
+      "summary": "Choose preview resolution, wait for real detail, and manage generated caches.",
+      "keywords": [
+        "performance",
+        "slow",
+        "blurry",
+        "pixelated",
+        "preview",
+        "resolution",
+        "100%",
+        "1:1",
+        "gpu",
+        "rust",
+        "python",
+        "cache",
+        "purge"
+      ],
+      "sections": [
+        {
+          "title": "Check what has finished rendering",
+          "paragraphs": [
+            "A 100% zoom setting does not guarantee that full image detail has arrived. The viewer may show Loading 100% detail…, Refining RAW detail…, or Updating preview detail… while it works. Wait for 100% detail ready when assessing fine detail.",
+            "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."
+          ],
+          "steps": [
+            "Open Settings → Performance.",
+            "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.",
+            "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.",
+            "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."
+          ]
+        },
+        {
+          "title": "Manage cache storage",
+          "paragraphs": [
+            "Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.",
+            "Preview resolution is separate from the Dimensions setting used for exported files."
+          ]
+        }
+      ],
+      "related": [
+        "film-grain-and-format",
+        "export-format-color-space",
+        "catalog-health-recovery"
+      ]
+    }
+  ]
+}

--- a/web/help-panel.js
+++ b/web/help-panel.js
@@ -1,0 +1,212 @@
+import { HELP_CATEGORIES, helpSearch } from '/web/help-search.js';
+
+const byId = (id) => document.getElementById(id);
+const dialog = byId('helpDialog');
+const search = byId('helpSearch');
+const results = byId('helpResults');
+const reader = byId('helpArticle');
+const category = byId('helpCategory');
+let articles = null;
+let pendingLoad = null;
+let selectedId = null;
+let returnFocus = null;
+let inertElements = [];
+let openGeneration = 0;
+
+// Article text is never interpreted as HTML. Source evidence stays in docs/;
+// the shipped bundle contains only the reader-facing fields.
+function element(tag, text, className) {
+  const node = document.createElement(tag);
+  if (text != null) node.textContent = text;
+  if (className) node.className = className;
+  return node;
+}
+function button(text, action, className = 'quiet') {
+  const node = element('button', text, className);
+  node.type = 'button';
+  node.addEventListener('click', action);
+  return node;
+}
+
+function showArticle(article, focus = false) {
+  selectedId = article.id;
+  reader.replaceChildren(element('p', article.category, 'help-eyebrow'));
+  const heading = element('h2', article.title);
+  heading.tabIndex = -1;
+  reader.append(heading, element('p', article.summary, 'help-summary'));
+  for (const section of article.sections) {
+    const block = element('section');
+    if (section.title) block.append(element('h3', section.title));
+    for (const paragraph of section.paragraphs) block.append(element('p', paragraph));
+    if (section.steps?.length) {
+      const list = element('ol');
+      section.steps.forEach((step) => list.append(element('li', step)));
+      block.append(list);
+    }
+    for (const tip of section.tips || []) block.append(element('p', tip, 'help-tip'));
+    reader.append(block);
+  }
+  const related = (article.related || []).map((id) => articles.find((item) => item.id === id)).filter(Boolean);
+  if (related.length) {
+    const links = element('section', null, 'help-related');
+    links.append(element('h3', 'Related help'));
+    related.forEach((item) => links.append(button(item.title, () => showArticle(item, true))));
+    reader.append(links);
+  }
+  for (const item of results.querySelectorAll('[data-help-article]')) {
+    item.setAttribute('aria-current', String(item.dataset.helpArticle === selectedId));
+  }
+  reader.scrollTop = 0;
+  dialog.classList.add('help-reading');
+  if (focus) heading.focus({ preventScroll: true });
+}
+
+function renderResults() {
+  if (!articles) return;
+  const matches = helpSearch(articles, search.value, category.value);
+  results.replaceChildren();
+  byId('helpResultCount').textContent = `${matches.length} ${matches.length === 1 ? 'article' : 'articles'}`;
+  byId('helpClear').hidden = !search.value;
+  for (const article of matches) {
+    const item = button(null, () => showArticle(article, true), 'help-result');
+    item.dataset.helpArticle = article.id;
+    item.setAttribute('aria-current', String(article.id === selectedId));
+    item.append(element('span', article.category, 'help-result-category'),
+      element('span', article.title, 'help-result-title'), element('span', article.summary, 'help-result-summary'));
+    results.append(item);
+  }
+  if (!matches.length) {
+    results.append(element('p', 'No matching articles.', 'help-empty-title'),
+      element('p', 'Try a tool name or a shorter phrase, such as “crop”, “missing photos”, or “export”.', 'help-empty'));
+    results.append(button('Browse all help', () => {
+      search.value = ''; category.value = ''; renderResults(); search.focus();
+    }));
+    reader.replaceChildren(element('h2', 'Let’s find the right help'),
+      element('p', 'Search covers article titles, tool names, and the full instructions. Choose All topics to search across the app.'));
+    selectedId = null;
+    return;
+  }
+  showArticle(matches.find((article) => article.id === selectedId) || matches[0]);
+}
+
+async function loadArticles() {
+  if (articles) return articles;
+  if (!pendingLoad) pendingLoad = fetch('/web/help-content.json').then(async (response) => {
+    if (!response.ok) throw new Error('Help content is unavailable.');
+    const content = await response.json();
+    if (content.version !== 1 || !Array.isArray(content.articles) || !content.articles.length) {
+      throw new Error('Help content could not be read.');
+    }
+    articles = content.articles;
+    return articles;
+  }).finally(() => { pendingLoad = null; });
+  return pendingLoad;
+}
+
+async function open(options = {}) {
+  const generation = ++openGeneration;
+  if (!dialog.classList.contains('on')) {
+    returnFocus = document.activeElement;
+    inertElements = [...document.body.children].filter((node) => node !== dialog &&
+      !['SCRIPT', 'STYLE', 'LINK'].includes(node.tagName) && !node.inert);
+    inertElements.forEach((node) => { node.inert = true; });
+  }
+  dialog.classList.add('on');
+  dialog.setAttribute('aria-hidden', 'false');
+  byId('helpBtn').setAttribute('aria-expanded', 'true');
+  if (options.query != null) { search.value = options.query; selectedId = null; }
+  if (options.category != null) category.value = options.category;
+  if (options.article) selectedId = options.article;
+  search.focus(); search.select();
+  if (!articles) {
+    byId('helpResultCount').textContent = 'Loading help…';
+    reader.replaceChildren(element('p', 'Loading help…'));
+  }
+  try {
+    await loadArticles();
+    if (generation !== openGeneration) return;
+    renderResults();
+    if (options.article) {
+      const article = articles.find((item) => item.id === options.article);
+      if (article) showArticle(article);
+    }
+    dialog.classList.toggle('help-reading', Boolean(options.article));
+  } catch {
+    if (generation !== openGeneration) return;
+    byId('helpResultCount').textContent = 'Help unavailable';
+    reader.replaceChildren(element('h2', 'Help couldn’t be loaded'),
+      element('p', 'Try again. If this continues, reopen LightTable to reload its bundled help.'),
+      button('Try again', () => open(options)));
+  }
+}
+
+function close() {
+  if (!dialog.classList.contains('on')) return;
+  ++openGeneration;
+  dialog.classList.remove('on');
+  dialog.setAttribute('aria-hidden', 'true');
+  byId('helpBtn').setAttribute('aria-expanded', 'false');
+  inertElements.forEach((node) => { node.inert = false; });
+  inertElements = [];
+  const target = returnFocus?.isConnected && !returnFocus.closest('[hidden]') ? returnFocus : byId('helpBtn');
+  target?.focus({ preventScroll: true });
+  returnFocus = null;
+}
+
+HELP_CATEGORIES.forEach((name) => category.append(new Option(name, name)));
+byId('helpBtn').addEventListener('click', () => open());
+byId('helpClose').onclick = close;
+byId('helpClear').onclick = () => { search.value = ''; renderResults(); search.focus(); };
+byId('helpBack').onclick = () => { dialog.classList.remove('help-reading'); results.querySelector('button')?.focus(); };
+byId('helpShortcuts').onclick = () => { close(); window.LightTableSettings?.open('shortcuts'); };
+search.addEventListener('input', () => { selectedId = null; renderResults(); dialog.classList.remove('help-reading'); });
+category.addEventListener('change', () => { selectedId = null; renderResults(); dialog.classList.remove('help-reading'); });
+search.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowDown') { event.preventDefault(); results.querySelector('button')?.focus(); }
+  if (event.key === 'Enter') { event.preventDefault(); results.querySelector('[data-help-article]')?.click(); }
+});
+results.addEventListener('keydown', (event) => {
+  if (!['ArrowDown', 'ArrowUp'].includes(event.key)) return;
+  const items = [...results.querySelectorAll('button')];
+  const index = items.indexOf(document.activeElement);
+  if (index < 0) return;
+  event.preventDefault();
+  items[(index + (event.key === 'ArrowDown' ? 1 : -1) + items.length) % items.length]?.focus();
+});
+dialog.addEventListener('pointerdown', (event) => { if (event.target === dialog) close(); });
+
+// Capture before photo/speed-key handlers. Keep text selection/copy and native
+// input behavior working, but never let reading help rate or alter a photo.
+document.addEventListener('keydown', (event) => {
+  if (!dialog.classList.contains('on')) {
+    const typing = event.target.closest?.('input, textarea, select, [contenteditable="true"]');
+    if (event.key === 'F1' || (event.key === '?' && !typing && !event.metaKey && !event.ctrlKey && !event.altKey)) {
+      if (document.querySelector('.modal-backdrop.on')) return;
+      event.preventDefault(); event.stopImmediatePropagation(); open();
+    }
+    return;
+  }
+  if (event.key === 'Escape') { event.preventDefault(); event.stopImmediatePropagation(); close(); return; }
+  if (event.key === 'F1') {
+    event.preventDefault(); event.stopImmediatePropagation();
+    dialog.classList.remove('help-reading'); search.focus(); search.select(); return;
+  }
+  if (event.key === 'Tab') {
+    const focusables = [...dialog.querySelectorAll('button, input, select, a[href], [tabindex="0"]')]
+      .filter((node) => !node.disabled && node.getClientRects().length);
+    const first = focusables[0], last = focusables.at(-1);
+    const active = document.activeElement;
+    if (event.shiftKey && (active === first || !focusables.includes(active))) {
+      event.preventDefault(); last?.focus();
+    } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+      event.preventDefault(); first?.focus();
+    }
+  }
+  // Let target handlers (search/list navigation) run, then stop bubbling below.
+}, true);
+dialog.addEventListener('keydown', (event) => event.stopPropagation());
+dialog.addEventListener('keyup', (event) => event.stopPropagation());
+document.addEventListener('focusin', (event) => {
+  if (dialog.classList.contains('on') && !dialog.contains(event.target)) search.focus();
+});
+window.LightTableHelp = { open, close, isOpen: () => dialog.classList.contains('on') };

--- a/web/help-search.js
+++ b/web/help-search.js
@@ -1,0 +1,44 @@
+// Search is shared by the help UI and its behavioral tests. No server or index
+// service is needed; all searchable text comes from the bundled articles.
+const STOP_WORDS = new Set(['a', 'an', 'and', 'are', 'can', 'do', 'does', 'how',
+  'i', 'in', 'is', 'it', 'my', 'of', 'on', 'the', 'to', 'with']);
+export const HELP_CATEGORIES = ['Getting started', 'Library', 'Editing', 'Film',
+  'Export', 'Settings', 'Troubleshooting'];
+// Direct article IDs keep contextual help stable when search ranking changes.
+// Tests validate every destination against the shipped content.
+export const HELP_SECTION_TOPICS = {
+  Editing: {
+    Light: 'editing-tone', Color: 'editing-white-balance', Curve: 'editing-curves',
+    'Color Grading': 'editing-color-grading', Effects: 'editing-effects',
+    Detail: 'editing-detail-effects-enhance', 'Lens corrections': 'editing-lens-corrections',
+    Profile: 'settings-and-defaults',
+  },
+  Film: {
+    'Film profile': 'film-getting-started', 'Physical film stages': 'film-halation-diffusion-scan',
+    'Reference Match': 'film-reference-match',
+  },
+};
+
+export function normalizeHelpText(value) {
+  return String(value).normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+export function helpSearch(articles, query = '', category = '') {
+  const phrase = normalizeHelpText(query);
+  const terms = [...new Set(phrase.split(' ').filter((term) => term && !STOP_WORDS.has(term)))];
+  return articles.flatMap((article, index) => {
+    if (category && article.category !== category) return [];
+    const title = normalizeHelpText(article.title);
+    const keywords = normalizeHelpText(article.keywords.join(' '));
+    const summary = normalizeHelpText(article.summary);
+    const body = normalizeHelpText(article.sections.map((section) =>
+      [section.title, ...section.paragraphs, ...(section.steps || []), ...(section.tips || [])].join(' ')).join(' '));
+    const fields = [title, keywords, summary, body, normalizeHelpText(article.category)];
+    if (!terms.every((term) => fields.some((field) => field.includes(term)))) return [];
+    const score = terms.reduce((sum, term) => sum + (title.includes(term) ? 12 : 0)
+      + (keywords.includes(term) ? 7 : 0) + (summary.includes(term) ? 4 : 0)
+      + (body.includes(term) ? 1 : 0), 0) + (phrase && title.includes(phrase) ? 25 : 0);
+    return [{ article, score, index }];
+  }).sort((a, b) => b.score - a.score || a.index - b.index).map(({ article }) => article);
+}

--- a/web/help.css
+++ b/web/help.css
@@ -1,0 +1,56 @@
+.help-backdrop { z-index:110; }
+.help-panel { width:min(960px,calc(100vw - 40px)); height:min(760px,calc(100vh - 64px)); display:flex; flex-direction:column; padding:0; overflow:hidden; background:var(--panel); }
+.help-header { display:flex; align-items:center; gap:16px; padding:18px 22px; border-bottom:1px solid var(--line); flex-shrink:0; }
+.help-heading { margin-right:auto; }
+.help-heading h1 { font-size:15px; font-weight:600; margin:0 0 4px; }
+.help-heading p { margin:0; color:var(--muted); font-size:11px; }
+.help-layout { display:grid; grid-template-columns:300px minmax(0,1fr); flex:1; min-height:0; }
+.help-browser { display:flex; flex-direction:column; min-height:0; padding:18px 12px 0; border-right:1px solid var(--line); background:var(--inset); }
+.help-search-label { display:block; margin:0 4px 8px; font-size:11px; color:var(--ink-2); }
+.help-search-box { display:flex; align-items:center; border:1px solid var(--line-strong); border-radius:var(--radius); background:var(--field); margin:0 4px 12px; }
+.help-search-box:focus-within { border-color:var(--accent); box-shadow:0 0 0 2px var(--accent-soft); }
+.help-search-box input { flex:1; min-width:0; height:36px; border:0; background:transparent; box-shadow:none; outline:0; font-size:12px; padding:8px 10px; }
+.help-search-box input::-webkit-search-cancel-button { -webkit-appearance:none; }
+.help-search-box button { flex-shrink:0; margin-right:3px; }
+.help-filter { display:flex; align-items:center; gap:10px; margin:0 4px 10px; }
+.help-filter select { width:auto; flex:1; min-width:0; }
+.help-filter .dd { flex:1; min-width:0; }
+.help-filter output { color:var(--muted); font-size:10px; white-space:nowrap; }
+.help-results { overflow-y:auto; min-height:0; padding:0 4px 16px; }
+.help-result { display:block; width:100%; text-align:left; height:auto; white-space:normal; padding:13px 12px; border:1px solid transparent; background:transparent; border-radius:var(--radius); box-shadow:none; margin-bottom:3px; }
+.help-result:hover { background:var(--hover); }
+.help-result[aria-current="true"] { background:var(--accent-soft); border-color:var(--line-strong); }
+.help-result span { display:block; }
+.help-result-category { color:var(--muted); font-size:10px; margin-bottom:5px; }
+.help-result-title { color:var(--ink); font-size:12px; font-weight:600; line-height:1.45; }
+.help-result-summary { color:var(--muted); font-size:11px; font-weight:400; line-height:1.5; margin-top:5px; display:-webkit-box !important; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.help-reader { min-width:0; min-height:0; display:flex; flex-direction:column; }
+.help-article { overflow-y:auto; padding:28px 34px 36px; color:var(--ink-2); font-size:13px; line-height:1.7; flex:1; }
+.help-article h2 { color:var(--ink); font-size:22px; line-height:1.25; font-weight:600; letter-spacing:-.4px; margin:8px 0 12px; outline:none; }
+.help-article h3 { color:var(--ink); font-size:13px; font-weight:600; margin:25px 0 8px; }
+.help-article p { margin:0 0 12px; }
+.help-article .help-eyebrow { font-size:11px; color:var(--muted); margin:0; }
+.help-article .help-summary { font-size:13px; color:var(--muted); margin-bottom:24px; }
+.help-article ol { padding-left:22px; margin:8px 0 18px; }
+.help-article li { padding-left:5px; margin-bottom:10px; }
+.help-article li::marker { color:var(--muted); font-size:11px; }
+.help-article .help-tip { border-left:2px solid var(--line-strong); padding:4px 0 4px 14px; color:var(--muted); font-size:12px; margin:18px 0; }
+.help-related { border-top:1px solid var(--line); margin-top:30px; }
+.help-related button { display:block; height:auto; white-space:normal; padding:6px 0; text-align:left; color:var(--accent); }
+.help-empty-title { font-weight:600; margin-top:18px; }
+.help-empty { color:var(--muted); line-height:1.6; font-size:12px; }
+.help-back { display:none; }
+.help-panel :focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+.help-search-box input:focus-visible { outline:none; }
+@media (max-width:700px) {
+  .help-panel { width:calc(100vw - 20px); height:calc(100vh - 24px); }
+  .help-header { padding:14px; gap:8px; }
+  .help-heading p { display:none; }
+  .help-layout { grid-template-columns:1fr; }
+  .help-browser { border-right:0; }
+  .help-reader { display:none; }
+  .help-reading .help-browser { display:none; }
+  .help-reading .help-reader { display:flex; }
+  .help-reading .help-back { display:block; align-self:flex-start; margin:10px 18px 0; }
+  .help-article { padding:20px 22px; }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="/web/style.css">
 <link rel="stylesheet" href="/web/grid-layout.css">
 <link rel="stylesheet" href="/web/preset-browser.css">
+<link rel="stylesheet" href="/web/help.css">
 </head>
 <body>
 
@@ -65,6 +66,9 @@
     </button>
     <span id="estat" role="status" aria-live="polite"></span><button class="quiet compact" id="exportCancel" hidden>Cancel export</button><button class="quiet compact" id="exportDetails" hidden>Export details</button>
     <span id="editSaveStatus" role="status" aria-live="polite"></span><button class="quiet compact" id="retryEditSave" hidden>Retry save</button>
+    <button class="quiet icon-btn" id="helpBtn" title="Help (F1 or ?)" aria-label="Help" aria-haspopup="dialog" aria-controls="helpDialog" aria-expanded="false">
+      <svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="7"/><path d="M8 7a2 2 0 0 1 4 .5c0 1.5-2 1.5-2 3M10 13.5v.2"/></svg>
+    </button>
     <button class="accent-btn icon-btn topbar-export-btn" id="exportBtn" title="Export photos" aria-label="Export photos">
       <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M10 13V2M6 6l4-4 4 4M4 10v6h12v-6"/></svg>
     </button>
@@ -1224,6 +1228,25 @@
 
 <div class="health-overlay" id="healthOverlay" hidden><div class="b"></div><span id="healthOverlayText"></span></div>
 <div class="toast" id="toast"></div>
+<div class="modal-backdrop help-backdrop" id="helpDialog" aria-hidden="true">
+  <div class="modal help-panel" role="dialog" aria-modal="true" aria-labelledby="helpTitle">
+    <header class="help-header">
+      <div class="help-heading"><h1 id="helpTitle">LightTable Help</h1><p>Guides for your photographs, from first edit to export.</p></div>
+      <button class="quiet compact" id="helpShortcuts">Keyboard shortcuts</button>
+      <button class="quiet icon-btn" id="helpClose" aria-label="Close help" title="Close help (Escape)">×</button>
+    </header>
+    <div class="help-layout">
+      <aside class="help-browser" aria-label="Find help">
+        <label class="help-search-label" for="helpSearch">Search help</label>
+        <div class="help-search-box"><input id="helpSearch" type="search" placeholder="Try crop, masks, or export…" autocomplete="off" spellcheck="false" aria-controls="helpResults"><button class="quiet icon-btn" id="helpClear" aria-label="Clear help search" hidden>×</button></div>
+        <div class="help-filter no-dd"><select id="helpCategory" aria-label="Help topic"><option value="">All topics</option></select><output id="helpResultCount" role="status" aria-live="polite"></output></div>
+        <nav class="help-results" id="helpResults" aria-label="Help articles"></nav>
+      </aside>
+      <div class="help-reader"><button class="quiet help-back" id="helpBack">← Back to articles</button><article class="help-article" id="helpArticle" aria-label="Help article" tabindex="0"></article></div>
+    </div>
+  </div>
+</div>
+<script type="module" src="/web/help-panel.js"></script>
 <script type="module" src="/web/dropdown.js"></script>
 <script type="module" src="/web/app.js"></script>
 <script type="module" src="/web/slider-ux.js"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -631,7 +631,7 @@
             <div class="row"><span class="name">Horizontal</span><input type="range" data-optics="horizontal" min="-1" max="1" step="0.01"><span class="val" data-opticsv="horizontal">0.00</span></div>
             <div class="row"><span class="name">Scale</span><input type="range" data-optics="scale" min="1" max="1.6" step="0.005" value="1"><span class="val" data-opticsv="scale">1.00</span></div>
           </div></details>
-          <p class="hint crop-hint">Drag outside the frame to draw a new crop. Drag inside to reposition it, or use the handles to resize. Arrow keys nudge the selection; hold Shift for larger steps. Enter accepts; Escape restores the frame from when you opened Crop.</p>
+          <p class="hint crop-hint">Drag the handles to resize; the photo zooms to keep the frame centred. Drag inside the frame to move the photo under it, or outside it to draw a new crop. Arrow keys nudge the crop; hold Shift for larger steps. Enter accepts; Escape restores the frame from when you opened Crop.</p>
         </div>
       </section>
 

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="/web/grid-layout.css">
 <link rel="stylesheet" href="/web/preset-browser.css">
 <link rel="stylesheet" href="/web/help.css">
+<link rel="stylesheet" href="/web/first-run.css">
 </head>
 <body>
 
@@ -918,6 +919,60 @@
   </div>
 </div>
 
+<div class="modal-backdrop setup-backdrop" id="firstRunDialog" aria-hidden="true">
+  <section class="setup-window" id="setupPanel" role="dialog" aria-modal="true" aria-labelledby="setupWelcome">
+    <div class="setup-brand"><svg class="setup-mark" viewBox="0 0 32 32" fill="none" aria-hidden="true"><rect x="4" y="4" width="24" height="24" rx="5" stroke="currentColor" stroke-width="1.5"/><path d="M10 10v12h12M10 17h12M17 10v12" stroke="currentColor" stroke-width="1.5"/></svg><span>LightTable</span></div>
+    <div data-setup-page="choices">
+      <h1 id="setupWelcome" tabindex="-1">Where are your photos?</h1>
+      <p class="setup-intro">Choose a place to start. Make yourself at home.</p>
+      <div class="setup-options">
+        <button class="setup-option" id="setupLightroom"><span class="setup-option-icon setup-lr" aria-hidden="true">Lr</span><span><strong>Move from Lightroom</strong><small>Bring your catalog, ratings, and collections.</small></span><span class="setup-arrow" aria-hidden="true">›</span></button>
+        <button class="setup-option" id="setupPhotos"><span class="setup-option-icon" aria-hidden="true"><svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.3"><ellipse cx="16" cy="16" rx="5" ry="13"/><ellipse cx="16" cy="16" rx="5" ry="13" transform="rotate(45 16 16)"/><ellipse cx="16" cy="16" rx="5" ry="13" transform="rotate(90 16 16)"/><ellipse cx="16" cy="16" rx="5" ry="13" transform="rotate(135 16 16)"/></svg></span><span><strong>Apple Photos</strong><small>Start with the photos in your Mac’s library.</small></span><span class="setup-arrow" aria-hidden="true">›</span></button>
+        <button class="setup-option" id="setupFolder"><span class="setup-option-icon" aria-hidden="true"><svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 10V7a2 2 0 0 1 2-2h7l3 4h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V10Z"/><path d="M3 12h26"/></svg></span><span><strong>Choose a folder</strong><small>Browse photos right where they are.</small></span><span class="setup-arrow" aria-hidden="true">›</span></button>
+      </div>
+      <p class="setup-caption">You can add more sources any time.</p>
+    </div>
+    <div class="setup-detail" data-setup-page="lightroom" hidden>
+      <h2 id="setupHeading-lightroom" tabindex="-1">Bring your Lightroom library</h2>
+      <p class="setup-intro">Start with a Lightroom Classic catalog.</p>
+      <ul class="setup-facts"><li>Your originals stay where they are. Your Lightroom catalog stays unchanged.</li><li>Bring ratings, keywords, collections, and supported edits. Develop settings are approximate.</li><li>Close Lightroom Classic, then choose its <strong>.lrcat</strong> file. You’ll review what to import before starting.</li></ul>
+      <button class="accent-btn" id="setupCatalogChoose">Choose catalog…</button>
+      <p class="setup-availability">Using cloud-based Lightroom? Export your originals to a folder, then choose that folder here.</p>
+    </div>
+    <div class="setup-detail" data-setup-page="photos" hidden>
+      <h2 id="setupHeading-photos" tabindex="-1">Start with Apple Photos</h2>
+      <p class="setup-intro">Import the originals from your Photos library.</p>
+      <ul class="setup-facts"><li>LightTable saves separate copies in <strong>Pictures / LightTable Imports / Apple Photos</strong>. Your Photos library stays unchanged.</li><li>Originals stored in iCloud will download. A large library may take time and extra disk space.</li><li>This imports photo originals, including RAW files. Albums, videos, and edits made in Photos aren’t transferred.</li></ul>
+      <button class="accent-btn" id="setupPhotosAll">Import entire library</button><button class="quiet" id="setupPhotosSelected" hidden>Choose a few…</button>
+      <p class="setup-availability" id="setupPhotosAvailability">Whole-library import requires the updated LightTable app for macOS. You can also export originals from Photos and choose their folder.</p>
+      <p class="setup-availability">Add new photos by running this import again. There’s no automatic sync.</p>
+    </div>
+    <div class="setup-detail" data-setup-page="folder" hidden>
+      <h2 id="setupHeading-folder" tabindex="-1">Start with a folder</h2>
+      <p class="setup-intro">A few favorites or your whole photo archive.</p>
+      <ul class="setup-facts"><li>Photos stay in their current folder. No moving or copying required.</li><li>Subfolders are included, so you can start with a single folder or an entire archive.</li><li>You can add more folders later from the Library menu.</li></ul>
+      <label class="field" id="setupFolderPathField" hidden><span>Folder path on this computer</span><input id="setupFolderPath" type="text" placeholder="/Users/you/Pictures/My photos" autocomplete="off" spellcheck="false"></label>
+      <button class="accent-btn" id="setupFolderChoose">Choose folder…</button>
+    </div>
+    <div class="setup-detail" data-setup-page="photos-progress" hidden>
+      <h2 id="setupHeading-photos-progress" tabindex="-1">Bringing in your photos</h2>
+      <p class="setup-intro">Your library in Photos stays unchanged.</p>
+      <progress class="setup-progress" id="setupPhotosProgress" aria-label="Import progress"></progress>
+      <p id="setupPhotosProgressText" role="status" aria-live="polite">Preparing import…</p>
+      <p class="setup-availability">Keep LightTable open. iCloud originals may take a little longer.</p>
+      <button class="quiet" id="setupPhotosCancel">Stop import</button>
+    </div>
+    <div class="setup-detail" data-setup-page="result" hidden>
+      <svg class="setup-result-icon" viewBox="0 0 40 40" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="20" cy="20" r="17"/><path d="m12 20 5 5 11-11"/></svg>
+      <h2 id="setupHeading-result" tabindex="-1">Your photos are ready</h2>
+      <p id="setupResultMessage" class="setup-intro"></p>
+      <button class="accent-btn" id="setupDone">Start editing</button>
+    </div>
+    <p class="setup-error" id="setupError" role="alert"></p>
+    <footer class="setup-footer"><button id="setupBack" hidden>‹ Back</button><button id="setupLater">Set up later</button></footer>
+  </section>
+</div>
+
 <div class="modal-backdrop" id="importDialog" aria-hidden="true">
   <div class="modal modal-wide" role="dialog" aria-modal="true" aria-labelledby="importTitle">
     <strong id="importTitle">Import a catalog</strong>
@@ -927,6 +982,7 @@
     </div>
     <div class="import-summary" id="importSummary">Choose a catalog to see what it holds.</div>
     <div class="import-options" id="importOptions" hidden>
+      <label><input type="checkbox" id="impAddSources" checked> Add the photo folders used by this catalog</label>
       <label><input type="checkbox" id="impMetadata" checked> Ratings, flags, labels, and IPTC</label>
       <label><input type="checkbox" id="impKeywords" checked> Keywords</label>
       <label><input type="checkbox" id="impCollections" checked> Collections</label>
@@ -993,6 +1049,7 @@
       <div class="settings-content">
         <section class="settings-pane on" data-settings-pane="general" role="tabpanel">
           <h2>General</h2><p class="settings-intro">Culling, updates, and job completion behavior.</p>
+          <div class="settings-group"><div class="settings-action-row"><span>Bring photos from Lightroom, Apple Photos, or a folder.</span><button id="setupReopen">Photo setup…</button></div></div>
           <div class="settings-group">
             <label class="settings-choice"><span><strong>Auto-advance</strong><small>Move to the next photo after a pick, reject, or rating.</small></span><input type="checkbox" id="autoAdvance" checked></label>
             <label class="settings-choice"><span><strong>Completion notifications</strong><small>Notify when exports, ingests, or denoise jobs finish.</small></span><input type="checkbox" id="completionNotifications"></label>

--- a/web/presentation-cache.js
+++ b/web/presentation-cache.js
@@ -12,6 +12,7 @@ export function renderRequestKey(image, request) {
     source: [image.name, image.fileKey, image.mtime],
     w: request.w, engine: request.engine, native: request.native,
     params: request.params, optics: request.optics, heals: request.heals,
+    viewport: request.viewport || null,
   }));
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -646,7 +646,7 @@ input[type=checkbox]:disabled { opacity:.4; }
 @keyframes spin { to { transform:rotate(360deg); } }
 #cropLayer { position:absolute; inset:0; z-index:4; display:none; cursor:crosshair; touch-action:none; }
 #cropLayer.on { display:block; }
-.crop-dimmer { position:absolute; background:rgba(0,0,0,.62); pointer-events:none; }
+.crop-dimmer { position:absolute; background:rgb(var(--crop-dim-rgb,0 0 0) / var(--crop-dim-alpha,.62)); pointer-events:none; }
 .crop-dimmer-top { inset:0 0 auto; height:var(--crop-y,0%); }
 .crop-dimmer-bottom { inset:calc(var(--crop-y,0%) + var(--crop-h,100%)) 0 0; }
 .crop-dimmer-left { left:0; top:var(--crop-y,0%); width:var(--crop-x,0%); height:var(--crop-h,100%); }
@@ -703,6 +703,11 @@ input[type=checkbox]:disabled { opacity:.4; }
 #cropLayer[data-active-crop-handle="ne"],
 #cropLayer[data-active-crop-handle="sw"] { cursor:nesw-resize; }
 #cropLayer[data-active-crop-handle] * { cursor:inherit !important; }
+/* Lightroom-style cropping: the frame is the whole photo, sized by the
+   cropping zoom and panned under a centred crop, and the workspace clips it. */
+.cmp.is-cropping { flex:0 0 auto; overflow:visible; max-width:none; max-height:none; }
+#cropLayer.exiting { pointer-events:none; }
+#cropLayer.exiting #cropRect { opacity:0; transition:opacity .12s ease; }
 .under { min-height:44px; flex:0 0 44px; display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:12px; padding:6px 12px; border-top:1px solid var(--line-soft); background:var(--inset); min-width:0; overflow:hidden; }
 .under-group { display:flex; align-items:center; gap:4px; min-width:0; }
 .centre-tools { justify-content:center; }

--- a/windows-shell/src/lib.rs
+++ b/windows-shell/src/lib.rs
@@ -14,11 +14,22 @@ pub struct FolderSource {
     pub favorite: bool,
 }
 
+/// Logical window geometry remembered between launches.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WindowState {
+    pub width: f64,
+    pub height: f64,
+    #[serde(default)]
+    pub maximized: bool,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Settings {
     pub active: Option<PathBuf>,
     #[serde(default)]
     pub sources: Vec<FolderSource>,
+    #[serde(default)]
+    pub window: Option<WindowState>,
 }
 
 impl Settings {
@@ -113,6 +124,30 @@ pub fn normalise(path: PathBuf) -> PathBuf {
     path.canonicalize().unwrap_or(path)
 }
 
+/// Threads for the server's OpenMP, numba, and BLAS pools.
+///
+/// The macOS host fixes these at four. Windows desktops commonly expose eight
+/// to sixteen logical processors, so RAW decoding and export workers may take
+/// up to half of them while the webview, the resident GPU engine, and the
+/// server's own threads keep the rest. Small machines keep the proven four.
+pub fn worker_threads(logical_processors: usize) -> usize {
+    (logical_processors / 2).clamp(4, 8)
+}
+
+/// Fit a requested logical window size inside the monitor's work area.
+///
+/// A remembered or default size larger than the current display would open
+/// with its frame off screen. The margin keeps the title bar and taskbar
+/// reachable; the minimum still wins on displays smaller than the UI.
+pub fn fit_window(requested: (f64, f64), minimum: (f64, f64), available: (f64, f64)) -> (f64, f64) {
+    // Monitor size, not work area: leave room for the frame and a taskbar.
+    const MARGIN: (f64, f64) = (24.0, 72.0);
+    (
+        requested.0.min(available.0 - MARGIN.0).max(minimum.0),
+        requested.1.min(available.1 - MARGIN.1).max(minimum.1),
+    )
+}
+
 pub fn source_folders(files: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut seen = HashSet::new();
     files
@@ -198,6 +233,48 @@ mod tests {
             validate_windows_folder_name("Scans  2026").unwrap(),
             "Scans 2026"
         );
+    }
+
+    #[test]
+    fn worker_threads_scale_with_the_machine_but_stay_bounded() {
+        assert_eq!(worker_threads(1), 4);
+        assert_eq!(worker_threads(4), 4);
+        assert_eq!(worker_threads(8), 4);
+        assert_eq!(worker_threads(12), 6);
+        assert_eq!(worker_threads(16), 8);
+        assert_eq!(worker_threads(64), 8);
+    }
+
+    #[test]
+    fn window_size_fits_the_work_area_and_respects_the_minimum() {
+        let minimum = (1100.0, 700.0);
+        assert_eq!(
+            fit_window((1500.0, 950.0), minimum, (2560.0, 1400.0)),
+            (1500.0, 950.0)
+        );
+        assert_eq!(
+            fit_window((1500.0, 950.0), minimum, (1280.0, 800.0)),
+            (1256.0, 728.0)
+        );
+        assert_eq!(
+            fit_window((1500.0, 950.0), minimum, (1024.0, 600.0)),
+            (1100.0, 700.0)
+        );
+    }
+
+    #[test]
+    fn window_state_round_trips_and_is_optional_for_older_settings() {
+        let legacy: Settings = serde_json::from_str(r#"{"active":null,"sources":[]}"#).unwrap();
+        assert_eq!(legacy.window, None);
+        let mut settings = Settings::default();
+        settings.window = Some(WindowState {
+            width: 1440.0,
+            height: 900.0,
+            maximized: true,
+        });
+        let encoded = serde_json::to_string(&settings).unwrap();
+        let decoded: Settings = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.window, settings.window);
     }
 
     #[test]

--- a/windows-shell/src/main.rs
+++ b/windows-shell/src/main.rs
@@ -1014,7 +1014,9 @@ fn run() -> Result<()> {
             _ => {}
         }
         if app.close_approved {
-            app.server.stop();
+            if let Some(mut server) = app.server.take() {
+                server.stop();
+            }
             *control_flow = ControlFlow::Exit;
         } else if let Some(deadline) = app.close_deadline {
             *control_flow = ControlFlow::WaitUntil(deadline);

--- a/windows-shell/src/main.rs
+++ b/windows-shell/src/main.rs
@@ -960,7 +960,7 @@ fn run() -> Result<()> {
         server: None,
         paths,
         settings,
-        folder: normalise(folder),
+        folder: folder.clone(),
         journal: journal_tx,
         close_deadline: None,
         close_approved: false,

--- a/windows-shell/src/main.rs
+++ b/windows-shell/src/main.rs
@@ -15,16 +15,20 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 use directories::{BaseDirs, UserDirs};
-use lighttable_desktop_shell::{Settings, edit_recovery, normalise, rename_root, source_folders};
+use lighttable_desktop_shell::{
+    Settings, WindowState, edit_recovery, fit_window, normalise, rename_root, source_folders, worker_threads,
+};
 use rfd::{FileDialog, MessageButtons, MessageDialog, MessageLevel};
 use serde_json::{Value, json};
 use tao::{
     dpi::LogicalSize,
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoopBuilder},
-    window::{Window, WindowBuilder},
+    event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
+    window::{Theme, Window, WindowBuilder},
 };
-use wry::{PageLoadEvent, WebView, WebViewBuilder};
+#[cfg(target_os = "windows")]
+use wry::{Theme as WebViewTheme, WebViewBuilderExtWindows};
+use wry::{PageLoadEvent, WebContext, WebView, WebViewBuilder};
 
 fn photo_extensions() -> Vec<String> {
     let groups: Value = serde_json::from_str(include_str!("../../media-formats.json"))
@@ -51,13 +55,43 @@ document.documentElement.classList.add('native-shell', 'windows-shell');
 document.documentElement.style.setProperty('--native-window-controls-w', '0px');
 "#;
 
-#[derive(Debug)]
+/// `--bg` from `web/style.css`. The window and the webview paint it before
+/// the UI arrives, so a launch or a folder switch never flashes white.
+const BACKGROUND: (u8, u8, u8, u8) = (0x12, 0x12, 0x12, 0xff);
+
+/// Shown while the render server starts. The window opens immediately and
+/// stays responsive; the real UI replaces this page once the server answers.
+const LOADING_PAGE: &str = r#"<!doctype html>
+<html><head><meta charset="utf-8"><title>LightTable</title><style>
+html, body { margin: 0; height: 100%; background: #121212; color: #cfcfcf;
+  font: 13px system-ui, "Segoe UI", sans-serif; }
+main { height: 100%; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 14px; }
+.spin { width: 22px; height: 22px; border: 2px solid #353535; border-top-color: #f0f0f0;
+  border-radius: 50%; animation: spin 0.9s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style></head>
+<body><main><div class="spin"></div><div>Starting LightTable…</div></main></body></html>
+"#;
+
+const DEFAULT_WINDOW: (f64, f64) = (1500.0, 950.0);
+const MINIMUM_WINDOW: (f64, f64) = (1100.0, 700.0);
+const SERVER_READY_TIMEOUT: Duration = Duration::from_secs(45);
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 enum UserEvent {
     NativeMessage(String),
     EditJournalReply(Value),
     PageLoaded,
+    ServerReady {
+        generation: u64,
+        folder: PathBuf,
+        result: Result<ServerController>,
+    },
 }
 
+#[derive(Clone)]
 struct RuntimePaths {
     project: PathBuf,
     python: PathBuf,
@@ -115,8 +149,23 @@ impl ServerController {
         fs::create_dir_all(&paths.cache)?;
         let port = choose_port()?;
         let log = std::fs::OpenOptions::new().create(true).append(true).open(&paths.log)?;
+        let bytecode = paths.cache.join("python-bytecode");
+        let threads = worker_threads(
+            thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(4),
+        )
+        .to_string();
         let mut command = Command::new(&paths.python);
         command
+            // The embedded runtime's `python313._pth` puts the interpreter in
+            // isolated mode, which ignores every PYTHON* environment variable.
+            // Unbuffered logging and the bytecode cache location therefore
+            // travel as interpreter options; the variables below still serve
+            // a development virtual environment.
+            .arg("-u")
+            .arg("-X")
+            .arg(format!("pycache_prefix={}", bytecode.display()))
             .arg(paths.project.join("server.py"))
             .current_dir(&paths.project)
             .env("LIGHTTABLE_DIR", folder)
@@ -129,15 +178,21 @@ impl ServerController {
                 "LIGHTTABLE_PRESETS_FILE",
                 paths.support.join("presets.json"),
             )
-            .env("PYTHONDONTWRITEBYTECODE", "1")
-            .env("PYTHONPYCACHEPREFIX", paths.cache.join("python-bytecode"))
-            .env("OMP_NUM_THREADS", "4")
-            .env("NUMBA_NUM_THREADS", "4")
-            .env("OPENBLAS_NUM_THREADS", "4")
+            .env("LIGHTTABLE_SERVER_LOG", &paths.log)
+            .env("PYTHONPYCACHEPREFIX", &bytecode)
+            .env("OMP_NUM_THREADS", &threads)
+            .env("NUMBA_NUM_THREADS", &threads)
+            .env("OPENBLAS_NUM_THREADS", &threads)
             .env("PYTHONUNBUFFERED", "1")
             .env("LIGHTTABLE_LOG_FILE", &paths.log)
             .stdout(Stdio::from(log.try_clone()?))
             .stderr(Stdio::from(log));
+        if env::var_os("NUMBA_CACHE_DIR").is_none() {
+            // Compiled kernels otherwise land beside the shipped sources,
+            // which the uninstaller never removes and a read-only install
+            // cannot accept at all.
+            command.env("NUMBA_CACHE_DIR", paths.cache.join("compiled-runtime"));
+        }
 
         let mut python_paths = vec![paths.project.join("vendor").join("spektrafilm").join("src")];
         if let Some(existing) = env::var_os("PYTHONPATH") {
@@ -148,14 +203,14 @@ impl ServerController {
         #[cfg(target_os = "windows")]
         {
             use std::os::windows::process::CommandExt;
-            command.creation_flags(0x0800_0000);
+            command.creation_flags(CREATE_NO_WINDOW);
         }
 
         let child = command
             .spawn()
             .context("could not start the render server")?;
         let mut controller = Self { child, port };
-        if let Err(error) = wait_until_ready(port, Duration::from_secs(45)) {
+        if let Err(error) = wait_until_ready(port, SERVER_READY_TIMEOUT) {
             controller.stop();
             return Err(error);
         }
@@ -179,7 +234,8 @@ impl Drop for ServerController {
 struct AppState {
     window: Window,
     webview: WebView,
-    server: ServerController,
+    _web_context: WebContext,
+    server: Option<ServerController>,
     paths: RuntimePaths,
     settings: Settings,
     folder: PathBuf,
@@ -187,6 +243,16 @@ struct AppState {
     close_deadline: Option<Instant>,
     close_approved: bool,
     close_attempts: CloseAttempts,
+    proxy: EventLoopProxy<UserEvent>,
+    /// Identifies the server start whose result is still wanted.
+    launch_generation: u64,
+    /// A start is in flight; further folder choices wait in `queued`.
+    pending: bool,
+    queued: Option<PathBuf>,
+    /// Where to return if the folder being opened cannot start a server.
+    fallback: Option<PathBuf>,
+    /// Shown as a toast once the next page finishes loading.
+    pending_error: Option<String>,
 }
 
 impl AppState {
@@ -217,6 +283,13 @@ impl AppState {
         self.settings.save(&self.paths.settings)
     }
 
+    fn set_title(&self, folder: &Path) {
+        self.window.set_title(&format!(
+            "LightTable — {}",
+            folder.file_name().unwrap_or_default().to_string_lossy()
+        ));
+    }
+
     fn launch(&mut self, folder: PathBuf) -> Result<()> {
         let folder = normalise(folder);
         if !folder.is_dir() {
@@ -226,20 +299,127 @@ impl AppState {
             .add_source(folder.clone(), self.settings.sources.is_empty());
         self.settings.active = Some(folder.clone());
         self.settings.save(&self.paths.settings)?;
-        let server = ServerController::start(&self.paths, &folder)?;
-        self.server.stop();
-        self.server = server;
-        self.folder = folder;
-        self.window.set_title(&format!(
-            "LightTable — {}",
-            self.folder
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-        ));
-        self.webview
-            .load_url(&format!("http://127.0.0.1:{}/", self.server.port))?;
+        if self.pending {
+            // One server start at a time: the catalog lease belongs to the
+            // process being started, so the newest choice waits its turn.
+            self.queued = Some(folder);
+            return Ok(());
+        }
+        let fallback = self.server.as_ref().map(|_| self.folder.clone());
+        self.begin_server(folder, fallback);
         Ok(())
+    }
+
+    /// Stop the running server and start one for `folder` off the UI thread.
+    ///
+    /// One catalog holds one process lease, so the previous server must be
+    /// gone before its replacement opens the same library. The loading page
+    /// covers the gap while the window keeps painting, moving, and closing.
+    fn begin_server(&mut self, folder: PathBuf, fallback: Option<PathBuf>) {
+        if let Some(mut previous) = self.server.take() {
+            previous.stop();
+        }
+        self.folder = folder.clone();
+        self.fallback = fallback;
+        self.set_title(&folder);
+        let _ = self.webview.load_html(LOADING_PAGE);
+        self.launch_generation += 1;
+        self.pending = true;
+        let generation = self.launch_generation;
+        let paths = self.paths.clone();
+        let proxy = self.proxy.clone();
+        thread::spawn(move || {
+            let result = ServerController::start(&paths, &folder);
+            let _ = proxy.send_event(UserEvent::ServerReady {
+                generation,
+                folder,
+                result,
+            });
+        });
+    }
+
+    fn server_ready(&mut self, generation: u64, folder: PathBuf, result: Result<ServerController>) {
+        if generation != self.launch_generation {
+            // A newer start superseded this one; its server must not linger.
+            if let Ok(mut stale) = result {
+                stale.stop();
+            }
+            return;
+        }
+        self.pending = false;
+        if let Some(next) = self.queued.take() {
+            if let Ok(mut superseded) = result {
+                superseded.stop();
+            }
+            let fallback = self.fallback.take().or(Some(folder));
+            self.begin_server(next, fallback);
+            return;
+        }
+        match result {
+            Ok(server) => {
+                let url = format!("http://127.0.0.1:{}/", server.port);
+                self.server = Some(server);
+                self.fallback = None;
+                if let Err(error) = self.webview.load_url(&url) {
+                    show_fatal(&format!("{error:#}"));
+                    std::process::exit(1);
+                }
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                match self
+                    .fallback
+                    .take()
+                    .filter(|previous| previous != &folder && previous.is_dir())
+                {
+                    Some(previous) => {
+                        // Return to the folder that was open, and say why.
+                        self.pending_error = Some(format!(
+                            "Could not open {}: {message}",
+                            folder.file_name().unwrap_or_default().to_string_lossy()
+                        ));
+                        self.settings.active = Some(previous.clone());
+                        let _ = self.save_settings();
+                        self.begin_server(previous, None);
+                    }
+                    None => {
+                        show_fatal(&message);
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+    }
+
+    fn page_loaded(&mut self) {
+        let _ = self.send_sources();
+        if let Some(message) = self.pending_error.take() {
+            let _ = self.send_event(json!({"type": "error", "message": message}));
+        }
+    }
+
+    /// Remember the logical window size for the next launch. A maximized
+    /// window keeps the last restored size so un-maximizing later is sane.
+    fn remember_window(&mut self) {
+        let maximized = self.window.is_maximized();
+        let (width, height) = if maximized {
+            self.settings
+                .window
+                .map(|state| (state.width, state.height))
+                .unwrap_or(DEFAULT_WINDOW)
+        } else {
+            let size = self
+                .window
+                .inner_size()
+                .to_logical::<f64>(self.window.scale_factor());
+            (size.width, size.height)
+        };
+        self.settings.window = Some(WindowState {
+            width,
+            height,
+            maximized,
+        });
+        let _ = self.save_settings();
     }
 
     fn handle_command(&mut self, raw: &str) -> Result<()> {
@@ -351,9 +531,7 @@ impl AppState {
                     .unwrap_or_default();
                 if application.is_empty() {
                     for path in paths {
-                        Command::new("cmd.exe")
-                            .args(["/C", "start", "", &path])
-                            .spawn()?;
+                        open_with_default_application(&path)?;
                     }
                 } else if !paths.is_empty() {
                     Command::new(application).args(paths).spawn()?;
@@ -585,18 +763,46 @@ fn recycle(_path: &Path) -> Result<()> {
     Err(anyhow!("the Recycle Bin is only available on Windows"))
 }
 
+/// Open a file with the application registered for it.
+fn open_with_default_application(path: &str) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        // `cmd.exe` is a console program; without this flag a command window
+        // would flash on every double-click from a shell that has no console.
+        Command::new("cmd.exe")
+            .args(["/C", "start", "", path])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()?;
+    }
+    #[cfg(target_os = "macos")]
+    Command::new("open").arg(path).spawn()?;
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    Command::new("xdg-open").arg(path).spawn()?;
+    Ok(())
+}
+
 fn reveal(path: &Path) -> Result<()> {
     #[cfg(target_os = "windows")]
-    let status = Command::new("explorer.exe")
-        .arg(format!("/select,{}", path.display()))
-        .status()?;
+    {
+        use std::os::windows::process::CommandExt;
+        // Explorer reports a nonzero exit status even after it has selected
+        // the item, so only a failure to launch it is an error here.
+        Command::new("explorer.exe")
+            .raw_arg(format!("/select,\"{}\"", path.display()))
+            .spawn()
+            .context("File Explorer could not be started")?;
+        return Ok(());
+    }
     #[cfg(target_os = "macos")]
     let status = Command::new("open").arg("-R").arg(path).status()?;
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     let status = Command::new("xdg-open").arg(path).status()?;
+    #[cfg(not(target_os = "windows"))]
     if !status.success() {
         bail!("the file browser could not open that location")
     }
+    #[cfg(not(target_os = "windows"))]
     Ok(())
 }
 
@@ -667,26 +873,48 @@ fn run() -> Result<()> {
                 .pick_folder()
         })
         .context("no photo folder was chosen")?;
+    let folder = normalise(folder);
     settings.add_source(folder.clone(), settings.sources.is_empty());
     settings.active = Some(folder.clone());
     settings.save(&paths.settings)?;
-    let server = ServerController::start(&paths, &folder)?;
 
     let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
     let proxy = event_loop.create_proxy();
+    let available = event_loop
+        .primary_monitor()
+        .map(|monitor| {
+            let size = monitor.size().to_logical::<f64>(monitor.scale_factor());
+            (size.width, size.height)
+        })
+        .unwrap_or(DEFAULT_WINDOW);
+    let remembered = settings.window;
+    let (width, height) = fit_window(
+        remembered
+            .map(|state| (state.width, state.height))
+            .unwrap_or(DEFAULT_WINDOW),
+        MINIMUM_WINDOW,
+        available,
+    );
     let window = WindowBuilder::new()
         .with_title(format!(
             "LightTable — {}",
             folder.file_name().unwrap_or_default().to_string_lossy()
         ))
-        .with_inner_size(LogicalSize::new(1500.0, 950.0))
-        .with_min_inner_size(LogicalSize::new(1100.0, 700.0))
+        .with_inner_size(LogicalSize::new(width, height))
+        .with_min_inner_size(LogicalSize::new(MINIMUM_WINDOW.0, MINIMUM_WINDOW.1))
+        .with_maximized(remembered.is_some_and(|state| state.maximized))
+        .with_theme(Some(Theme::Dark))
+        .with_background_color(BACKGROUND)
         .build(&event_loop)?;
 
+    // WebView2 otherwise keeps its profile beside the executable, which the
+    // uninstaller never removes and a read-only location cannot hold.
+    let mut web_context = WebContext::new(Some(paths.support.join("WebView2")));
     let command_proxy = proxy.clone();
     let load_proxy = proxy.clone();
-    let webview = WebViewBuilder::new()
-        .with_url(format!("http://127.0.0.1:{}/", server.port))
+    let builder = WebViewBuilder::new_with_web_context(&mut web_context)
+        .with_html(LOADING_PAGE)
+        .with_background_color(BACKGROUND)
         .with_initialization_script(BRIDGE_SCRIPT)
         .with_clipboard(true)
         .with_ipc_handler(move |request| {
@@ -696,8 +924,10 @@ fn run() -> Result<()> {
             if matches!(event, PageLoadEvent::Finished) {
                 let _ = load_proxy.send_event(UserEvent::PageLoaded);
             }
-        })
-        .build(&window)?;
+        });
+    #[cfg(target_os = "windows")]
+    let builder = builder.with_theme(WebViewTheme::Dark);
+    let webview = builder.build(&window)?;
 
     let (journal_tx, journal_rx) = std::sync::mpsc::channel::<Value>();
     let journal_proxy = proxy.clone();
@@ -726,7 +956,8 @@ fn run() -> Result<()> {
     let mut app = AppState {
         window,
         webview,
-        server,
+        _web_context: web_context,
+        server: None,
         paths,
         settings,
         folder: normalise(folder),
@@ -734,7 +965,14 @@ fn run() -> Result<()> {
         close_deadline: None,
         close_approved: false,
         close_attempts: CloseAttempts::default(),
+        proxy,
+        launch_generation: 0,
+        pending: false,
+        queued: None,
+        fallback: None,
+        pending_error: None,
     };
+    app.begin_server(folder, None);
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = app.close_deadline.map(ControlFlow::WaitUntil).unwrap_or(ControlFlow::Wait);
@@ -750,13 +988,17 @@ fn run() -> Result<()> {
             Event::UserEvent(UserEvent::EditJournalReply(reply)) => {
                 let _ = app.send_event(reply);
             }
-            Event::UserEvent(UserEvent::PageLoaded) => {
-                let _ = app.send_sources();
-            }
+            Event::UserEvent(UserEvent::PageLoaded) => app.page_loaded(),
+            Event::UserEvent(UserEvent::ServerReady {
+                generation,
+                folder,
+                result,
+            }) => app.server_ready(generation, folder, result),
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
+                app.remember_window();
                 if app.close_deadline.is_none() {
                     app.close_deadline = Some(Instant::now() + Duration::from_secs(12));
                     let attempt = app.close_attempts.begin();


### PR DESCRIPTION
Combine the completed local work into the public application: first-run folder and Photos-library setup, searchable help with 54 source-linked articles, preview and export performance improvements, Windows startup and shared-memory support, and editing reliability fixes. The Windows quit path also handles startup still being pending.

Reconcile the overlapping changes with current main so native edit recovery, cancellable exports, catalog compatibility previews, and full-resolution scope sampling remain intact. Catalog imports can add referenced originals, preserve the preview/trial workflow, and inspect pasted paths automatically. Help now explains the integrated setup, crop, migration, and backup behavior.

Validation:
- Full Python/JavaScript/native regression suite: 1,080 tests, 4 skips, no failures before the final catalog-input debounce; 74 focused regression tests passed after the final catalog-input debounce.
- Rust engine: 18 tests passed. Windows shell library: 11 tests passed; the complete desktop-shell executable also passes cargo check locally.
- Swift type-checking and native shared-memory/Metal checks passed.
- Actual browser: first-run folder setup, photo rendering, help search, square-crop cancellation, catalog inspection, and compatibility preview with disposable data.
- Help source anchors and reviewed content are current; git diff checks pass.

The uncommitted localization work and separately active Filter work remain in their own worktrees. This PR does not replace the installed application.
