### PR TITLE
Add toolbar filters with file types and active chips

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -2035,6 +2035,33 @@ class Catalog:
             where.append("f.kind='video'")
         elif kind == "virtual":
             where.append("i.virtual=1")
+        # Saved toolbar filters use the same OR-within-types / AND-between-
+        # fields semantics as the browser, including virtual-copy source types.
+        file_types = flt.get("fileTypes")
+        if isinstance(file_types, list):
+            type_clauses = []
+            groups = {"jpeg": (".jpg", ".jpeg", ".jpe"),
+                      "heic": (".heic", ".heif", ".hif"),
+                      "tiff": (".tif", ".tiff"), "png": (".png",)}
+            if "raw" in file_types:
+                type_clauses.append("f.kind='raw'")
+            for name, suffixes in groups.items():
+                if name in file_types:
+                    placeholders = ",".join("?" for _ in suffixes)
+                    type_clauses.append(f"(f.kind='processed' AND f.ext IN ({placeholders}))")
+                    params.extend(suffixes)
+            if type_clauses:
+                where.append("(" + " OR ".join(type_clauses) + ")")
+        edit_state = flt.get("editState")
+        if edit_state in ("edited", "unedited"):
+            edited = "(" + " OR ".join(
+                f"s.{field}_json IS NOT NULL" for field in
+                ("params", "grade", "crop", "masks", "heals", "optics")) + ")"
+            where.append(edited if edit_state == "edited" else "NOT " + edited)
+        elif edit_state == "virtual":
+            where.append("i.virtual=1")
+        if flt.get("unrated") is True:
+            where.append("COALESCE(s.rating,0)=0")
         raw_excluded_kinds = spec.get("excludeKinds", [])
         if not isinstance(raw_excluded_kinds, (list, tuple, set)):
             raw_excluded_kinds = []

--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -209,7 +209,7 @@
     "id": "search-filter-sort",
     "title": "Find photos with search, filters, and sorting",
     "category": "Library",
-    "summary": "Narrow the current folder or collection by text, flags, stars, colour, and file kind.",
+    "summary": "Narrow the current folder or collection by text, file type, flags, stars, color label, and edit status.",
     "keywords": [
       "find",
       "search",
@@ -218,7 +218,15 @@
       "sort",
       "capture date",
       "no results",
-      "unrated"
+      "unrated",
+      "file type",
+      "RAW",
+      "JPEG",
+      "HEIC",
+      "TIFF",
+      "PNG",
+      "unedited",
+      "clear filters"
     ],
     "sections": [
       {
@@ -230,14 +238,22 @@
           "Click Search photos and keywords, or press / when you are not typing in a field.",
           "Type a word or phrase from the filename or keywords.",
           "Use All Photos, Unflagged, Picked, Rejected, or Rated in the sidebar to choose a flag or rating group.",
-          "Expand Filter for workflow state, minimum rating, colour label, and file kind.",
+          "Click Filter beside Sort. Select one or more file types, then combine them with Flag, Rating, Color label, or Edit status.",
           "Choose File name, Rating, Flag, Capture date, or Colour label in Sort."
+        ]
+      },
+      {
+        "title": "Combine and clear filters",
+        "paragraphs": [
+          "Select RAW, JPEG, HEIC / HEIF, TIFF, or PNG. Multiple file types include any of those formats; flag, rating, color label, edit status, and search narrow that set further. No selected file types means all file types.",
+          "The Filter button shows how many choices are active. Each choice appears as a removable chip above the grid, and the count shows how many photos match. Remove a chip with its ×, or choose Clear all to reset the filters. Search text and the selected folder or collection stay in place.",
+          "Edit status offers Edited, Unedited, and Virtual copies. A virtual copy uses its original file’s type. Press Escape or click outside the panel to close it without clearing your choices."
         ]
       },
       {
         "title": "When a photo seems missing",
         "paragraphs": [
-          "Clear the search text and reset Filter choices, then check the selected folder, Include subfolders, and any active collection. Paired-file preferences and collapsed stacks can also hide a companion or stack member.",
+          "Clear the search text and choose Clear all above the grid, then check the selected folder, Include subfolders, and any active collection. Paired-file preferences and collapsed stacks can also hide a companion or stack member.",
           "Capture date sorts from earlier to later; Rating sorts higher ratings first."
         ]
       }
@@ -255,11 +271,11 @@
       },
       {
         "path": "web/app.js",
-        "anchor": "return matchesKind && photoMatchesQuery(im, search);"
+        "anchor": "return matchesKind && matchesLibraryFilters(im, fileTypes, editState) && photoMatchesQuery(im, search);"
       },
       {
         "path": "web/index.html",
-        "anchor": "<label for=\"labelFilter\">Colour label</label>"
+        "anchor": "<label class=\"field-label\" for=\"labelFilter\">Color label</label>"
       },
       {
         "path": "web/app.js",
@@ -268,6 +284,10 @@
       {
         "path": "web/app.js",
         "anchor": "captureSortValue(a) - captureSortValue(b)"
+      },
+      {
+        "path": "web/library-filters.js",
+        "anchor": "export function installLibraryFilters"
       }
     ]
   },
@@ -427,7 +447,7 @@
           "Select a photo, or a set in a grid, and open Info.",
           "Under Colour label, choose Red, Yellow, Green, Blue, or Purple. Choose No label to clear it.",
           "Use 6 for Red, 7 for Yellow, 8 for Green, and 9 for Blue. Purple is available from the colour controls.",
-          "Expand Filter in the library sidebar and use Colour label to find a particular colour, any colour, or unlabelled photos."
+          "Click Filter beside Sort and use Color label to find a particular colour, any colour, or unlabelled photos."
         ],
         "tips": [
           "Applying the same label again clears it. Colour-label actions do not auto-advance."
@@ -588,10 +608,10 @@
       {
         "title": "Save supported rules",
         "paragraphs": [
-          "A smart collection finds photos that match its saved rules. Supported rules are pick/reject/unflag status, minimum star rating, file kind, and search text."
+          "A smart collection finds photos that match its saved rules. Supported rules include flag, rating, Unrated only, file types, color label, edit status, virtual copies, and search text."
         ],
         "steps": [
-          "Set the search text, desired flag group, minimum rating, and file kind in the library.",
+          "Set the search text and desired choices in Filter beside Sort.",
           "Click the ✦ beside Collections, labelled Save filters as smart collection.",
           "Name the collection and save.",
           "Click its name to view matching photos. Changing a photo’s relevant metadata changes whether it matches."
@@ -600,8 +620,8 @@
       {
         "title": "Know what is saved",
         "paragraphs": [
-          "Colour-label filters, the selected folder, and Include subfolders are not saved in the smart collection rules. Edited and Unrated only are not supported smart-collection rules. Use supported flag and minimum-rating choices when creating one.",
-          "You cannot manually add photos with Add selected to collection while a smart collection is active. Current search and sidebar filters can still narrow the collection view."
+          "The selected folder and Include subfolders are not saved in the smart collection rules. The collection searches the library using the saved filter choices.",
+          "You cannot manually add photos with Add selected to collection while a smart collection is active. Current search and library filters can still narrow the collection view."
         ]
       }
     ],
@@ -617,7 +637,7 @@
       },
       {
         "path": "web/app.js",
-        "anchor": "kind: $('kindFilter').value, query: $('search').value },"
+        "anchor": "fileTypes: LIBRARY_FILTERS.types(),"
       },
       {
         "path": "web/library.js",
@@ -718,7 +738,7 @@
           "Make the source photo active.",
           "Open the Photo actions ••• menu beside Sort and Size, then choose Create virtual copy.",
           "Name the copy and save. The new copy becomes active.",
-          "Edit the copy. Use Filter → Workflow state → Virtual copies to find copies later."
+          "Edit the copy. Use Filter → Edit status → Virtual copies to find copies later."
         ],
         "tips": [
           "Delete virtual copy in Photo actions removes the active virtual copy. For a real second file on disk, export a rendered image."

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -5,14 +5,14 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
     },
@@ -20,22 +20,22 @@
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "capture-time": {
       "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
       "sources": {
         "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "catalog-health-recovery": {
       "content": "41e3f81ef36412cf1ec4ce0f431988f484834120a750a45d31a1fef66365c718",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82"
       }
@@ -43,14 +43,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "colour-labels": {
-      "content": "2c5b7d4b0df298ecfb0ddc7e025366294fd42d2036114e43c9d87a70e98b48f4",
+      "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -58,14 +58,14 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-copy-paste-match-exposure": {
@@ -73,21 +73,21 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
     "editing-crop-geometry": {
       "content": "847f666d8a355cae0104998f95f855baf7de6490a8445d2603e67e681623393c",
       "sources": {
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-curves": {
       "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-detail-effects-enhance": {
@@ -95,53 +95,53 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-effects": {
       "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-masks-ai": {
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "7702f31a22aca801cec4d6985a696f77e4d038fb86613ba1953b2590cd855434",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-photo-merge": {
@@ -150,134 +150,134 @@
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-presets": {
       "content": "53107c055d29749d94f8708d4e18b5e246db2eb67b1b68948659c3f46fc65026",
       "sources": {
         "preset_io.py": "16aafa7edd016912ba7538ae223b1b532c3214b507763c22575ba2d0da25c2ea",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-remove-heal": {
       "content": "41b396a3d13fa3364bd68d63aec838869e50787b3e2a7ab68a5cf4530af3fbf7",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "export-filenames-and-folders": {
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "export-format-color-space": {
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "export-metadata-sidecars": {
       "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "export-photos": {
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-getting-started": {
       "content": "40ee07cc67a0c1adc8399b5637ce2013db09cb112ceb00513b673006e42bddf8",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-grain-and-format": {
       "content": "9a1053af3c49d0067e62943d4ab3f7a8ca8162b2205e4a815d392fb32d980234",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-halation-diffusion-scan": {
       "content": "f02ee05d45129d688db98d5b9f91ecb520904e7a508b12926168955ba9bb120d",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-negative-paper-and-slides": {
       "content": "58fd1a72df074b9eba7c45f90e5d34f9d817c60977dfbd42a93ef0ada8fe02bb",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-reference-match": {
       "content": "1be79ec76df974f733a333725c268d6f7314ee6f96216593dc2c0c128786e3ed",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -286,7 +286,7 @@
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "import-lightroom-catalog": {
@@ -295,30 +295,30 @@
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "keyboard-midi": {
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
     },
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
       "content": "7310080ae9b9d7bfedfa16f4cc37b14892aa4390165db7e2c8ae9c3be52c14ea",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
@@ -328,15 +328,15 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -349,47 +349,48 @@
       }
     },
     "search-filter-sort": {
-      "content": "ff18bb946e9c68623d3d2f104a2a22025ea0c5d74c3a232c12bf0915ec9730ea",
+      "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
-        "web/library.js": "f34f4221773427bb7372af094babf01a0283b4c9e1b4052c26f9b758c5a619f2"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
+        "web/library-filters.js": "ce5a8b7272b19301b684af76675ec25ea87f53f2e76fdaea17ef1c99f1116825",
+        "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
     "settings-and-defaults": {
       "content": "c924f166996e97b4da2d038d431ef735d757dc5cc12fba6e959f5fc39450f006",
       "sources": {
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82"
       }
     },
     "shortcut-schemes": {
       "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
     "smart-collections": {
-      "content": "2f91873697f5787c3aa826af3e449ff1487e15ab7f2f57bdcc89d19d92095035",
+      "content": "811716ffcdf02245d65b07cf0f3a60a85ba2fa11c540ce4a9d5993086a311bef",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/library.js": "f34f4221773427bb7372af094babf01a0283b4c9e1b4052c26f9b758c5a619f2"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
     "soft-proof": {
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
         "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
       }
     },
@@ -398,21 +399,21 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "server.py": "e1cc7aa3f3050f8a2487a2532c5edd3fd10b93a74b09b7332a3b9fb3f8f9adf7",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576"
       }
     },
     "views-and-selection": {
       "content": "7412cdc7f39cc344f7b438ad008a5661ec18d13009da7cbbe2a405bf6a5e710b",
       "sources": {
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b",
-        "web/index.html": "42e921fd1cb8c08cebb3ca956f9a3316138f98334e7bd5d505a701bec62f30dc"
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "virtual-copies-and-stacks": {
-      "content": "48e2beb283a16a46d8174bac5f9a0511c623a5665591f02deac6badd33ba3692",
+      "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
-        "library_workflow.py": "ac36ded31b6b62e88c8a8624004d769942d060db1a910afda0077092dd31274c",
-        "web/app.js": "736a900fa85caed8b854a8dfa23fde2548d3e1e740cda6ed627a2919c2d6664b"
+        "library_workflow.py": "9dfeb6839e0970471158d6abab48c867f4ec408748fde056d0fd721ec5e5009a",
+        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576"
       }
     }
   },

--- a/library_workflow.py
+++ b/library_workflow.py
@@ -66,6 +66,13 @@ def clean_collections(values) -> list[dict]:
                 if str(rules.get("kind", "all")) in
                 ("all", "raw", "processed", "virtual") else "all",
                 "query": str(rules.get("query", ""))[:200],
+                "fileTypes": [kind for kind in ("raw", "jpeg", "heic", "tiff", "png")
+                              if isinstance(rules.get("fileTypes"), list) and kind in rules["fileTypes"]],
+                "editState": rules.get("editState") if rules.get("editState") in
+                ("edited", "unedited", "virtual") else "all",
+                "unrated": rules.get("unrated") is True,
+                "label": rules.get("label") if rules.get("label") in
+                ("any", "none", "red", "yellow", "green", "blue", "purple") else "all",
             },
         })
     return result

--- a/tests/library-filters.test.mjs
+++ b/tests/library-filters.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import vm from 'node:vm';
+import { normalizeFileTypes, photoFileType, photoHasEdits, matchesLibraryFilters, filterChips } from '../web/library-filters.js';
+import { collapsePairs, pairViewPreference } from '../web/photo-pairs.js';
+
+const images = [
+  {name:'1:Tree.ARW', raw:true, rating:5, status:'approved', hasEdits:true},
+  {name:'1:Tree.JPG', rating:4, status:'approved', label:'red'},
+  {name:'2:Portrait.JPEG', rating:2, status:'skipped', grade:{exposure:1}},
+  {name:'2:Portrait.PNG', rating:4, status:'approved', label:'red'},
+  {name:'copy', sourceName:'2:Portrait.TIFF', virtual:true, rating:5, status:'approved'},
+];
+
+function harness() {
+  const controls = Object.fromEntries(Object.entries({ filter:'all', ratingFilter:'0', kindFilter:'all',
+    labelFilter:'all', editFilter:'all', search:'', sort:'name' }).map(([id,value])=>[id,{value}]));
+  let types = [];
+  const ctx = vm.createContext({ $: id=>controls[id], S:{images,library:{stacks:[]},cull:{review:'all',on:{}}},
+    LIBRARY_FILTERS:{types:()=>types}, APP_PREFS:{pairView:'raw'},
+    _cachedVisibleList:null, _cachedVisibleKey:'', _visibleEpoch:0, _cachedVisibleImages:null, _cachedVisibleLibrary:null,
+    CULL_SELECT:[], CULL_REJECT:[], matchesCullReview:()=>true, collectionScope:()=>images,
+    cleanLabel:label=>label||'none', photoHasEdits, matchesLibraryFilters,
+    photoMatchesQuery:(im,query)=>im.name.toLowerCase().includes(query.toLowerCase()),
+    collapsePairs, pairViewPreference, pairOverrides:new Map() });
+  const source = readFileSync(new URL('../web/app.js', import.meta.url),'utf8');
+  vm.runInContext(source.slice(source.indexOf('function visible() {'), source.indexOf('\nfunction inFolderScope')),ctx);
+  return { controls, types(next) {types=next;}, names:()=>Array.from(ctx.visible(),im=>im.name) };
+}
+
+test('file types normalize safely and match source extensions, not display names',()=>{
+  assert.deepEqual(normalizeFileTypes(['png','raw','raw','bad']),['raw','png']);
+  assert.deepEqual(normalizeFileTypes('raw'),[]);
+  for (const [name,type] of [['a.JPG','jpeg'],['a.jpeg','jpeg'],['a.HEIF','heic'],['a.HIF','heic'],['a.TIF','tiff'],['a.TIFF','tiff'],['a.PNG','png'],['a.webp','other']]) {
+    assert.equal(photoFileType({name:'virtual id',sourceName:name,displayName:'My RAW photo'}),type);
+  }
+  assert.equal(photoFileType({name:'capture.DNG',raw:true}),'raw');
+});
+
+test('file types combine with OR, other filters with AND, before RAW/JPEG pair collapsing',()=>{
+  const h=harness();
+  h.types(['jpeg']); assert.deepEqual(h.names(),['1:Tree.JPG','2:Portrait.JPEG']);
+  h.types(['jpeg','png']); assert.deepEqual(h.names(),['1:Tree.JPG','2:Portrait.JPEG','2:Portrait.PNG']);
+  h.controls.filter.value='approved';h.controls.ratingFilter.value='4';h.controls.labelFilter.value='red';
+  assert.deepEqual(h.names(),['1:Tree.JPG','2:Portrait.PNG']);
+  h.controls.search.value='portrait'; assert.deepEqual(h.names(),['2:Portrait.PNG']);
+  h.controls.editFilter.value='edited'; assert.deepEqual(h.names(),[]);
+  h.controls.editFilter.value='unedited'; assert.deepEqual(h.names(),['2:Portrait.PNG']);
+});
+
+test('changing only a file type or edit status invalidates the visible-list cache',()=>{
+  const h=harness();
+  h.types(['raw']); assert.deepEqual(h.names(),['1:Tree.ARW']);
+  h.types(['tiff']); assert.deepEqual(h.names(),['copy']);
+  h.controls.editFilter.value='virtual'; assert.deepEqual(h.names(),['copy']);
+  h.controls.editFilter.value='edited'; assert.deepEqual(h.names(),[]);
+  h.controls.editFilter.value='all'; h.types([]); assert.equal(h.names().length,4);
+});
+
+test('ratings and empty edit containers do not count as edits',()=>{
+  assert.equal(photoHasEdits({rating:5,params:{},grade:{}}),false);
+  assert.equal(matchesLibraryFilters({hasEdits:true},[],'unedited'),false);
+  assert.equal(matchesLibraryFilters({name:'copy',sourceName:'a.JPG',virtual:true},['jpeg'],'virtual'),true);
+});
+
+test('each active restriction is visible in the summary, including old saved filters',()=>{
+  const chips=filterChips({filter:'approved',ratingFilter:'4',labelFilter:'red',editFilter:'unedited',kindFilter:'processed'},['jpeg','png']);
+  assert.deepEqual(chips.map(c=>c.id),['type:jpeg','type:png','filter','ratingFilter','labelFilter','editFilter','kindFilter']);
+  assert.deepEqual(filterChips({filter:'all',ratingFilter:'0',labelFilter:'all',editFilter:'all',kindFilter:'all'},[]),[]);
+});
+
+test('saved collection rules preserve the same file type, flag, rating and edit restrictions',()=>{
+  const source=readFileSync(new URL('../web/library.js',import.meta.url),'utf8');
+  const ctx=vm.createContext({matchesLibraryFilters,normalizeFileTypes,aiSearchTerms:()=>[]});
+  vm.runInContext(source.replace(/^import .*;\n/gm,'').replaceAll('export function','function'),ctx);
+  const rules={fileTypes:['jpeg','png'],status:'approved',ratingMin:4,label:'red',editState:'unedited'};
+  assert.deepEqual(images.filter(im=>ctx.photoMatchesRules(im,rules)).map(im=>im.name),['1:Tree.JPG','2:Portrait.PNG']);
+  assert.equal(ctx.photoMatchesRules(images[1],{...rules,unrated:true}),false);
+});

--- a/tests/test_library_filters.py
+++ b/tests/test_library_filters.py
@@ -1,0 +1,54 @@
+"""Toolbar filters retain their semantics in the browser and saved collections."""
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import catalog as catalog_module
+import catalog_scan
+import library_workflow
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class LibraryFilterTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which('node'), 'Node.js is unavailable')
+    def test_browser_filter_behaviors(self):
+        result = subprocess.run(['node', '--test', str(ROOT / 'tests/library-filters.test.mjs')],
+                                capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_saved_filters_match_the_catalog_after_reopen(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            photos = root / 'photos'
+            photos.mkdir()
+            for name in ('a.JPG', 'b.PNG', 'c.TIFF', 'd.HEIC', 'e.ARW'):
+                (photos / name).write_bytes(name.encode() * 64)
+            cat = catalog_module.Catalog(root / 'library.sqlite3')
+            source_id = cat.add_source(photos)
+            catalog_scan.scan_source(cat, source_id, read_metadata_for_new=False)
+            rows = {item['filename']: item for item in cat.query()['items']}
+            cat.save_state(rows['a.JPG']['id'], {'rating': 4, 'status': 'approved', 'label': 'red'})
+            cat.save_state(rows['b.PNG']['id'], {'rating': 5, 'status': 'approved', 'label': 'red', 'grade': {'exposure': 1}})
+            rules = {'fileTypes': ['jpeg', 'png'], 'ratingMin': 4, 'status': 'approved', 'label': 'red', 'editState': 'unedited'}
+            ident = cat.add_collection('Filtered', kind='smart', rules=rules)
+            cat.close()
+            cat = catalog_module.Catalog(root / 'library.sqlite3')
+            try:
+                result = cat.query({'scope': 'collection', 'collectionId': ident})
+                self.assertEqual([item['filename'] for item in result['items']], ['a.JPG'])
+                for kind, expected in [('raw','e.ARW'),('heic','d.HEIC'),('tiff','c.TIFF')]:
+                    result = cat.query({'filter': {'fileTypes': [kind]}})
+                    self.assertEqual([item['filename'] for item in result['items']], [expected])
+                self.assertEqual(cat.query({'filter': {'fileTypes': ['jpeg'], 'unrated': True}})['total'], 0)
+            finally:
+                cat.close()
+
+    def test_folder_mode_preserves_saved_rules(self):
+        rules = {'fileTypes': ['jpeg','raw','wrong'], 'editState':'unedited', 'unrated':True, 'label':'red'}
+        cleaned = library_workflow.clean_collections([{'name':'Filtered','type':'smart','rules':rules}])[0]['rules']
+        self.assertEqual(cleaned['fileTypes'], ['raw','jpeg'])
+        for key in ('editState','unrated','label'):
+            self.assertEqual(cleaned[key], rules[key])

--- a/web/app.js
+++ b/web/app.js
@@ -1,3 +1,5 @@
+import { installLibraryFilters, matchesLibraryFilters, photoHasEdits } from '/web/library-filters.js';
+import { close as closeDropdown } from '/web/dropdown.js';
 import {installDialogFocus} from '/web/dialog-focus.js';
 import {installMaskBatch, mergeMaskDelta} from '/web/batch-masks.js';
 import {createSelectionRequest} from '/web/selection-request.js';
@@ -104,6 +106,8 @@ const RESET_GROUPS = {
 const S = createAppState(GRADE_DEFAULTS, OPTICS_DEFAULTS);
 const photoUndo = createPhotoUndoHistory();
 const APP_PREFS = {};
+const LIBRARY_FILTERS = installLibraryFilters({ el: $, closeDropdown,
+  onChange: () => { refreshFilteredView(); savePrefs(); } });
 let MASK_BATCH = null;
 let SELECTION_REQUEST = null;
 let KEY_SCHEME_NAME = 'lighttable';
@@ -296,8 +300,8 @@ document.addEventListener('keydown', (event) => {
 
 function selectionScope() {
   return JSON.stringify([S.activeFolder, S.includeSubfolders, S.activeCollection,
-    ...['filter', 'ratingFilter', 'kindFilter', 'labelFilter', 'search', 'sort'].map(id => $(id)?.value),
-    S.library.stacks, S.cull, pairViewPreference(APP_PREFS), [...pairOverrides]]);
+    ...['filter', 'ratingFilter', 'kindFilter', 'labelFilter', 'editFilter', 'search', 'sort'].map(id => $(id)?.value),
+    LIBRARY_FILTERS.types(), S.library.stacks, S.cull, pairViewPreference(APP_PREFS), [...pairOverrides]]);
 }
 function setAllPhotoSelection(selected) {
   if (selected) return SELECTION_REQUEST.selectAll();
@@ -4301,6 +4305,7 @@ $('switchPair').onclick = async () => {
   // The requested member is explicit. A RAW-only/JPEG-only filter should not
   // immediately navigate away from it; keep other library filters intact.
   if (['raw', 'processed'].includes($('kindFilter').value)) $('kindFilter').value = 'all';
+  LIBRARY_FILTERS.setTypes([]);
   if (S.msel.delete(image.name)) S.msel.add(companion.name);
   await go(S.images.indexOf(companion));
   refreshLists(); savePrefs();
@@ -4311,13 +4316,15 @@ function visible() {
   const rf = $('ratingFilter')?.value || 'all';
   const kind = $('kindFilter')?.value || 'all';
   const labelFilter = $('labelFilter') ? $('labelFilter').value : 'all';
+  const editState = $('editFilter')?.value || 'all';
+  const fileTypes = LIBRARY_FILTERS.types();
   const search = $('search')?.value || '';
   const s = $('sort')?.value || 'capture';
   const stacksKey = (S.library.stacks || []).map((stack) => `${stack.id}:${stack.collapsed}`).join(',');
   const pairMode = pairViewPreference(APP_PREFS);
   const cullKey = `${S.cull.review}|${CULL_SELECT.filter((k) => S.cull.on[k]).join(',')}`
     + `|${CULL_REJECT.filter((k) => S.cull.on[k]).join(',')}|${S.cull.revision}`;
-  const cacheKey = `${S.libraryRevision || 0}|${S.activeFolder}|${S.includeSubfolders}|${S.activeCollection}|${f}|${rf}|${kind}|${labelFilter}|${search}|${s}|${stacksKey}|${pairMode}|${cullKey}|${S.images.length}`;
+  const cacheKey = `${S.libraryRevision || 0}|${S.activeFolder}|${S.includeSubfolders}|${S.activeCollection}|${f}|${rf}|${kind}|${labelFilter}|${editState}|${fileTypes.join(",")}|${search}|${s}|${stacksKey}|${pairMode}|${cullKey}|${S.images.length}`;
   if (_cachedVisibleList && _cachedVisibleKey === cacheKey &&
       _cachedVisibleImages === S.images && _cachedVisibleLibrary === S.library) {
     return _cachedVisibleList;
@@ -4329,7 +4336,8 @@ function visible() {
       if (f === 'all') return true;
       if (f === 'rated') return (im.rating || 0) >= 1;
       if (f === 'unrated') return !im.rating || +im.rating === 0;
-      if (f === 'edited') return !!(im.hasEdits || im.params || (im.grade && Object.keys(im.grade).length) || im.crop);
+      if (f === 'edited') return photoHasEdits(im);
+      if (f === 'unedited') return !photoHasEdits(im);
       if (f === 'virtual') return !!im.virtual;
       if (f === 'pending') return !im.status || im.status === 'pending';
       return im.status === f;
@@ -4347,7 +4355,7 @@ function visible() {
     const matchesKind = (kind === 'all' || (kind === 'raw' && im.raw) ||
       (kind === 'processed' && !im.raw && !im.virtual) ||
       (kind === 'virtual' && im.virtual));
-    return matchesKind && photoMatchesQuery(im, search);
+    return matchesKind && matchesLibraryFilters(im, fileTypes, editState) && photoMatchesQuery(im, search);
   });
   list = collapsePairs(list, pairMode, pairOverrides);
   for (const stack of S.library.stacks || []) {
@@ -4915,6 +4923,7 @@ const cachedLibrarySummary = createSummaryCache();
 let _countsPaintKey = '';
 
 function counts() {
+  LIBRARY_FILTERS.sync();
   // Selection changes do not alter catalog counts or collection membership.
   const summaryKey = `${S.libraryRevision || 0}|${_visibleEpoch}|${S.activeFolder}|${S.includeSubfolders}|${S.activeCollection}|${S.images.length}`;
   const summary = cachedLibrarySummary(summaryKey, S.images, () => {
@@ -4943,7 +4952,7 @@ function counts() {
   $('sourceRatedCount').textContent = rated;
   $('filmstripCount').textContent = `${shown} photo${shown === 1 ? '' : 's'}`;
   const labels = { all: 'All Photos', pending: 'Unflagged', approved: 'Picked',
-    skipped: 'Rejected', rated: 'Rated', unrated: 'Unrated', edited: 'Edited',
+    skipped: 'Rejected', rated: 'Rated', unrated: 'Unrated', edited: 'Edited', unedited: 'Unedited',
     virtual: 'Virtual Copies' };
   const folder = S.folders.find((item) => item.path === S.activeFolder);
   const folderLabel = folder?.name || (S.rootFolder.split('/').filter(Boolean).pop() || 'All Photos');
@@ -4951,9 +4960,12 @@ function counts() {
   const scopeLabel = collection?.name || folderLabel;
   $('libraryTitle').textContent = $('filter').value === 'all'
     ? scopeLabel : `${labels[$('filter').value] || 'All Photos'} — ${scopeLabel}`;
+  const resultCount = shown === scope.length
+    ? `${scope.length} photo${scope.length === 1 ? '' : 's'}`
+    : `${shown} of ${scope.length} photos`;
   $('searchSummary').textContent = $('search').value.trim()
-    ? `Results for “${$('search').value.trim()}”`
-    : `${scope.length} photo${scope.length === 1 ? '' : 's'} · Local`;
+    ? `${resultCount} · Results for “${$('search').value.trim()}”`
+    : `${resultCount} · Local`;
   document.querySelectorAll('[data-source]').forEach((b) => {
     b.classList.toggle('on', !collection && b.dataset.source === $('filter').value);
   });
@@ -5154,10 +5166,15 @@ $('addSmartCollection').onclick = async () => {
   if (!name) return;
   const result = await runLibraryAction({
     action: 'create_smart_collection', name,
-    rules: { flag: $('filter').value === 'rated' ? 'all' : $('filter').value,
+    rules: { flag: ['pending', 'approved', 'skipped'].includes($('filter').value) ? $('filter').value : 'all',
       ratingMin: Math.max(+$('ratingFilter').value || 0,
         $('filter').value === 'rated' ? 1 : 0),
-      kind: $('kindFilter').value, query: $('search').value },
+      kind: $('kindFilter').value, query: $('search').value,
+      fileTypes: LIBRARY_FILTERS.types(),
+      editState: ['edited', 'unedited', 'virtual'].includes($('filter').value)
+        ? $('filter').value : $('editFilter').value,
+      unrated: $('ratingFilter').value === 'unrated' || $('filter').value === 'unrated',
+      label: $('labelFilter').value },
   });
   const created = result?.library?.collections?.find(
     (collection) => String(collection.id) === String(result.id));
@@ -5547,6 +5564,7 @@ function refreshFilteredView() {
 function setViewMode(mode, persist = true) {
   if (!['photo', 'square', 'detail'].includes(mode)) return;
   const gridMode = mode !== 'detail';
+  LIBRARY_FILTERS.close();
   S.viewMode = mode;
   if (gridMode) S.gridViewMode = mode;
   $('library').classList.toggle('show', gridMode);
@@ -7243,6 +7261,7 @@ document.querySelectorAll('[data-view]').forEach((button) => {
   button.onclick = () => setViewMode(button.dataset.view);
 });
 $('filter').onchange = refreshFilteredView;
+$('editFilter').onchange = () => { refreshFilteredView(); savePrefs(); };
 $('ratingFilter').onchange = () => { refreshFilteredView(); savePrefs(); };
 $('kindFilter').onchange = () => { refreshFilteredView(); savePrefs(); };
 $('sort').onchange = refreshFilteredView;
@@ -10061,7 +10080,8 @@ async function savePrefs() {
     gridViewMode: S.gridViewMode,
     activeCollection: S.activeCollection,
     ratingFilter: $('ratingFilter').value, kindFilter: $('kindFilter').value,
-    labelFilter: $('labelFilter').value,
+    labelFilter: $('labelFilter').value, editFilter: $('editFilter').value,
+    fileTypeFilters: LIBRARY_FILTERS.types(),
     exWhich: $('exWhich').value, exFormat: $('exFormat').value,
     exQuality: $('exQuality').value, exSize: $('exSize').value,
     exColorSpace: $('exColorSpace').value,
@@ -10119,6 +10139,8 @@ fetch('/api/prefs').then((r) => r.json()).then((p) => {
     if (el && v != null) el.value = v;
   }
   if (!$('kindFilter').value) $('kindFilter').value = 'all';
+  if (!$('editFilter').value) $('editFilter').value = 'all';
+  LIBRARY_FILTERS.setTypes(p.fileTypeFilters);
   if (p.gridSize) document.documentElement.style.setProperty('--cell', `${p.gridSize}px`);
   S.activeFolders = p.activeFolders && typeof p.activeFolders === 'object'
     ? p.activeFolders : {};
@@ -10665,6 +10687,7 @@ function uiStateReport() {
       status: $('filter')?.value || 'all',
       rating: $('ratingFilter')?.value || 'all',
       kind: $('kindFilter')?.value || 'all',
+      fileTypes: LIBRARY_FILTERS.types(), editState: $('editFilter')?.value || 'all',
       label: $('labelFilter')?.value || 'all',
       query: $('search')?.value || '',
     },

--- a/web/dropdown.js
+++ b/web/dropdown.js
@@ -103,6 +103,7 @@ function render(state) {
   menu.replaceChildren();
   state.items = [];
   const addOption = (option) => {
+    if (option.hidden) return;
     const el = document.createElement('div');
     el.className = 'dd-option';
     el.id = `${menu.id}-${option.index}`;

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -398,7 +398,7 @@
       "id": "search-filter-sort",
       "title": "Find photos with search, filters, and sorting",
       "category": "Library",
-      "summary": "Narrow the current folder or collection by text, flags, stars, colour, and file kind.",
+      "summary": "Narrow the current folder or collection by text, file type, flags, stars, color label, and edit status.",
       "keywords": [
         "find",
         "search",
@@ -407,7 +407,15 @@
         "sort",
         "capture date",
         "no results",
-        "unrated"
+        "unrated",
+        "file type",
+        "RAW",
+        "JPEG",
+        "HEIC",
+        "TIFF",
+        "PNG",
+        "unedited",
+        "clear filters"
       ],
       "sections": [
         {
@@ -419,14 +427,22 @@
             "Click Search photos and keywords, or press / when you are not typing in a field.",
             "Type a word or phrase from the filename or keywords.",
             "Use All Photos, Unflagged, Picked, Rejected, or Rated in the sidebar to choose a flag or rating group.",
-            "Expand Filter for workflow state, minimum rating, colour label, and file kind.",
+            "Click Filter beside Sort. Select one or more file types, then combine them with Flag, Rating, Color label, or Edit status.",
             "Choose File name, Rating, Flag, Capture date, or Colour label in Sort."
+          ]
+        },
+        {
+          "title": "Combine and clear filters",
+          "paragraphs": [
+            "Select RAW, JPEG, HEIC / HEIF, TIFF, or PNG. Multiple file types include any of those formats; flag, rating, color label, edit status, and search narrow that set further. No selected file types means all file types.",
+            "The Filter button shows how many choices are active. Each choice appears as a removable chip above the grid, and the count shows how many photos match. Remove a chip with its ×, or choose Clear all to reset the filters. Search text and the selected folder or collection stay in place.",
+            "Edit status offers Edited, Unedited, and Virtual copies. A virtual copy uses its original file’s type. Press Escape or click outside the panel to close it without clearing your choices."
           ]
         },
         {
           "title": "When a photo seems missing",
           "paragraphs": [
-            "Clear the search text and reset Filter choices, then check the selected folder, Include subfolders, and any active collection. Paired-file preferences and collapsed stacks can also hide a companion or stack member.",
+            "Clear the search text and choose Clear all above the grid, then check the selected folder, Include subfolders, and any active collection. Paired-file preferences and collapsed stacks can also hide a companion or stack member.",
             "Capture date sorts from earlier to later; Rating sorts higher ratings first."
           ]
         }
@@ -548,7 +564,7 @@
             "Select a photo, or a set in a grid, and open Info.",
             "Under Colour label, choose Red, Yellow, Green, Blue, or Purple. Choose No label to clear it.",
             "Use 6 for Red, 7 for Yellow, 8 for Green, and 9 for Blue. Purple is available from the colour controls.",
-            "Expand Filter in the library sidebar and use Colour label to find a particular colour, any colour, or unlabelled photos."
+            "Click Filter beside Sort and use Color label to find a particular colour, any colour, or unlabelled photos."
           ],
           "tips": [
             "Applying the same label again clears it. Colour-label actions do not auto-advance."
@@ -662,10 +678,10 @@
         {
           "title": "Save supported rules",
           "paragraphs": [
-            "A smart collection finds photos that match its saved rules. Supported rules are pick/reject/unflag status, minimum star rating, file kind, and search text."
+            "A smart collection finds photos that match its saved rules. Supported rules include flag, rating, Unrated only, file types, color label, edit status, virtual copies, and search text."
           ],
           "steps": [
-            "Set the search text, desired flag group, minimum rating, and file kind in the library.",
+            "Set the search text and desired choices in Filter beside Sort.",
             "Click the ✦ beside Collections, labelled Save filters as smart collection.",
             "Name the collection and save.",
             "Click its name to view matching photos. Changing a photo’s relevant metadata changes whether it matches."
@@ -674,8 +690,8 @@
         {
           "title": "Know what is saved",
           "paragraphs": [
-            "Colour-label filters, the selected folder, and Include subfolders are not saved in the smart collection rules. Edited and Unrated only are not supported smart-collection rules. Use supported flag and minimum-rating choices when creating one.",
-            "You cannot manually add photos with Add selected to collection while a smart collection is active. Current search and sidebar filters can still narrow the collection view."
+            "The selected folder and Include subfolders are not saved in the smart collection rules. The collection searches the library using the saved filter choices.",
+            "You cannot manually add photos with Add selected to collection while a smart collection is active. Current search and library filters can still narrow the collection view."
           ]
         }
       ],
@@ -709,7 +725,7 @@
             "Make the source photo active.",
             "Open the Photo actions ••• menu beside Sort and Size, then choose Create virtual copy.",
             "Name the copy and save. The new copy becomes active.",
-            "Edit the copy. Use Filter → Workflow state → Virtual copies to find copies later."
+            "Edit the copy. Use Filter → Edit status → Virtual copies to find copies later."
           ],
           "tips": [
             "Delete virtual copy in Photo actions removes the active virtual copy. For a real second file on disk, export a rendered image."

--- a/web/index.html
+++ b/web/index.html
@@ -132,32 +132,42 @@
         <div class="btnrow"><button id="cullApplyPicks" disabled>Pick selects</button><button id="cullApplyRejects" disabled>Reject rejects</button></div>
       </div>
     </details>
-
-    <section class="sidebar-controls">
-      <details class="sidebar-disclosure filter-disclosure">
-        <summary>Filter</summary>
-        <div class="sidebar-disclosure-body">
-          <label for="filter">Workflow state</label>
-          <select id="filter"><option value="all">Any state</option><option value="unrated">Unrated</option><option value="edited">Edited</option><option value="virtual">Virtual copies</option><option value="pending" hidden>Unflagged</option><option value="approved" hidden>Picked</option><option value="skipped" hidden>Rejected</option><option value="rated" hidden>Rated 1+</option></select>
-          <label for="ratingFilter">Minimum rating</label>
-          <select id="ratingFilter"><option value="0">Any rating</option><option value="unrated">Unrated only</option><option value="1">1 star+</option><option value="2">2 stars+</option><option value="3">3 stars+</option><option value="4">4 stars+</option><option value="5">5 stars</option></select>
-          <label for="labelFilter">Colour label</label>
-          <select id="labelFilter"><option value="all">Any label</option><option value="any">Any colour</option><option value="none">No label</option><option value="red">Red</option><option value="yellow">Yellow</option><option value="green">Green</option><option value="blue">Blue</option><option value="purple">Purple</option></select>
-          <label for="kindFilter">File kind</label>
-          <select id="kindFilter"><option value="all">RAW and processed</option><option value="raw">RAW originals</option><option value="processed">Processed files</option><option value="virtual">Virtual copies</option></select>
-        </div>
-      </details>
-    </section>
   </aside>
+
+  <div id="libraryFilterPanel" class="library-filter-panel" role="dialog" aria-labelledby="libraryFilterTitle" hidden>
+    <div class="library-filter-heading"><strong id="libraryFilterTitle">Filter photos</strong><button id="closeLibraryFilters" class="quiet icon-btn" type="button" aria-label="Close filters">×</button></div>
+    <fieldset class="file-type-filters"><legend>File type</legend>
+      <label><input type="checkbox" data-file-type="raw">RAW</label>
+      <label><input type="checkbox" data-file-type="jpeg">JPEG</label>
+      <label><input type="checkbox" data-file-type="heic">HEIC / HEIF</label>
+      <label><input type="checkbox" data-file-type="tiff">TIFF</label>
+      <label><input type="checkbox" data-file-type="png">PNG</label>
+    </fieldset>
+    <label class="field-label" for="filter">Flag</label>
+    <select id="filter"><option value="all">Any flag</option><option value="pending">Unflagged</option><option value="approved">Picked</option><option value="skipped">Rejected</option><option value="rated" hidden>Rated 1+</option><option value="unrated" hidden>Unrated</option><option value="edited" hidden>Edited</option><option value="unedited" hidden>Unedited</option><option value="virtual" hidden>Virtual copies</option></select>
+    <label class="field-label" for="ratingFilter">Rating</label>
+    <select id="ratingFilter"><option value="0">Any rating</option><option value="unrated">Unrated only</option><option value="1">1 star+</option><option value="2">2 stars+</option><option value="3">3 stars+</option><option value="4">4 stars+</option><option value="5">5 stars</option></select>
+    <label class="field-label" for="labelFilter">Color label</label>
+    <select id="labelFilter"><option value="all">Any label</option><option value="any">Any color</option><option value="none">No label</option><option value="red">Red</option><option value="yellow">Yellow</option><option value="green">Green</option><option value="blue">Blue</option><option value="purple">Purple</option></select>
+    <label class="field-label" for="editFilter">Edit status</label>
+    <select id="editFilter"><option value="all">Any edit status</option><option value="edited">Edited</option><option value="unedited">Unedited</option><option value="virtual">Virtual copies</option></select>
+    <div class="no-dd" hidden><select id="kindFilter" aria-label="Legacy file kind"><option value="all">All photos</option><option value="raw">RAW originals</option><option value="processed">Processed files</option><option value="virtual">Virtual copies</option></select></div>
+    <div class="library-filter-footer"><button id="clearLibraryFilters" class="quiet" type="button">Clear all filters</button></div>
+  </div>
 
   <main class="workspace">
     <div class="library" id="library">
       <div class="library-head">
         <div><strong id="libraryTitle">All Photos</strong><span id="searchSummary">Local folder</span></div>
         <div class="library-tools">
+          <button id="libraryFilterBtn" class="library-filter-btn" type="button" aria-haspopup="dialog" aria-controls="libraryFilterPanel" aria-expanded="false"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2 3h12M4 8h8M6 13h4"/></svg><span id="libraryFilterLabel">Filter</span></button>
           <label><span>Sort</span><select id="sort"><option value="name">File name</option><option value="rating">Rating</option><option value="status">Flag</option><option value="date">Capture date</option><option value="label">Colour label</option></select></label>
           <label class="thumbnail-size-control"><span>Size</span><input type="range" id="gridSize" min="120" max="280" step="10" value="180"></label>
           <button class="quiet icon-btn" id="libraryMenuBtn" aria-controls="libraryMenu" title="Photo actions" aria-label="Photo actions" aria-expanded="false">•••</button>
+        </div>
+        <div id="activeLibraryFilters" class="active-library-filters" hidden>
+          <div id="libraryFilterChips" class="library-filter-chips" role="group" aria-label="Active filters"></div>
+          <button id="clearActiveLibraryFilters" class="quiet" type="button">Clear all</button>
         </div>
       </div>
       <div class="grid" id="grid"></div>

--- a/web/library-filters.js
+++ b/web/library-filters.js
@@ -1,0 +1,140 @@
+export const FILE_TYPES = { raw: 'RAW', jpeg: 'JPEG', heic: 'HEIC / HEIF', tiff: 'TIFF', png: 'PNG' };
+
+export function normalizeFileTypes(value) {
+  return Array.isArray(value) ? Object.keys(FILE_TYPES).filter(type => value.includes(type)) : [];
+}
+
+export function photoFileType(image) {
+  if (image.raw) return 'raw';
+  const ext = String(image.sourceName || image.source || image.name || '').split('.').pop().toLowerCase();
+  if (['jpg', 'jpeg', 'jpe'].includes(ext)) return 'jpeg';
+  if (['heic', 'heif', 'hif'].includes(ext)) return 'heic';
+  if (['tif', 'tiff'].includes(ext)) return 'tiff';
+  return ext === 'png' ? 'png' : 'other';
+}
+
+export function photoHasEdits(image) {
+  return !!(image.hasEdits || (image.params && Object.keys(image.params).length)
+    || (image.grade && Object.keys(image.grade).length) || image.crop);
+}
+
+export function matchesLibraryFilters(image, types, editState) {
+  if (types.length && !types.includes(photoFileType(image))) return false;
+  if (editState === 'edited') return photoHasEdits(image);
+  if (editState === 'unedited') return !photoHasEdits(image);
+  if (editState === 'virtual') return !!image.virtual;
+  return true;
+}
+
+// Keep old saved settings and automation's kind/status values readable. Every
+// active restriction, including a legacy one, gets a removable chip.
+export function filterChips(values, types) {
+  const chips = types.map(type => ({ id: `type:${type}`, label: FILE_TYPES[type] }));
+  const flags = { pending: 'Unflagged', approved: 'Picked', skipped: 'Rejected',
+    rated: '1★ and up', unrated: 'Unrated', edited: 'Edited', unedited: 'Unedited', virtual: 'Virtual copies' };
+  if (flags[values.filter]) chips.push({ id: 'filter', label: flags[values.filter] });
+  if (values.ratingFilter === 'unrated') chips.push({ id: 'ratingFilter', label: 'Unrated' });
+  else if (+values.ratingFilter > 0) chips.push({ id: 'ratingFilter', label: `${values.ratingFilter}★${+values.ratingFilter < 5 ? ' and up' : ''}` });
+  if (values.labelFilter && values.labelFilter !== 'all') {
+    const label = values.labelFilter;
+    chips.push({ id: 'labelFilter', label: label === 'any' ? 'Any color label'
+      : label === 'none' ? 'No color label' : `${label[0].toUpperCase()}${label.slice(1)} label` });
+  }
+  const edits = { edited: 'Edited', unedited: 'Unedited', virtual: 'Virtual copies' };
+  if (edits[values.editFilter]) chips.push({ id: 'editFilter', label: edits[values.editFilter] });
+  const kinds = { raw: 'RAW originals', processed: 'Processed files', virtual: 'Virtual copies' };
+  if (kinds[values.kindFilter]) chips.push({ id: 'kindFilter', label: kinds[values.kindFilter] });
+  return chips;
+}
+
+export function installLibraryFilters({ el, onChange, closeDropdown }) {
+  const trigger = el('libraryFilterBtn'), panel = el('libraryFilterPanel');
+  const row = el('activeLibraryFilters'), chipsHost = el('libraryFilterChips');
+  const defaults = { filter: 'all', ratingFilter: '0', labelFilter: 'all', editFilter: 'all', kindFilter: 'all' };
+  let types = [], paintKey = '';
+  const values = () => Object.fromEntries(Object.keys(defaults).map(id => [id, el(id).value]));
+
+  function setTypes(next) {
+    types = normalizeFileTypes(next);
+    panel.querySelectorAll('[data-file-type]').forEach(input => { input.checked = types.includes(input.dataset.fileType); });
+  }
+  function sync() {
+    const chips = filterChips(values(), types), key = JSON.stringify(chips);
+    if (paintKey === key) return;
+    paintKey = key;
+    el('libraryFilterLabel').textContent = chips.length ? `Filter · ${chips.length}` : 'Filter';
+    trigger.classList.toggle('on', chips.length > 0);
+    row.hidden = !chips.length;
+    el('clearLibraryFilters').disabled = !chips.length;
+    chipsHost.replaceChildren(...chips.map(chip => {
+      const button = document.createElement('button');
+      button.type = 'button'; button.className = 'filter-chip';
+      button.dataset.filterChip = chip.id;
+      button.setAttribute('aria-label', `Remove ${chip.label} filter`);
+      button.textContent = `${chip.label} ×`;
+      button.onclick = () => {
+        const index = [...chipsHost.children].indexOf(button);
+        if (chip.id.startsWith('type:')) setTypes(types.filter(type => type !== chip.id.slice(5)));
+        else el(chip.id).value = defaults[chip.id];
+        sync(); onChange();
+        (chipsHost.children[Math.min(index, chipsHost.children.length - 1)] || trigger).focus();
+      };
+      return button;
+    }));
+  }
+  function clear() {
+    setTypes([]);
+    for (const [id, value] of Object.entries(defaults)) el(id).value = value;
+    sync(); onChange();
+  }
+  function close(restoreFocus = false) {
+    if (panel.hidden) return;
+    closeDropdown();
+    panel.hidden = true;
+    trigger.setAttribute('aria-expanded', 'false');
+    if (restoreFocus) trigger.focus();
+  }
+  function place() {
+    if (panel.hidden) return;
+    const rect = trigger.getBoundingClientRect();
+    panel.style.left = `${Math.max(8, Math.min(rect.left, innerWidth - panel.offsetWidth - 8))}px`;
+    const top = Math.max(8, Math.min(rect.bottom + 6, innerHeight - panel.offsetHeight - 8));
+    panel.style.top = `${top}px`;
+  }
+  trigger.onclick = () => {
+    if (!panel.hidden) return close(true);
+    closeDropdown(); sync(); panel.hidden = false;
+    trigger.setAttribute('aria-expanded', 'true'); place();
+    panel.querySelector('input').focus();
+  };
+  panel.addEventListener('change', event => {
+    if (!event.target.matches('[data-file-type]')) return;
+    setTypes([...panel.querySelectorAll('[data-file-type]:checked')].map(input => input.dataset.fileType));
+    sync(); onChange();
+  });
+  el('clearLibraryFilters').onclick = () => { clear(); panel.querySelector('input').focus(); };
+  el('clearActiveLibraryFilters').onclick = () => { clear(); trigger.focus(); };
+  el('closeLibraryFilters').onclick = () => close(true);
+  panel.addEventListener('keydown', event => {
+    if (event.key === 'Escape') { event.preventDefault(); close(true); }
+    event.stopPropagation();
+  });
+  // Buttons must not pass typing/Space through to the photo-marking shortcuts.
+  for (const host of [trigger, row]) host.addEventListener('keydown', event => event.stopPropagation());
+  function inDropdown(target) {
+    const dropdown = panel.querySelector('.dd-trigger[aria-expanded="true"]');
+    return dropdown && el(dropdown.getAttribute('aria-controls'))?.contains(target);
+  }
+  document.addEventListener('pointerdown', event => {
+    if (panel.hidden || panel.contains(event.target) || trigger.contains(event.target)) return;
+    // Custom selects place their listbox on body, outside this panel.
+    if (inDropdown(event.target)) return;
+    close();
+  }, true);
+  document.addEventListener('focusin', event => {
+    if (!panel.contains(event.target) && event.target !== trigger && !inDropdown(event.target)) close();
+  });
+  window.addEventListener('resize', place);
+  el('library').addEventListener('scroll', place);
+  return { types: () => types, setTypes, sync, close, clear };
+}

--- a/web/library.js
+++ b/web/library.js
@@ -1,3 +1,4 @@
+import { matchesLibraryFilters, normalizeFileTypes } from '/web/library-filters.js';
 import { aiSearchTerms } from '/web/local-ai.js';
 
 export function photoMatchesQuery(image, query, exif = null) {
@@ -11,7 +12,14 @@ export function photoMatchesQuery(image, query, exif = null) {
 
 export function photoMatchesRules(image, rules = {}, exif = null) {
   if ((+image.rating || 0) < (+rules.ratingMin || 0)) return false;
-  if (rules.flag && rules.flag !== 'all' && image.status !== rules.flag) return false;
+  const flag = rules.status || rules.flag;
+  if (flag && flag !== 'all' && (image.status || 'pending') !== flag) return false;
+  if (rules.unrated && (+image.rating || 0) !== 0) return false;
+  if (rules.label && rules.label !== 'all') {
+    const label = image.label || 'none';
+    if (rules.label === 'any' ? label === 'none' : label !== rules.label) return false;
+  }
+  if (!matchesLibraryFilters(image, normalizeFileTypes(rules.fileTypes), rules.editState)) return false;
   if (rules.kind === 'raw' && !image.raw) return false;
   if (rules.kind === 'processed' && (image.raw || image.virtual)) return false;
   if (rules.kind === 'virtual' && !image.virtual) return false;

--- a/web/style.css
+++ b/web/style.css
@@ -534,6 +534,22 @@ input[type=checkbox]:disabled { opacity:.4; }
 .library-tools select { width:116px; }
 .library-tools .thumbnail-size-control { width:126px; }
 .library-tools #gridSize { min-width:70px; }
+.library-filter-btn { display:flex; align-items:center; gap:6px; white-space:nowrap; }
+.library-filter-btn svg { width:14px; height:14px; fill:none; stroke:currentColor; stroke-width:1.5; stroke-linecap:round; }
+.library-head .library-filter-btn span { margin:0; color:inherit; font-size:12px; }
+.library-filter-btn.on { color:var(--accent); border-color:var(--accent); }
+.library-filter-panel { position:fixed; z-index:110; width:280px; max-width:calc(100vw - 16px); max-height:calc(100vh - 16px); overflow:auto; padding:12px 16px; background:var(--panel); border:1px solid var(--line-strong); border-radius:var(--radius); box-shadow:0 12px 35px #0008; }
+.library-filter-heading { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:12px; }
+.library-filter-heading strong { font-size:13px; font-weight:600; }
+.file-type-filters { display:grid; grid-template-columns:1fr 1fr; gap:8px 12px; margin:0; padding:0 0 12px; border:0; border-bottom:1px solid var(--line-soft); }
+.file-type-filters legend { padding:0 0 8px; font-size:11px; color:var(--muted); }
+.file-type-filters label { display:flex; align-items:center; gap:7px; font-size:12px; cursor:pointer; }
+.file-type-filters input { margin:0; }
+.library-filter-footer { margin-top:14px; padding-top:8px; border-top:1px solid var(--line-soft); }
+.active-library-filters { flex:0 0 100%; display:flex; align-items:center; flex-wrap:wrap; gap:6px 10px; }
+.library-filter-chips { display:flex; flex-wrap:wrap; gap:6px; }
+.filter-chip { min-height:24px; padding:3px 8px; border-radius:var(--radius-s); color:var(--ink-2); font-size:11px; }
+.active-library-filters > button { font-size:11px; }
 .grid { position:relative; flex:0 0 auto; margin-top:16px; overflow-anchor:none; }
 .grid > .cell { position:absolute; content-visibility:visible; contain:layout paint; }
 .cell { position:relative; min-width:0; cursor:default; border-radius:var(--radius-s); background:#1f1f1f; }


### PR DESCRIPTION
Filter now sits immediately before Sort and opens a compact panel for multi-select RAW, JPEG, HEIC/HEIF, TIFF, and PNG filters, alongside flag, rating, color label, and edit status. Active choices appear as removable chips with a count and Clear all; preferences persist across launches.

Saved smart collections retain the new criteria. The change also keeps dropdown choices inside the filter panel usable, hides legacy-only options, and updates the in-app help.

Validation: the 1,083-test suite completed with only a stale help reference and a sandbox-blocked native shared-memory test; after updating help, all 10 help tests and all 3 native shared-surface tests passed. The new browser-filter and catalog-persistence regressions pass. Real-browser checks covered mixed file types, combined flags/ratings/labels, Edited/Unedited, empty results, clear/remove, Escape, persistence, and saved smart collections; no console errors in the final review session.
