### PR TITLE
Describe the crop view without naming another editor

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -5886,7 +5886,7 @@ function setCropMode(on) {
   syncCompareControl();
 }
 
-/* ------------------------------------------------ crop view (Lightroom feel) */
+/* ---------------------------------------------- crop view (centred frame) */
 // While cropping, the crop frame stays centred in the workspace and the photo
 // zooms and pans underneath it. The on-screen frame is the geometric mean of
 // the crop's fitted size and the workspace (zoom bias 0.5), so a dragged handle

--- a/web/style.css
+++ b/web/style.css
@@ -719,7 +719,7 @@ input[type=checkbox]:disabled { opacity:.4; }
 #cropLayer[data-active-crop-handle="ne"],
 #cropLayer[data-active-crop-handle="sw"] { cursor:nesw-resize; }
 #cropLayer[data-active-crop-handle] * { cursor:inherit !important; }
-/* Lightroom-style cropping: the frame is the whole photo, sized by the
+/* Centred-frame cropping: the frame is the whole photo, sized by the
    cropping zoom and panned under a centred crop, and the workspace clips it. */
 .cmp.is-cropping { flex:0 0 auto; overflow:visible; max-width:none; max-height:none; }
 #cropLayer.exiting { pointer-events:none; }


### PR DESCRIPTION
The centred-frame crop view merged in #9 carried two section comments that named a third-party editor. Repository rules keep product names out of source and history except for preset import compatibility, so the comments now describe the behaviour instead. No functional change; the crop and photo-tool test modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
