### PR TITLE
Keep RAW preview progress steady through refinement

### DIFF
--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -4,72 +4,19 @@
     "title": "Choose and preview a film stock",
     "category": "Film",
     "summary": "Turn on the physical film workflow and compare stocks using your own photo.",
-    "keywords": [
-      "film",
-      "stock",
-      "simulation",
-      "negative",
-      "slide",
-      "browse",
-      "preview",
-      "preset",
-      "film off"
-    ],
+    "keywords": ["film", "stock", "simulation", "negative", "slide", "browse", "preview", "preset", "film off"],
     "sections": [
-      {
-        "title": "Start with a stock",
-        "paragraphs": [
-          "Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."
-        ],
-        "steps": [
-          "Open a still photo and select Film in the tool rail.",
-          "Turn the Film profile switch on.",
-          "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.",
-          "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."
-        ]
-      },
-      {
-        "title": "What the previews include",
-        "paragraphs": [
-          "Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.",
-          "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.",
-          "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The steady status badge explains the work still in progress. Wait for it to finish before judging fine detail."
-        ],
-        "tips": [
-          "If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."
-        ]
-      }
+      {"title": "Start with a stock", "paragraphs": ["Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."], "steps": ["Open a still photo and select Film in the tool rail.", "Turn the Film profile switch on.", "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.", "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."]},
+      {"title": "What the previews include", "paragraphs": ["Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.", "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.", "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The steady status badge explains the work still in progress. Wait for it to finish before judging fine detail."], "tips": ["If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."]}
     ],
-    "related": [
-      "film-exposure-and-processing",
-      "film-negative-paper-and-slides",
-      "film-grain-and-format"
-    ],
+    "related": ["film-exposure-and-processing", "film-negative-paper-and-slides", "film-grain-and-format"],
     "sources": [
-      {
-        "path": "web/film-browser.js",
-        "anchor": "Previews use this photo’s edits. Choose a stock to apply it."
-      },
-      {
-        "path": "web/film-browser.js",
-        "anchor": "button.onclick = () => { close(); apply(stock.id, snapshot.name); };"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Film processing is bypassed. Edit adjustments remain active."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "option.disabled = profile.rustOnly && !S.rustAvailable;"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Include Film profile and physical settings"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "previewProgress.start('Refining RAW detail…');"
-      }
+      {"path": "web/film-browser.js", "anchor": "Previews use this photo’s edits. Choose a stock to apply it."},
+      {"path": "web/film-browser.js", "anchor": "button.onclick = () => { close(); apply(stock.id, snapshot.name); };"},
+      {"path": "web/index.html", "anchor": "Film processing is bypassed. Edit adjustments remain active."},
+      {"path": "web/app.js", "anchor": "option.disabled = profile.rustOnly && !S.rustAvailable;"},
+      {"path": "web/index.html", "anchor": "Include Film profile and physical settings"},
+      {"path": "web/app.js", "anchor": "previewProgress.start('Refining RAW detail…');"}
     ]
   },
   {
@@ -77,70 +24,19 @@
     "title": "Set film exposure and development",
     "category": "Film",
     "summary": "Understand Camera EV, capture white balance, metering, and development controls.",
-    "keywords": [
-      "exposure",
-      "camera ev",
-      "meter",
-      "white balance",
-      "temperature",
-      "tint",
-      "development",
-      "contrast",
-      "authentic",
-      "creative"
-    ],
+    "keywords": ["exposure", "camera ev", "meter", "white balance", "temperature", "tint", "development", "contrast", "authentic", "creative"],
     "sections": [
-      {
-        "title": "Capture controls and finishing controls",
-        "paragraphs": [
-          "Camera EV and Capture white balance act before film exposure. Exposure and Temp/Tint in the Edit panel are finishing adjustments later in the workflow.",
-          "Capture white balance requires a RAW original. For a JPEG, HEIF, TIFF, or another processed file, use Edit Temp/Tint."
-        ],
-        "steps": [
-          "Turn on Film, choose a stock, and adjust Camera EV.",
-          "Keep Meter scene automatically enabled for automatic scene metering, or turn it off to set the capture exposure yourself.",
-          "Expand Capture & processing to choose As shot, Daylight, Tungsten, or Custom capture white balance for a RAW photo.",
-          "For Custom, adjust Temperature and Capture tint."
-        ]
-      },
-      {
-        "title": "Development and linked defaults",
-        "paragraphs": [
-          "Development appears only when the chosen film profile supplies development times. Print development depends on the selected paper and is hidden for slide film. Development contrast is a separate film control.",
-          "Authentic uses linked physical defaults, including the stock’s recommended paper when paper is unlocked. Creative preserves paper overrides when compatible. Changing stocks can still select that stock’s default development time and exposure; compare the result after changing a stock."
-        ]
-      }
+      {"title": "Capture controls and finishing controls", "paragraphs": ["Camera EV and Capture white balance act before film exposure. Exposure and Temp/Tint in the Edit panel are finishing adjustments later in the workflow.", "Capture white balance requires a RAW original. For a JPEG, HEIF, TIFF, or another processed file, use Edit Temp/Tint."], "steps": ["Turn on Film, choose a stock, and adjust Camera EV.", "Keep Meter scene automatically enabled for automatic scene metering, or turn it off to set the capture exposure yourself.", "Expand Capture & processing to choose As shot, Daylight, Tungsten, or Custom capture white balance for a RAW photo.", "For Custom, adjust Temperature and Capture tint."]},
+      {"title": "Development and linked defaults", "paragraphs": ["Development appears only when the chosen film profile supplies development times. Print development depends on the selected paper and is hidden for slide film. Development contrast is a separate film control.", "Authentic uses linked physical defaults, including the stock’s recommended paper when paper is unlocked. Creative preserves paper overrides when compatible. Changing stocks can still select that stock’s default development time and exposure; compare the result after changing a stock."]}
     ],
-    "related": [
-      "film-getting-started",
-      "film-negative-paper-and-slides",
-      "film-reference-match"
-    ],
+    "related": ["film-getting-started", "film-negative-paper-and-slides", "film-reference-match"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "Camera EV and capture white balance act before film exposure. Edit-panel Exposure and Temp/Tint are creative finishing controls."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Capture white balance requires a RAW original. Use Edit Temp/Tint for a processed file."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "field.hidden = times.length === 0;"
-      },
-      {
-        "path": "web/film-browser.js",
-        "anchor": "next.development_time = film?.defaultDevelopmentTime || 0;"
-      },
-      {
-        "path": "web/film-browser.js",
-        "anchor": "if (Number.isFinite(film?.defaultExposureEv)) next.exposure_ev = film.defaultExposureEv;"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Meter scene automatically"
-      }
+      {"path": "web/index.html", "anchor": "Camera EV and capture white balance act before film exposure. Edit-panel Exposure and Temp/Tint are creative finishing controls."},
+      {"path": "web/index.html", "anchor": "Capture white balance requires a RAW original. Use Edit Temp/Tint for a processed file."},
+      {"path": "web/app.js", "anchor": "field.hidden = times.length === 0;"},
+      {"path": "web/film-browser.js", "anchor": "next.development_time = film?.defaultDevelopmentTime || 0;"},
+      {"path": "web/film-browser.js", "anchor": "if (Number.isFinite(film?.defaultExposureEv)) next.exposure_ev = film.defaultExposureEv;"},
+      {"path": "web/index.html", "anchor": "Meter scene automatically"}
     ]
   },
   {
@@ -148,70 +44,19 @@
     "title": "Work with negative film, paper, and slides",
     "category": "Film",
     "summary": "Choose a print process for negatives and understand why print controls disappear for slide film.",
-    "keywords": [
-      "negative",
-      "positive",
-      "reversal",
-      "slide",
-      "transparency",
-      "paper",
-      "print",
-      "output",
-      "lock paper",
-      "filtration",
-      "preflash"
-    ],
+    "keywords": ["negative", "positive", "reversal", "slide", "transparency", "paper", "print", "output", "lock paper", "filtration", "preflash"],
     "sections": [
-      {
-        "title": "Negative film and paper",
-        "paragraphs": [
-          "Negative stocks use a film-to-print process. Paper choices are restricted to profiles compatible with the selected film’s color or monochrome channel model.",
-          "Use Print exposure to adjust the print stage. In Capture & processing, choose Paper and enable Lock paper when stock changes if you want to keep a compatible paper while trying other stocks. An incompatible paper still has to be replaced."
-        ],
-        "steps": [
-          "Choose a negative stock in Film.",
-          "Choose an Output recipe: Clean scan, Neutral print scan, or Soft optical print.",
-          "Expand Capture & processing to choose Paper and any available Print development time.",
-          "Expand Physical film stages for Print glare, Print preflash, Yellow filter, and Magenta filter."
-        ]
-      },
-      {
-        "title": "Slide film is scanned directly",
-        "paragraphs": [
-          "Positive or reversal stocks use a direct transparency scan with no negative-to-paper stage. Paper, print exposure, print development, and other print-only controls are hidden for these stocks.",
-          "Output recipes are modeled starting points for scan softness, sharpening, and print effects where applicable. They are not measured emulations of particular commercial scanners."
-        ]
-      }
+      {"title": "Negative film and paper", "paragraphs": ["Negative stocks use a film-to-print process. Paper choices are restricted to profiles compatible with the selected film’s color or monochrome channel model.", "Use Print exposure to adjust the print stage. In Capture & processing, choose Paper and enable Lock paper when stock changes if you want to keep a compatible paper while trying other stocks. An incompatible paper still has to be replaced."], "steps": ["Choose a negative stock in Film.", "Choose an Output recipe: Clean scan, Neutral print scan, or Soft optical print.", "Expand Capture & processing to choose Paper and any available Print development time.", "Expand Physical film stages for Print glare, Print preflash, Yellow filter, and Magenta filter."]},
+      {"title": "Slide film is scanned directly", "paragraphs": ["Positive or reversal stocks use a direct transparency scan with no negative-to-paper stage. Paper, print exposure, print development, and other print-only controls are hidden for these stocks.", "Output recipes are modeled starting points for scan softness, sharpening, and print effects where applicable. They are not measured emulations of particular commercial scanners."]}
     ],
-    "related": [
-      "film-exposure-and-processing",
-      "film-halation-diffusion-scan"
-    ],
+    "related": ["film-exposure-and-processing", "film-halation-diffusion-scan"],
     "sources": [
-      {
-        "path": "film_pipeline.py",
-        "anchor": "# Reversal film has no negative-to-paper stage and is scanned directly."
-      },
-      {
-        "path": "film_pipeline.py",
-        "anchor": "Return print-stage profiles with the film's channel model."
-      },
-      {
-        "path": "web/film-browser.js",
-        "anchor": "if (next.workflow_mode === 'authentic' && !next.paper_locked && film?.targetPrint) next.paper = film.targetPrint;"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('paperField').hidden = positive;"
-      },
-      {
-        "path": "film_pipeline.py",
-        "anchor": "# Coherent output-chain starting points. These are modeled recipes, not claims"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Lock paper when stock changes"
-      }
+      {"path": "film_pipeline.py", "anchor": "# Reversal film has no negative-to-paper stage and is scanned directly."},
+      {"path": "film_pipeline.py", "anchor": "Return print-stage profiles with the film's channel model."},
+      {"path": "web/film-browser.js", "anchor": "if (next.workflow_mode === 'authentic' && !next.paper_locked && film?.targetPrint) next.paper = film.targetPrint;"},
+      {"path": "web/app.js", "anchor": "$('paperField').hidden = positive;"},
+      {"path": "film_pipeline.py", "anchor": "# Coherent output-chain starting points. These are modeled recipes, not claims"},
+      {"path": "web/index.html", "anchor": "Lock paper when stock changes"}
     ]
   },
   {
@@ -219,66 +64,18 @@
     "title": "Adjust film grain and format",
     "category": "Film",
     "summary": "Control grain relative to the stock and choose the simulated film size.",
-    "keywords": [
-      "grain",
-      "size",
-      "texture",
-      "35mm",
-      "medium format",
-      "645",
-      "6x6",
-      "6x7",
-      "4x5",
-      "particle",
-      "noise"
-    ],
+    "keywords": ["grain", "size", "texture", "35mm", "medium format", "645", "6x6", "6x7", "4x5", "particle", "noise"],
     "sections": [
-      {
-        "title": "Set the format and grain",
-        "paragraphs": [
-          "Film format sets the physical long edge used by the simulation. The choices are 35 mm, 645, 6 × 6, 6 × 7, and 4 × 5; this setting is separate from cropping the photo.",
-          "Grain size multiplies the chosen stock’s baseline particle area. The readout shows the resulting area in µm², so the same multiplier can show a different area after you change stocks."
-        ],
-        "steps": [
-          "In Film profile, choose Film format.",
-          "Expand Physical film stages.",
-          "Enable Grain size and adjust its slider, or clear its checkbox to disable grain.",
-          "Inspect the image at 1:1 and wait for preview detail to finish before judging texture."
-        ]
-      },
-      {
-        "title": "What the number represents",
-        "paragraphs": [
-          "The per-stock grain baselines are derived from film speed as visual starting points. They are not laboratory granularity measurements for each emulsion.",
-          "The Grain size setting belongs to the film simulation. Detail sharpening and noise reduction in Edit are separate adjustments."
-        ]
-      }
+      {"title": "Set the format and grain", "paragraphs": ["Film format sets the physical long edge used by the simulation. The choices are 35 mm, 645, 6 × 6, 6 × 7, and 4 × 5; this setting is separate from cropping the photo.", "Grain size multiplies the chosen stock’s baseline particle area. The readout shows the resulting area in µm², so the same multiplier can show a different area after you change stocks."], "steps": ["In Film profile, choose Film format.", "Expand Physical film stages.", "Enable Grain size and adjust its slider, or clear its checkbox to disable grain.", "Inspect the image at 1:1 and wait for preview detail to finish before judging texture."]},
+      {"title": "What the number represents", "paragraphs": ["The per-stock grain baselines are derived from film speed as visual starting points. They are not laboratory granularity measurements for each emulsion.", "The Grain size setting belongs to the film simulation. Detail sharpening and noise reduction in Edit are separate adjustments."]}
     ],
-    "related": [
-      "film-getting-started",
-      "performance-previews"
-    ],
+    "related": ["film-getting-started", "performance-previews"],
     "sources": [
-      {
-        "path": "film_pipeline.py",
-        "anchor": "# The simulation uses the physical long edge to derive micrometres per pixel."
-      },
-      {
-        "path": "film_pipeline.py",
-        "anchor": "# field, so these are explicit speed-derived baselines rather than claims of"
-      },
-      {
-        "path": "film_pipeline.py",
-        "anchor": "Resolve the stock baseline multiplied by the user's grain amount."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Judge sharpening and noise reduction at 1:1."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "id=\"grain_on\" checked"
-      }
+      {"path": "film_pipeline.py", "anchor": "# The simulation uses the physical long edge to derive micrometres per pixel."},
+      {"path": "film_pipeline.py", "anchor": "# field, so these are explicit speed-derived baselines rather than claims of"},
+      {"path": "film_pipeline.py", "anchor": "Resolve the stock baseline multiplied by the user's grain amount."},
+      {"path": "web/index.html", "anchor": "Judge sharpening and noise reduction at 1:1."},
+      {"path": "web/index.html", "anchor": "id=\"grain_on\" checked"}
     ]
   },
   {
@@ -286,66 +83,18 @@
     "title": "Adjust halation, diffusion, and scan character",
     "category": "Film",
     "summary": "Refine the film’s physical effects and the selected output recipe.",
-    "keywords": [
-      "halation",
-      "glow",
-      "bloom",
-      "diffusion",
-      "couplers",
-      "glare",
-      "scan",
-      "sharpness",
-      "softness",
-      "scanner",
-      "preflash"
-    ],
+    "keywords": ["halation", "glow", "bloom", "diffusion", "couplers", "glare", "scan", "sharpness", "softness", "scanner", "preflash"],
     "sections": [
-      {
-        "title": "Physical film stages",
-        "paragraphs": [
-          "Open Film → Physical film stages while Film is enabled. Couplers, Halation, Grain size, and Print glare each have an enable checkbox and an amount control. Turning off a stage disables its amount slider.",
-          "Capture diffusion changes the modeled camera stage. Print glare and Print preflash belong to the print stage and are unavailable for direct slide scans."
-        ],
-        "steps": [
-          "Choose the stock and Output recipe before refining the stage controls.",
-          "Change one stage at a time and compare the result.",
-          "Use each stage’s checkbox to compare its contribution without replacing the selected stock."
-        ]
-      },
-      {
-        "title": "Scan controls",
-        "paragraphs": [
-          "Scan softness adds lens blur to the selected output recipe. Scan sharpness scales that recipe’s sharpening; Scan sharpening enables or disables it.",
-          "These are adjustments to modeled output recipes, not selections of measured scanner brands. Evaluate fine texture and sharpness with completed 1:1 preview detail."
-        ]
-      }
+      {"title": "Physical film stages", "paragraphs": ["Open Film → Physical film stages while Film is enabled. Couplers, Halation, Grain size, and Print glare each have an enable checkbox and an amount control. Turning off a stage disables its amount slider.", "Capture diffusion changes the modeled camera stage. Print glare and Print preflash belong to the print stage and are unavailable for direct slide scans."], "steps": ["Choose the stock and Output recipe before refining the stage controls.", "Change one stage at a time and compare the result.", "Use each stage’s checkbox to compare its contribution without replacing the selected stock."]},
+      {"title": "Scan controls", "paragraphs": ["Scan softness adds lens blur to the selected output recipe. Scan sharpness scales that recipe’s sharpening; Scan sharpening enables or disables it.", "These are adjustments to modeled output recipes, not selections of measured scanner brands. Evaluate fine texture and sharpness with completed 1:1 preview detail."]}
     ],
-    "related": [
-      "film-negative-paper-and-slides",
-      "film-grain-and-format",
-      "performance-previews"
-    ],
+    "related": ["film-negative-paper-and-slides", "film-grain-and-format", "performance-previews"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "These controls modify the selected output recipe. Scanner brand names are intentionally omitted until measured reference scans exist."
-      },
-      {
-        "path": "film_pipeline.py",
-        "anchor": "\"lens_blur\": recipe[\"scanner_lens_blur\"] + p[\"scan_softness\"],"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('halation_amount').disabled = !profileEnabled || !S.params.halation_on;"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('scan_sharpness').disabled = !profileEnabled || !S.params.scan_sharpen;"
-      },
-      {
-        "path": "film_pipeline.py",
-        "anchor": "\"active\": p[\"camera_diffusion_strength\"] > 0,"
-      }
+      {"path": "web/index.html", "anchor": "These controls modify the selected output recipe. Scanner brand names are intentionally omitted until measured reference scans exist."},
+      {"path": "film_pipeline.py", "anchor": "\"lens_blur\": recipe[\"scanner_lens_blur\"] + p[\"scan_softness\"],"},
+      {"path": "web/app.js", "anchor": "$('halation_amount').disabled = !profileEnabled || !S.params.halation_on;"},
+      {"path": "web/app.js", "anchor": "$('scan_sharpness').disabled = !profileEnabled || !S.params.scan_sharpen;"},
+      {"path": "film_pipeline.py", "anchor": "\"active\": p[\"camera_diffusion_strength\"] > 0,"}
     ]
   },
   {
@@ -353,66 +102,18 @@
     "title": "Compare with a reference image",
     "category": "Film",
     "summary": "Align a scan or other reference, measure the difference, and apply a starting match.",
-    "keywords": [
-      "reference",
-      "match",
-      "scan",
-      "calibration",
-      "overlay",
-      "split",
-      "opacity",
-      "measure",
-      "color match"
-    ],
+    "keywords": ["reference", "match", "scan", "calibration", "overlay", "split", "opacity", "measure", "color match"],
     "sections": [
-      {
-        "title": "Load and align",
-        "paragraphs": [
-          "Reference Match is in the Film panel. Use a reference with corresponding image content so alignment and comparison are meaningful."
-        ],
-        "steps": [
-          "Expand Reference Match and choose a Reference image.",
-          "Choose Overlay or Split, then set Opacity / split.",
-          "Use Scale, Horizontal, and Vertical to align the reference with your photo.",
-          "Click Measure to inspect the comparison, or Starting match to apply an initial adjustment."
-        ]
-      },
-      {
-        "title": "What Starting match changes",
-        "paragraphs": [
-          "Starting match turns off automatic scene metering and adjusts Camera EV. For RAW photos it also sets custom capture white balance; for processed photos it adjusts yellow and magenta print filtration.",
-          "This is a starting adjustment based on measured image statistics, not a guarantee of an exact film or color match. Review the image after applying it and use Undo if needed. Clear removes the reference overlay."
-        ],
-        "tips": [
-          "The Calibration target button downloads an image you can use in a reference workflow."
-        ]
-      }
+      {"title": "Load and align", "paragraphs": ["Reference Match is in the Film panel. Use a reference with corresponding image content so alignment and comparison are meaningful."], "steps": ["Expand Reference Match and choose a Reference image.", "Choose Overlay or Split, then set Opacity / split.", "Use Scale, Horizontal, and Vertical to align the reference with your photo.", "Click Measure to inspect the comparison, or Starting match to apply an initial adjustment."]},
+      {"title": "What Starting match changes", "paragraphs": ["Starting match turns off automatic scene metering and adjusts Camera EV. For RAW photos it also sets custom capture white balance; for processed photos it adjusts yellow and magenta print filtration.", "This is a starting adjustment based on measured image statistics, not a guarantee of an exact film or color match. Review the image after applying it and use Undo if needed. Clear removes the reference overlay."], "tips": ["The Calibration target button downloads an image you can use in a reference workflow."]}
     ],
-    "related": [
-      "film-exposure-and-processing",
-      "film-negative-paper-and-slides"
-    ],
+    "related": ["film-exposure-and-processing", "film-negative-paper-and-slides"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "Load a scan, align it, then measure."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Starting match adjusts physical capture exposure and capture WB for RAW, or print filtration for processed files."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('startReferenceMatch').onclick = () => {"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "S.params.auto_exposure = false;"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "download=\"lighttable-calibration-target.png\""
-      }
+      {"path": "web/index.html", "anchor": "Load a scan, align it, then measure."},
+      {"path": "web/index.html", "anchor": "Starting match adjusts physical capture exposure and capture WB for RAW, or print filtration for processed files."},
+      {"path": "web/app.js", "anchor": "$('startReferenceMatch').onclick = () => {"},
+      {"path": "web/app.js", "anchor": "S.params.auto_exposure = false;"},
+      {"path": "web/index.html", "anchor": "download=\"lighttable-calibration-target.png\""}
     ]
   },
   {
@@ -420,71 +121,19 @@
     "title": "Export selected photos",
     "category": "Export",
     "summary": "Choose exactly which photos to export, preview the output, and monitor progress.",
-    "keywords": [
-      "export",
-      "save",
-      "jpeg",
-      "jpg",
-      "download",
-      "selection",
-      "picked",
-      "rated",
-      "batch",
-      "cancel",
-      "progress"
-    ],
+    "keywords": ["export", "save", "jpeg", "jpg", "download", "selection", "picked", "rated", "batch", "cancel", "progress"],
     "sections": [
-      {
-        "title": "Make an export",
-        "paragraphs": [
-          "Export creates rendered output files from your photo edits. Use Selected photos when you want the export limited to a specific selection."
-        ],
-        "steps": [
-          "Select the photos you want, then click the Export photos button in the top bar. Command/Ctrl+Shift+E also opens Export.",
-          "Check the Photos field. Choose Selected photos, Picked only, Rated 1+, or All except rejected.",
-          "Choose an export preset or set file type, dimensions, quality, and color space.",
-          "Set the destination and inspect Output preview for the filename, dimensions, and path.",
-          "Click Export and follow the progress in the top bar."
-        ]
-      },
-      {
-        "title": "Check the scope and result",
-        "paragraphs": [
-          "Picked only, Rated 1+, and All except rejected select matching still photos from the active catalog, and can include photos outside the displayed collection or filter. Selected photos provides explicit control over the set.",
-          "Use Cancel export to request a stop. Export details reports completed, skipped, and cancelled counts, plus warnings and errors; a warning can occur after a photo was successfully written. Video clips are not rendered by the still-photo export workflow."
-        ]
-      }
+      {"title": "Make an export", "paragraphs": ["Export creates rendered output files from your photo edits. Use Selected photos when you want the export limited to a specific selection."], "steps": ["Select the photos you want, then click the Export photos button in the top bar. Command/Ctrl+Shift+E also opens Export.", "Check the Photos field. Choose Selected photos, Picked only, Rated 1+, or All except rejected.", "Choose an export preset or set file type, dimensions, quality, and color space.", "Set the destination and inspect Output preview for the filename, dimensions, and path.", "Click Export and follow the progress in the top bar."]},
+      {"title": "Check the scope and result", "paragraphs": ["Picked only, Rated 1+, and All except rejected select matching still photos from the active catalog, and can include photos outside the displayed collection or filter. Selected photos provides explicit control over the set.", "Use Cancel export to request a stop. Export details reports completed, skipped, and cancelled counts, plus warnings and errors; a warning can occur after a photo was successfully written. Video clips are not rendered by the still-photo export workflow."]}
     ],
-    "related": [
-      "export-format-color-space",
-      "export-filenames-and-folders",
-      "export-metadata-sidecars"
-    ],
+    "related": ["export-format-color-space", "export-filenames-and-folders", "export-metadata-sidecars"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "aria-label=\"Export photos\""
-      },
-      {
-        "path": "server.py",
-        "anchor": "def export_candidates() -> list[tuple[str, dict, str]]:"
-      },
-      {
-        "path": "server.py",
-        "anchor": "for n, e, export_base_name in export_candidates():"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "if (meta && e.shiftKey && e.key.toLowerCase() === 'e')"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('exportDetails').onclick = () => {"
-      },
-      {
-        "path": "server.py",
-        "anchor": "Photo exported, but its recipe sidecar could not be saved:"
-      }
+      {"path": "web/index.html", "anchor": "aria-label=\"Export photos\""},
+      {"path": "server.py", "anchor": "def export_candidates() -> list[tuple[str, dict, str]]:"},
+      {"path": "server.py", "anchor": "for n, e, export_base_name in export_candidates():"},
+      {"path": "web/app.js", "anchor": "if (meta && e.shiftKey && e.key.toLowerCase() === 'e')"},
+      {"path": "web/app.js", "anchor": "$('exportDetails').onclick = () => {"},
+      {"path": "server.py", "anchor": "Photo exported, but its recipe sidecar could not be saved:"}
     ]
   },
   {
@@ -492,70 +141,18 @@
     "title": "Choose export size, format, and color space",
     "category": "Export",
     "summary": "Use export presets and understand bit depth, resizing, and the current color-gamut limits.",
-    "keywords": [
-      "jpeg",
-      "jpg",
-      "png",
-      "heif",
-      "heic",
-      "tiff",
-      "16 bit",
-      "srgb",
-      "p3",
-      "prophoto",
-      "icc",
-      "quality",
-      "full size",
-      "resolution",
-      "preset"
-    ],
+    "keywords": ["jpeg", "jpg", "png", "heif", "heic", "tiff", "16 bit", "srgb", "p3", "prophoto", "icc", "quality", "full size", "resolution", "preset"],
     "sections": [
-      {
-        "title": "Formats and presets",
-        "paragraphs": [
-          "The export dialog offers JPEG, HEIF, PNG, and 16-bit TIFF. HEIF is an 8-bit output option on macOS. The quality slider applies to JPEG and HEIF.",
-          "JPG (Large) uses full-size JPEG at quality 92 in sRGB. JPG (Small) uses a 2048-pixel long edge at quality 90 in sRGB. 16-bit TIFF uses full size and ProPhoto RGB. Changing these settings selects Custom."
-        ],
-        "steps": [
-          "Open Export and choose a preset across the top.",
-          "Set Dimensions to Full size or a long-edge limit.",
-          "Check Output preview: the exported size reflects rotation and crop, and a long-edge limit downsizes larger images without enlarging smaller ones."
-        ]
-      },
-      {
-        "title": "Color space limits",
-        "paragraphs": [
-          "Every export embeds the selected ICC profile. Choose sRGB, Display P3, or ProPhoto RGB in Colour space.",
-          "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors. Encoding one of those results in P3 or ProPhoto does not restore colors already limited by rendering."
-        ]
-      }
+      {"title": "Formats and presets", "paragraphs": ["The export dialog offers JPEG, HEIF, PNG, and 16-bit TIFF. HEIF is an 8-bit output option on macOS. The quality slider applies to JPEG and HEIF.", "JPG (Large) uses full-size JPEG at quality 92 in sRGB. JPG (Small) uses a 2048-pixel long edge at quality 90 in sRGB. 16-bit TIFF uses full size and ProPhoto RGB. Changing these settings selects Custom."], "steps": ["Open Export and choose a preset across the top.", "Set Dimensions to Full size or a long-edge limit.", "Check Output preview: the exported size reflects rotation and crop, and a long-edge limit downsizes larger images without enlarging smaller ones."]},
+      {"title": "Color space limits", "paragraphs": ["Every export embeds the selected ICC profile. Choose sRGB, Display P3, or ProPhoto RGB in Colour space.", "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors. Encoding one of those results in P3 or ProPhoto does not restore colors already limited by rendering."]}
     ],
-    "related": [
-      "export-photos",
-      "soft-proof",
-      "external-editor"
-    ],
+    "related": ["export-photos", "soft-proof", "external-editor"],
     "sources": [
-      {
-        "path": "web/app.js",
-        "anchor": "const EXPORT_MODAL_PRESETS = {"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "TIFF exports are 16-bit RGB. HEIF is high-efficiency 8-bit output on macOS. Every export embeds its selected ICC profile."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors."
-      },
-      {
-        "path": "export_workflow.py",
-        "anchor": "if long_edge and max(width, height) > int(long_edge):"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('modalExQualityRow').style.display = ['jpeg', 'heif'].includes($('modalExFormat').value) ? '' : 'none';"
-      }
+      {"path": "web/app.js", "anchor": "const EXPORT_MODAL_PRESETS = {"},
+      {"path": "web/index.html", "anchor": "TIFF exports are 16-bit RGB. HEIF is high-efficiency 8-bit output on macOS. Every export embeds its selected ICC profile."},
+      {"path": "web/index.html", "anchor": "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors."},
+      {"path": "export_workflow.py", "anchor": "if long_edge and max(width, height) > int(long_edge):"},
+      {"path": "web/app.js", "anchor": "$('modalExQualityRow').style.display = ['jpeg', 'heif'].includes($('modalExFormat').value) ? '' : 'none';"}
     ]
   },
   {
@@ -563,65 +160,18 @@
     "title": "Set export folders and filenames",
     "category": "Export",
     "summary": "Choose a destination layout and decide what happens when a filename already exists.",
-    "keywords": [
-      "destination",
-      "folder",
-      "path",
-      "filename",
-      "rename",
-      "overwrite",
-      "skip",
-      "collision",
-      "hierarchy",
-      "sequence",
-      "template"
-    ],
+    "keywords": ["destination", "folder", "path", "filename", "rename", "overwrite", "skip", "collision", "hierarchy", "sequence", "template"],
     "sections": [
-      {
-        "title": "Destination layout",
-        "paragraphs": [
-          "One destination folder sends exports to the chosen folder. Subfolder beside each original uses a relative subfolder name for each source photo. Keep source folder hierarchy preserves source-folder organization beneath the export destination."
-        ],
-        "steps": [
-          "Open Export and choose Destination layout.",
-          "Use Choose… for a destination folder, or enter a subfolder name such as film-exports for Subfolder beside each original.",
-          "Expand Advanced and edit Filename template.",
-          "Check the filename and destination shown in Output preview before exporting."
-        ]
-      },
-      {
-        "title": "Names and existing files",
-        "paragraphs": [
-          "Filename templates support {filename}, {stock}, {date}, {rating}, and {sequence}. For example, {filename}_{stock} includes the source name and film stock.",
-          "Keep both · add a number creates another filename, such as a name ending in -2. Skip existing leaves occupied names alone. Overwrite replaces existing output at the chosen path. Use the output preview to confirm the destination before choosing Overwrite."
-        ]
-      }
+      {"title": "Destination layout", "paragraphs": ["One destination folder sends exports to the chosen folder. Subfolder beside each original uses a relative subfolder name for each source photo. Keep source folder hierarchy preserves source-folder organization beneath the export destination."], "steps": ["Open Export and choose Destination layout.", "Use Choose… for a destination folder, or enter a subfolder name such as film-exports for Subfolder beside each original.", "Expand Advanced and edit Filename template.", "Check the filename and destination shown in Output preview before exporting."]},
+      {"title": "Names and existing files", "paragraphs": ["Filename templates support {filename}, {stock}, {date}, {rating}, and {sequence}. For example, {filename}_{stock} includes the source name and film stock.", "Keep both · add a number creates another filename, such as a name ending in -2. Skip existing leaves occupied names alone. Overwrite replaces existing output at the chosen path. Use the output preview to confirm the destination before choosing Overwrite."]}
     ],
-    "related": [
-      "export-photos",
-      "export-metadata-sidecars"
-    ],
+    "related": ["export-photos", "export-metadata-sidecars"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "Keep source folder hierarchy"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "'Subfolder name, e.g. film-exports'"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Filename fields: {filename}, {stock}, {date}, {rating}, {sequence}."
-      },
-      {
-        "path": "export_workflow.py",
-        "anchor": "def collision_path(path: Path, policy: str,"
-      },
-      {
-        "path": "export_workflow.py",
-        "anchor": "candidate = path.with_name(f\"{path.stem}-{index}{path.suffix}\")"
-      }
+      {"path": "web/index.html", "anchor": "Keep source folder hierarchy"},
+      {"path": "web/app.js", "anchor": "'Subfolder name, e.g. film-exports'"},
+      {"path": "web/index.html", "anchor": "Filename fields: {filename}, {stock}, {date}, {rating}, {sequence}."},
+      {"path": "export_workflow.py", "anchor": "def collision_path(path: Path, policy: str,"},
+      {"path": "export_workflow.py", "anchor": "candidate = path.with_name(f\"{path.stem}-{index}{path.suffix}\")"}
     ]
   },
   {
@@ -629,70 +179,19 @@
     "title": "Control export metadata, sidecars, and timestamps",
     "category": "Export",
     "summary": "Choose metadata privacy, optional recipe files, and capture-time handling.",
-    "keywords": [
-      "metadata",
-      "privacy",
-      "gps",
-      "location",
-      "copyright",
-      "sidecar",
-      "recipe",
-      "timestamp",
-      "date",
-      "timezone",
-      "capture time"
-    ],
+    "keywords": ["metadata", "privacy", "gps", "location", "copyright", "sidecar", "recipe", "timestamp", "date", "timezone", "capture time"],
     "sections": [
-      {
-        "title": "Metadata and recipe files",
-        "paragraphs": [
-          "Export → Advanced offers All except location, All metadata, Copyright only, and No metadata. The initial metadata choice is All except location.",
-          "Recipe sidecar controls whether LightTable writes a recipe beside the rendered export. This is separate from the portable edits and XMP sidecar preferences for originals in Settings → Files & Metadata."
-        ],
-        "steps": [
-          "Expand Advanced in Export.",
-          "Choose the Metadata policy appropriate for the files you will share.",
-          "Choose whether to write a Recipe sidecar beside each exported photo."
-        ]
-      },
-      {
-        "title": "File timestamps",
-        "paragraphs": [
-          "File timestamp can use the time of export or the original capture time. If capture timezone is missing, the default is to keep export time and report a warning. You can instead choose to interpret it in this computer’s local timezone.",
-          "Missing or invalid capture time can also leave the export timestamp unchanged. Check Export details for the reported warning. A file’s filesystem timestamp is separate from the metadata policy selected above."
-        ]
-      }
+      {"title": "Metadata and recipe files", "paragraphs": ["Export → Advanced offers All except location, All metadata, Copyright only, and No metadata. The initial metadata choice is All except location.", "Recipe sidecar controls whether LightTable writes a recipe beside the rendered export. This is separate from the portable edits and XMP sidecar preferences for originals in Settings → Files & Metadata."], "steps": ["Expand Advanced in Export.", "Choose the Metadata policy appropriate for the files you will share.", "Choose whether to write a Recipe sidecar beside each exported photo."]},
+      {"title": "File timestamps", "paragraphs": ["File timestamp can use the time of export or the original capture time. If capture timezone is missing, the default is to keep export time and report a warning. You can instead choose to interpret it in this computer’s local timezone.", "Missing or invalid capture time can also leave the export timestamp unchanged. Check Export details for the reported warning. A file’s filesystem timestamp is separate from the metadata policy selected above."]}
     ],
-    "related": [
-      "export-photos",
-      "export-filenames-and-folders",
-      "settings-and-defaults"
-    ],
+    "related": ["export-photos", "export-filenames-and-folders", "settings-and-defaults"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "<span>Metadata</span><select id=\"modalExMetadata\">"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "<span>Recipe sidecar</span><select id=\"modalExSidecar\">"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "<span>File timestamp</span><select id=\"modalExPreserveCaptureTime\">"
-      },
-      {
-        "path": "export_workflow.py",
-        "anchor": "Capture timezone is missing; kept the export file timestamp."
-      },
-      {
-        "path": "export_workflow.py",
-        "anchor": "Capture time or timezone is invalid; kept the export file timestamp."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Keep portable LightTable edits beside originals"
-      }
+      {"path": "web/index.html", "anchor": "<span>Metadata</span><select id=\"modalExMetadata\">"},
+      {"path": "web/index.html", "anchor": "<span>Recipe sidecar</span><select id=\"modalExSidecar\">"},
+      {"path": "web/index.html", "anchor": "<span>File timestamp</span><select id=\"modalExPreserveCaptureTime\">"},
+      {"path": "export_workflow.py", "anchor": "Capture timezone is missing; kept the export file timestamp."},
+      {"path": "export_workflow.py", "anchor": "Capture time or timezone is invalid; kept the export file timestamp."},
+      {"path": "web/index.html", "anchor": "Keep portable LightTable edits beside originals"}
     ]
   },
   {
@@ -700,65 +199,18 @@
     "title": "Preview an output with soft proofing",
     "category": "Export",
     "summary": "View a display or modeled paper preview without making it part of the exported photo.",
-    "keywords": [
-      "soft proof",
-      "proofing",
-      "gamut",
-      "paper",
-      "ink",
-      "matte",
-      "gloss",
-      "print",
-      "p3",
-      "srgb"
-    ],
+    "keywords": ["soft proof", "proofing", "gamut", "paper", "ink", "matte", "gloss", "print", "p3", "srgb"],
     "sections": [
-      {
-        "title": "Turn on soft proof",
-        "paragraphs": [
-          "Soft-proof controls are in the viewer’s View options (•••). They let you inspect an output preview while editing."
-        ],
-        "steps": [
-          "Open View options (•••) below the viewer.",
-          "Enable Preview output profile.",
-          "Choose sRGB display, Display P3 display, Matte paper, or Gloss paper.",
-          "For paper targets, choose whether to Simulate paper and ink. Toggle Show out-of-gamut warning as needed.",
-          "Use the Soft Proof on button in the viewer toolbar to turn the preview off."
-        ]
-      },
-      {
-        "title": "Interpret the preview",
-        "paragraphs": [
-          "Matte and Gloss in this interface are modeled paper previews; they are not a selection of your printer’s measured ICC profile. Treat the preview as guidance when comparing contrast and color.",
-          "Soft proof is a viewing state. Choose the file’s actual Colour space separately in Export."
-        ]
-      }
+      {"title": "Turn on soft proof", "paragraphs": ["Soft-proof controls are in the viewer’s View options (•••). They let you inspect an output preview while editing."], "steps": ["Open View options (•••) below the viewer.", "Enable Preview output profile.", "Choose sRGB display, Display P3 display, Matte paper, or Gloss paper.", "For paper targets, choose whether to Simulate paper and ink. Toggle Show out-of-gamut warning as needed.", "Use the Soft Proof on button in the viewer toolbar to turn the preview off."]},
+      {"title": "Interpret the preview", "paragraphs": ["Matte and Gloss in this interface are modeled paper previews; they are not a selection of your printer’s measured ICC profile. Treat the preview as guidance when comparing contrast and color.", "Soft proof is a viewing state. Choose the file’s actual Colour space separately in Export."]}
     ],
-    "related": [
-      "export-format-color-space",
-      "export-photos"
-    ],
+    "related": ["export-format-color-space", "export-photos"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "<strong>Soft proof</strong><div id=\"viewProofControls\"></div>"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "<select id=\"softProofProfile\">"
-      },
-      {
-        "path": "soft_proof.py",
-        "anchor": "\"matte\": (0.68, 0.032, 0.90),"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('softProofPaper').disabled = !S.softProof.enabled || !printTarget;"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "function exportModalOptions() {"
-      }
+      {"path": "web/index.html", "anchor": "<strong>Soft proof</strong><div id=\"viewProofControls\"></div>"},
+      {"path": "web/index.html", "anchor": "<select id=\"softProofProfile\">"},
+      {"path": "soft_proof.py", "anchor": "\"matte\": (0.68, 0.032, 0.90),"},
+      {"path": "web/app.js", "anchor": "$('softProofPaper').disabled = !S.softProof.enabled || !printTarget;"},
+      {"path": "web/app.js", "anchor": "function exportModalOptions() {"}
     ]
   },
   {
@@ -766,64 +218,18 @@
     "title": "Edit a photo in another application",
     "category": "Export",
     "summary": "Send an adjusted TIFF to another editor and set the format and stacking defaults.",
-    "keywords": [
-      "external",
-      "editor",
-      "photoshop",
-      "affinity",
-      "edit in",
-      "tiff",
-      "round trip",
-      "derivative",
-      "stack"
-    ],
+    "keywords": ["external", "editor", "photoshop", "affinity", "edit in", "tiff", "round trip", "derivative", "stack"],
     "sections": [
-      {
-        "title": "Open an external editor",
-        "paragraphs": [
-          "Use Edit in… to prepare photos for another pixel editor. The adjusted TIFF is written beside its original, and can be stacked with it in the catalog."
-        ],
-        "steps": [
-          "Select a photo and press Command/Ctrl+E to open Edit in another app.",
-          "Choose Application.",
-          "Choose TIFF with current adjustments, then set TIFF colour space and TIFF bit depth.",
-          "Choose whether to Stack rendered file with original.",
-          "Click Edit and wait for rendering to finish before working in the other app."
-        ]
-      },
-      {
-        "title": "RAW files and defaults",
-        "paragraphs": [
-          "RAW originals must be rendered as adjusted TIFFs. Processed original is unavailable if the selection contains a RAW file. For processed photos, that option opens the original rather than preparing an adjusted TIFF.",
-          "Set the default application, color space, bit depth, and stacking behavior in Settings → External Editing. Adjusted TIFFs can use 16 or 8 bits and ProPhoto RGB, Display P3, or sRGB."
-        ]
-      }
+      {"title": "Open an external editor", "paragraphs": ["Use Edit in… to prepare photos for another pixel editor. The adjusted TIFF is written beside its original, and can be stacked with it in the catalog."], "steps": ["Select a photo and press Command/Ctrl+E to open Edit in another app.", "Choose Application.", "Choose TIFF with current adjustments, then set TIFF colour space and TIFF bit depth.", "Choose whether to Stack rendered file with original.", "Click Edit and wait for rendering to finish before working in the other app."]},
+      {"title": "RAW files and defaults", "paragraphs": ["RAW originals must be rendered as adjusted TIFFs. Processed original is unavailable if the selection contains a RAW file. For processed photos, that option opens the original rather than preparing an adjusted TIFF.", "Set the default application, color space, bit depth, and stacking behavior in Settings → External Editing. Adjusted TIFFs can use 16 or 8 bits and ProPhoto RGB, Display P3, or sRGB."]}
     ],
-    "related": [
-      "export-format-color-space",
-      "settings-and-defaults"
-    ],
+    "related": ["export-format-color-space", "settings-and-defaults"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "<strong id=\"externalEditTitle\">Edit in another app</strong>"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "The adjusted TIFF is written beside its original."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "$('externalEditMode').querySelector('[value=\"original\"]').disabled = hasRaw;"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "if (meta && !e.shiftKey && e.key.toLowerCase() === 'e')"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Defaults for rendered files sent to another pixel editor."
-      }
+      {"path": "web/index.html", "anchor": "<strong id=\"externalEditTitle\">Edit in another app</strong>"},
+      {"path": "web/index.html", "anchor": "The adjusted TIFF is written beside its original."},
+      {"path": "web/app.js", "anchor": "$('externalEditMode').querySelector('[value=\"original\"]').disabled = hasRaw;"},
+      {"path": "web/app.js", "anchor": "if (meta && !e.shiftKey && e.key.toLowerCase() === 'e')"},
+      {"path": "web/index.html", "anchor": "Defaults for rendered files sent to another pixel editor."}
     ]
   },
   {
@@ -831,75 +237,19 @@
     "title": "Change preferences and new-photo defaults",
     "category": "Settings",
     "summary": "Adjust the interface, culling behavior, portable edits, and starting edits for new photos.",
-    "keywords": [
-      "settings",
-      "preferences",
-      "defaults",
-      "camera",
-      "raw",
-      "serial",
-      "iso",
-      "font",
-      "background",
-      "lights out",
-      "notifications",
-      "xmp",
-      "portable"
-    ],
+    "keywords": ["settings", "preferences", "defaults", "camera", "raw", "serial", "iso", "font", "background", "lights out", "notifications", "xmp", "portable"],
     "sections": [
-      {
-        "title": "Interface and behavior",
-        "paragraphs": [
-          "Settings changes save automatically. General controls Auto-advance after picking, rejecting, or rating, completion notifications, and update checks.",
-          "Interface controls the viewer background, font scale, Lights Out, loupe information overlay, and crop guides. These preferences change the workspace appearance without changing exported pixels.",
-          "Files & Metadata controls portable LightTable edits beside originals, automatic XMP writing, RAW/JPEG pairing, and keyword entry. Complete portable edits use .lighttable-state.json; XMP carries compatible edits and metadata."
-        ]
-      },
-      {
-        "title": "Defaults for unedited photos",
-        "paragraphs": [
-          "Develop Defaults apply only to photos that do not already have saved edits. They can start Film enabled, choose a workflow and neutral Develop profile, and apply a default preset."
-        ],
-        "steps": [
-          "Open Settings → Develop Defaults.",
-          "Choose the starting Film, workflow, profile, and preset settings.",
-          "To set camera-specific RAW defaults, open a RAW photo and adjust its RAW settings.",
-          "Choose matching by camera model, serial number, or camera and ISO, then click Use current RAW settings.",
-          "Use Reset in the Current camera area to remove that camera default."
-        ]
-      }
+      {"title": "Interface and behavior", "paragraphs": ["Settings changes save automatically. General controls Auto-advance after picking, rejecting, or rating, completion notifications, and update checks.", "Interface controls the viewer background, font scale, Lights Out, loupe information overlay, and crop guides. These preferences change the workspace appearance without changing exported pixels.", "Files & Metadata controls portable LightTable edits beside originals, automatic XMP writing, RAW/JPEG pairing, and keyword entry. Complete portable edits use .lighttable-state.json; XMP carries compatible edits and metadata."]},
+      {"title": "Defaults for unedited photos", "paragraphs": ["Develop Defaults apply only to photos that do not already have saved edits. They can start Film enabled, choose a workflow and neutral Develop profile, and apply a default preset."], "steps": ["Open Settings → Develop Defaults.", "Choose the starting Film, workflow, profile, and preset settings.", "To set camera-specific RAW defaults, open a RAW photo and adjust its RAW settings.", "Choose matching by camera model, serial number, or camera and ISO, then click Use current RAW settings.", "Use Reset in the Current camera area to remove that camera default."]}
     ],
-    "related": [
-      "keyboard-midi",
-      "photo-index",
-      "performance-previews",
-      "catalog-health-recovery"
-    ],
+    "related": ["keyboard-midi", "photo-index", "performance-previews", "catalog-health-recovery"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "Changes save automatically."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Applied only to photos that do not already have saved edits."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Tune the editing canvas without changing exported pixels."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Complete edits travel in .lighttable-state.json when you copy the folder."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Match camera defaults by"
-      },
-      {
-        "path": "web/settings.js",
-        "anchor": "byId('settingsSaveCameraDefault').disabled = !raw;"
-      }
+      {"path": "web/index.html", "anchor": "Changes save automatically."},
+      {"path": "web/index.html", "anchor": "Applied only to photos that do not already have saved edits."},
+      {"path": "web/index.html", "anchor": "Tune the editing canvas without changing exported pixels."},
+      {"path": "web/index.html", "anchor": "Complete edits travel in .lighttable-state.json when you copy the folder."},
+      {"path": "web/index.html", "anchor": "Match camera defaults by"},
+      {"path": "web/settings.js", "anchor": "byId('settingsSaveCameraDefault').disabled = !raw;"}
     ]
   },
   {
@@ -907,78 +257,20 @@
     "title": "Use keyboard shortcuts and MIDI controls",
     "category": "Settings",
     "summary": "Find shortcuts, choose a keyboard scheme, and map a hardware controller where Web MIDI is available.",
-    "keywords": [
-      "keyboard",
-      "shortcut",
-      "hotkey",
-      "midi",
-      "knob",
-      "fader",
-      "controller",
-      "speed keys",
-      "automation",
-      "classic",
-      "lighttable"
-    ],
+    "keywords": ["keyboard", "shortcut", "hotkey", "midi", "knob", "fader", "controller", "speed keys", "automation", "classic", "lighttable"],
     "sections": [
-      {
-        "title": "Keyboard preferences",
-        "paragraphs": [
-          "Settings → Shortcuts & Hardware contains the shortcut scheme and a keyboard reference under Keyboard and MIDI controls. The desktop Help menu also has Keyboard Shortcuts.",
-          "Choose LightTable or Classic; the scheme applies after a reload. Hold-key slider control lets you hold a mapped key while scrolling or using arrow keys. Allow automation controls whether approved local tools can control the window with history and Undo."
-        ],
-        "tips": [
-          "Command/Ctrl+Shift+E opens Export; Command/Ctrl+E opens external editing. Text fields keep ordinary typing behavior, so leave a text field before using unmodified editing shortcuts."
-        ]
-      },
-      {
-        "title": "MIDI mapping",
-        "paragraphs": [
-          "MIDI support depends on the Web MIDI API in the current runtime. The status can show Unavailable, Off, No devices, or a connected device count. Unavailable means this runtime cannot use the MIDI controls."
-        ],
-        "steps": [
-          "Connect a MIDI controller that sends Control Change messages.",
-          "When MIDI is available, open Keyboard and MIDI controls and choose MIDI Learn.",
-          "Click the adjustment slider you want to map, then turn a knob or move a fader.",
-          "Check the mapping message, then use the hardware control to adjust the slider.",
-          "Use Reset MIDI to restore the default mappings."
-        ]
-      }
+      {"title": "Keyboard preferences", "paragraphs": ["Settings → Shortcuts & Hardware contains the shortcut scheme and a keyboard reference under Keyboard and MIDI controls. The desktop Help menu also has Keyboard Shortcuts.", "Choose LightTable or Classic; the scheme applies after a reload. Hold-key slider control lets you hold a mapped key while scrolling or using arrow keys. Allow automation controls whether approved local tools can control the window with history and Undo."], "tips": ["Command/Ctrl+Shift+E opens Export; Command/Ctrl+E opens external editing. Text fields keep ordinary typing behavior, so leave a text field before using unmodified editing shortcuts."]},
+      {"title": "MIDI mapping", "paragraphs": ["MIDI support depends on the Web MIDI API in the current runtime. The status can show Unavailable, Off, No devices, or a connected device count. Unavailable means this runtime cannot use the MIDI controls."], "steps": ["Connect a MIDI controller that sends Control Change messages.", "When MIDI is available, open Keyboard and MIDI controls and choose MIDI Learn.", "Click the adjustment slider you want to map, then turn a knob or move a fader.", "Check the mapping message, then use the hardware control to adjust the slider.", "Use Reset MIDI to restore the default mappings."]}
     ],
-    "related": [
-      "settings-and-defaults",
-      "export-photos",
-      "external-editor"
-    ],
+    "related": ["settings-and-defaults", "export-photos", "external-editor"],
     "sources": [
-      {
-        "path": "web/app.js",
-        "anchor": "toast('Shortcut scheme applies after a reload');"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Hold a mapped key and scroll or use arrow keys."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Let approved local tools control this window with visible history and Undo."
-      },
-      {
-        "path": "web/midi.js",
-        "anchor": "pill.title = 'Web MIDI API not supported in this browser';"
-      },
-      {
-        "path": "web/midi.js",
-        "anchor": "if (status !== 0xb0) return;"
-      },
-      {
-        "path": "web/midi.js",
-        "anchor": "showMidiHud(`Turn any knob to map → ${target.label || target.control}`);"
-      },
-      {
-        "path": "app/main.swift",
-        "anchor": "addEditorItem(helpMenu, title: \"Keyboard Shortcuts\","
-      }
+      {"path": "web/app.js", "anchor": "toast('Shortcut scheme applies after a reload');"},
+      {"path": "web/index.html", "anchor": "Hold a mapped key and scroll or use arrow keys."},
+      {"path": "web/index.html", "anchor": "Let approved local tools control this window with visible history and Undo."},
+      {"path": "web/midi.js", "anchor": "pill.title = 'Web MIDI API not supported in this browser';"},
+      {"path": "web/midi.js", "anchor": "if (status !== 0xb0) return;"},
+      {"path": "web/midi.js", "anchor": "showMidiHud(`Turn any knob to map → ${target.label || target.control}`);"},
+      {"path": "app/main.swift", "anchor": "addEditorItem(helpMenu, title: \"Keyboard Shortcuts\","}
     ]
   },
   {
@@ -986,71 +278,19 @@
     "title": "Enable private photo-content search",
     "category": "Settings",
     "summary": "Build an on-device index of objects, scenes, visible text, and faces.",
-    "keywords": [
-      "ai",
-      "search",
-      "index",
-      "contents",
-      "objects",
-      "scenes",
-      "ocr",
-      "text",
-      "faces",
-      "privacy",
-      "local",
-      "description"
-    ],
+    "keywords": ["ai", "search", "index", "contents", "objects", "scenes", "ocr", "text", "faces", "privacy", "local", "description"],
     "sections": [
-      {
-        "title": "Build the index",
-        "paragraphs": [
-          "The Photo Index is off by default. Analysis stays on this Mac and does not modify photo folders. Apple Vision provides the core analysis; richer Foundation Models descriptions appear only when that capability is available."
-        ],
-        "steps": [
-          "Open Settings → Photo Index.",
-          "Check the On-device capabilities status and turn on Photo contents index.",
-          "Wait for indexing progress to complete. Photos can gain results as they are indexed.",
-          "Use the library search field to search photo contents, visible text, or faces alongside filenames and keywords.",
-          "Open Info → On-device description to inspect the current photo’s generated tags, visible text, and face count."
-        ]
-      },
-      {
-        "title": "Pause, rebuild, or delete",
-        "paragraphs": [
-          "Turning the index off pauses analysis and removes generated results from the active search view; existing index data remains local until deleted. Rebuild index reruns indexing when the feature is enabled.",
-          "Delete index removes generated index data after confirmation. Originals and saved edits are unchanged. If Apple Vision says Build required, the current installation lacks the required local analyzer. Foundation Models may be unavailable while basic Vision indexing remains usable."
-        ]
-      }
+      {"title": "Build the index", "paragraphs": ["The Photo Index is off by default. Analysis stays on this Mac and does not modify photo folders. Apple Vision provides the core analysis; richer Foundation Models descriptions appear only when that capability is available."], "steps": ["Open Settings → Photo Index.", "Check the On-device capabilities status and turn on Photo contents index.", "Wait for indexing progress to complete. Photos can gain results as they are indexed.", "Use the library search field to search photo contents, visible text, or faces alongside filenames and keywords.", "Open Info → On-device description to inspect the current photo’s generated tags, visible text, and face count."]},
+      {"title": "Pause, rebuild, or delete", "paragraphs": ["Turning the index off pauses analysis and removes generated results from the active search view; existing index data remains local until deleted. Rebuild index reruns indexing when the feature is enabled.", "Delete index removes generated index data after confirmation. Originals and saved edits are unchanged. If Apple Vision says Build required, the current installation lacks the required local analyzer. Foundation Models may be unavailable while basic Vision indexing remains usable."]}
     ],
-    "related": [
-      "assisted-culling",
-      "settings-and-defaults"
-    ],
+    "related": ["assisted-culling", "settings-and-defaults"],
     "sources": [
-      {
-        "path": "web/index.html",
-        "anchor": "Analysis stays on this Mac and never modifies photo folders."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "'Objects, scenes, visible text, and faces';"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "'Search photos, contents, text, and faces'"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "indexed ${S.ai.indexed === 1 ? 'photo remains' : 'photos remain'} local until deleted."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "Delete the generated local photo index? Your originals and edits will not be changed."
-      },
-      {
-        "path": "film_lab_ai/providers.py",
-        "anchor": "the local Vision analyzer has not been built"
-      }
+      {"path": "web/index.html", "anchor": "Analysis stays on this Mac and never modifies photo folders."},
+      {"path": "web/app.js", "anchor": "'Objects, scenes, visible text, and faces';"},
+      {"path": "web/app.js", "anchor": "'Search photos, contents, text, and faces'"},
+      {"path": "web/app.js", "anchor": "indexed ${S.ai.indexed === 1 ? 'photo remains' : 'photos remain'} local until deleted."},
+      {"path": "web/app.js", "anchor": "Delete the generated local photo index? Your originals and edits will not be changed."},
+      {"path": "film_lab_ai/providers.py", "anchor": "the local Vision analyzer has not been built"}
     ]
   },
   {
@@ -1058,70 +298,19 @@
     "title": "Review assisted culling suggestions",
     "category": "Settings",
     "summary": "Review local analysis signals and apply pick or reject flags only when you choose.",
-    "keywords": [
-      "cull",
-      "culling",
-      "ai",
-      "selects",
-      "rejects",
-      "sharpness",
-      "eyes",
-      "misfire",
-      "documents",
-      "review",
-      "flags"
-    ],
+    "keywords": ["cull", "culling", "ai", "selects", "rejects", "sharpness", "eyes", "misfire", "documents", "review", "flags"],
     "sections": [
-      {
-        "title": "Review signals",
-        "paragraphs": [
-          "Assisted culling uses the private Photo Index. It does not flag photos until you ask it to. A photo matches a group if any of your chosen criteria returns yes; not judged means that signal has no usable verdict."
-        ],
-        "steps": [
-          "Enable Photo Index in Settings and wait for photos to be scored.",
-          "Expand Assisted culling in the library sidebar.",
-          "Choose Select criteria such as Subject sharpness, Eye sharpness, or Eyes open, or Reject criteria such as Exposure issues, Misfires, or Documents.",
-          "Use Selects, Rejects, or All to review the matching photos.",
-          "Inspect the suggestions, then use Pick selects or Reject rejects if you want to apply those flags."
-        ]
-      },
-      {
-        "title": "Applying flags",
-        "paragraphs": [
-          "The confirmation shows the affected count and warns that existing flags on matching photos will be replaced. Linked RAW/JPEG metadata can also include the paired file when that preference is enabled.",
-          "These are analysis signals for your review, not final judgments about which photographs to keep. Rejecting sets a flag; it does not itself move originals to Trash."
-        ]
-      }
+      {"title": "Review signals", "paragraphs": ["Assisted culling uses the private Photo Index. It does not flag photos until you ask it to. A photo matches a group if any of your chosen criteria returns yes; not judged means that signal has no usable verdict."], "steps": ["Enable Photo Index in Settings and wait for photos to be scored.", "Expand Assisted culling in the library sidebar.", "Choose Select criteria such as Subject sharpness, Eye sharpness, or Eyes open, or Reject criteria such as Exposure issues, Misfires, or Documents.", "Use Selects, Rejects, or All to review the matching photos.", "Inspect the suggestions, then use Pick selects or Reject rejects if you want to apply those flags."]},
+      {"title": "Applying flags", "paragraphs": ["The confirmation shows the affected count and warns that existing flags on matching photos will be replaced. Linked RAW/JPEG metadata can also include the paired file when that preference is enabled.", "These are analysis signals for your review, not final judgments about which photographs to keep. Rejecting sets a flag; it does not itself move originals to Trash."]}
     ],
-    "related": [
-      "photo-index",
-      "settings-and-defaults"
-    ],
+    "related": ["photo-index", "settings-and-defaults"],
     "sources": [
-      {
-        "path": "web/app.js",
-        "anchor": "Nothing is flagged until you ask for it."
-      },
-      {
-        "path": "web/local-ai.js",
-        "anchor": "True when any of the chosen criteria answered yes for this photo."
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "<summary>Assisted culling</summary>"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "Existing flags on those photos are replaced."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "const targets = linkedMetadataTargets(cullResults(group));"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "for (const image of targets) enqueuePhotoPatch(image, { status });"
-      }
+      {"path": "web/app.js", "anchor": "Nothing is flagged until you ask for it."},
+      {"path": "web/local-ai.js", "anchor": "True when any of the chosen criteria answered yes for this photo."},
+      {"path": "web/index.html", "anchor": "<summary>Assisted culling</summary>"},
+      {"path": "web/app.js", "anchor": "Existing flags on those photos are replaced."},
+      {"path": "web/app.js", "anchor": "const targets = linkedMetadataTargets(cullResults(group));"},
+      {"path": "web/app.js", "anchor": "for (const image of targets) enqueuePhotoPatch(image, { status });"}
     ]
   },
   {
@@ -1129,85 +318,22 @@
     "title": "Improve preview speed and check image detail",
     "category": "Troubleshooting",
     "summary": "Choose preview resolution, wait for real detail, and manage generated caches.",
-    "keywords": [
-      "performance",
-      "slow",
-      "blurry",
-      "pixelated",
-      "preview",
-      "resolution",
-      "100%",
-      "1:1",
-      "gpu",
-      "rust",
-      "python",
-      "cache",
-      "purge"
-    ],
+    "keywords": ["performance", "slow", "blurry", "pixelated", "preview", "resolution", "100%", "1:1", "gpu", "rust", "python", "cache", "purge"],
     "sections": [
-      {
-        "title": "Check what has finished rendering",
-        "paragraphs": [
-          "A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. The steady status badge shows Applying film…, Refining RAW detail…, or Updating preview detail… as needed, and stays visible until the requested preview is displayed. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.",
-          "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."
-        ],
-        "steps": [
-          "Open Settings → Performance.",
-          "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.",
-          "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.",
-          "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."
-        ]
-      },
-      {
-        "title": "Manage cache storage",
-        "paragraphs": [
-          "Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.",
-          "Preview resolution is separate from the Dimensions setting used for exported files."
-        ]
-      }
+      {"title": "Check what has finished rendering", "paragraphs": ["A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. The steady status badge shows Applying film…, Refining RAW detail…, or Updating preview detail… as needed, and stays visible until the requested preview is displayed. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.", "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."], "steps": ["Open Settings → Performance.", "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.", "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.", "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."]},
+      {"title": "Manage cache storage", "paragraphs": ["Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.", "Preview resolution is separate from the Dimensions setting used for exported files."]}
     ],
-    "related": [
-      "film-grain-and-format",
-      "export-format-color-space",
-      "catalog-health-recovery"
-    ],
+    "related": ["film-grain-and-format", "export-format-color-space", "catalog-health-recovery"],
     "sources": [
-      {
-        "path": "web/preview-detail.js",
-        "anchor": "if (delivered >= source - 1) return '100% detail ready';"
-      },
-      {
-        "path": "web/preview-detail.js",
-        "anchor": "if (refining) return 'Refining RAW detail…';"
-      },
-      {
-        "path": "web/view-performance.js",
-        "anchor": "if (actualSize) return Math.max(64, Math.min(8000, source || 1100));"
-      },
-      {
-        "path": "web/index.html",
-        "anchor": "Auto · fit display"
-      },
-      {
-        "path": "web/settings.js",
-        "anchor": "Purge generated previews and render caches? Originals and edits are not affected."
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "pythonOption.disabled = rustOnly;"
-      },
-      {
-        "path": "web/app.js",
-        "anchor": "previewProgress.start('Refining RAW detail…');"
-      },
-      {
-        "path": "web/preview-progress.js",
-        "anchor": "export function createPreviewProgress"
-      },
-      {
-        "path": "web/preview-progress.js",
-        "anchor": "export async function waitForRawRefinement"
-      }
+      {"path": "web/preview-detail.js", "anchor": "if (delivered >= source - 1) return '100% detail ready';"},
+      {"path": "web/preview-detail.js", "anchor": "if (refining) return 'Refining RAW detail…';"},
+      {"path": "web/view-performance.js", "anchor": "if (actualSize) return Math.max(64, Math.min(8000, source || 1100));"},
+      {"path": "web/index.html", "anchor": "Auto · fit display"},
+      {"path": "web/settings.js", "anchor": "Purge generated previews and render caches? Originals and edits are not affected."},
+      {"path": "web/app.js", "anchor": "pythonOption.disabled = rustOnly;"},
+      {"path": "web/app.js", "anchor": "previewProgress.start('Refining RAW detail…');"},
+      {"path": "web/preview-progress.js", "anchor": "export function createPreviewProgress"},
+      {"path": "web/preview-progress.js", "anchor": "export async function waitForRawRefinement"}
     ]
   },
   {

--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -4,18 +4,72 @@
     "title": "Choose and preview a film stock",
     "category": "Film",
     "summary": "Turn on the physical film workflow and compare stocks using your own photo.",
-    "keywords": ["film", "stock", "simulation", "negative", "slide", "browse", "preview", "preset", "film off"],
-    "sections": [
-      {"title": "Start with a stock", "paragraphs": ["Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."], "steps": ["Open a still photo and select Film in the tool rail.", "Turn the Film profile switch on.", "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.", "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."]},
-      {"title": "What the previews include", "paragraphs": ["Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.", "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file."], "tips": ["If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."]}
+    "keywords": [
+      "film",
+      "stock",
+      "simulation",
+      "negative",
+      "slide",
+      "browse",
+      "preview",
+      "preset",
+      "film off"
     ],
-    "related": ["film-exposure-and-processing", "film-negative-paper-and-slides", "film-grain-and-format"],
+    "sections": [
+      {
+        "title": "Start with a stock",
+        "paragraphs": [
+          "Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."
+        ],
+        "steps": [
+          "Open a still photo and select Film in the tool rail.",
+          "Turn the Film profile switch on.",
+          "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.",
+          "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."
+        ]
+      },
+      {
+        "title": "What the previews include",
+        "paragraphs": [
+          "Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.",
+          "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.",
+          "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The steady status badge explains the work still in progress. Wait for it to finish before judging fine detail."
+        ],
+        "tips": [
+          "If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."
+        ]
+      }
+    ],
+    "related": [
+      "film-exposure-and-processing",
+      "film-negative-paper-and-slides",
+      "film-grain-and-format"
+    ],
     "sources": [
-      {"path": "web/film-browser.js", "anchor": "Previews use this photo’s edits. Choose a stock to apply it."},
-      {"path": "web/film-browser.js", "anchor": "button.onclick = () => { close(); apply(stock.id, snapshot.name); };"},
-      {"path": "web/index.html", "anchor": "Film processing is bypassed. Edit adjustments remain active."},
-      {"path": "web/app.js", "anchor": "option.disabled = profile.rustOnly && !S.rustAvailable;"},
-      {"path": "web/index.html", "anchor": "Include Film profile and physical settings"}
+      {
+        "path": "web/film-browser.js",
+        "anchor": "Previews use this photo’s edits. Choose a stock to apply it."
+      },
+      {
+        "path": "web/film-browser.js",
+        "anchor": "button.onclick = () => { close(); apply(stock.id, snapshot.name); };"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Film processing is bypassed. Edit adjustments remain active."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "option.disabled = profile.rustOnly && !S.rustAvailable;"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Include Film profile and physical settings"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "previewProgress.start('Refining RAW detail…');"
+      }
     ]
   },
   {
@@ -23,19 +77,70 @@
     "title": "Set film exposure and development",
     "category": "Film",
     "summary": "Understand Camera EV, capture white balance, metering, and development controls.",
-    "keywords": ["exposure", "camera ev", "meter", "white balance", "temperature", "tint", "development", "contrast", "authentic", "creative"],
-    "sections": [
-      {"title": "Capture controls and finishing controls", "paragraphs": ["Camera EV and Capture white balance act before film exposure. Exposure and Temp/Tint in the Edit panel are finishing adjustments later in the workflow.", "Capture white balance requires a RAW original. For a JPEG, HEIF, TIFF, or another processed file, use Edit Temp/Tint."], "steps": ["Turn on Film, choose a stock, and adjust Camera EV.", "Keep Meter scene automatically enabled for automatic scene metering, or turn it off to set the capture exposure yourself.", "Expand Capture & processing to choose As shot, Daylight, Tungsten, or Custom capture white balance for a RAW photo.", "For Custom, adjust Temperature and Capture tint."]},
-      {"title": "Development and linked defaults", "paragraphs": ["Development appears only when the chosen film profile supplies development times. Print development depends on the selected paper and is hidden for slide film. Development contrast is a separate film control.", "Authentic uses linked physical defaults, including the stock’s recommended paper when paper is unlocked. Creative preserves paper overrides when compatible. Changing stocks can still select that stock’s default development time and exposure; compare the result after changing a stock."]}
+    "keywords": [
+      "exposure",
+      "camera ev",
+      "meter",
+      "white balance",
+      "temperature",
+      "tint",
+      "development",
+      "contrast",
+      "authentic",
+      "creative"
     ],
-    "related": ["film-getting-started", "film-negative-paper-and-slides", "film-reference-match"],
+    "sections": [
+      {
+        "title": "Capture controls and finishing controls",
+        "paragraphs": [
+          "Camera EV and Capture white balance act before film exposure. Exposure and Temp/Tint in the Edit panel are finishing adjustments later in the workflow.",
+          "Capture white balance requires a RAW original. For a JPEG, HEIF, TIFF, or another processed file, use Edit Temp/Tint."
+        ],
+        "steps": [
+          "Turn on Film, choose a stock, and adjust Camera EV.",
+          "Keep Meter scene automatically enabled for automatic scene metering, or turn it off to set the capture exposure yourself.",
+          "Expand Capture & processing to choose As shot, Daylight, Tungsten, or Custom capture white balance for a RAW photo.",
+          "For Custom, adjust Temperature and Capture tint."
+        ]
+      },
+      {
+        "title": "Development and linked defaults",
+        "paragraphs": [
+          "Development appears only when the chosen film profile supplies development times. Print development depends on the selected paper and is hidden for slide film. Development contrast is a separate film control.",
+          "Authentic uses linked physical defaults, including the stock’s recommended paper when paper is unlocked. Creative preserves paper overrides when compatible. Changing stocks can still select that stock’s default development time and exposure; compare the result after changing a stock."
+        ]
+      }
+    ],
+    "related": [
+      "film-getting-started",
+      "film-negative-paper-and-slides",
+      "film-reference-match"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Camera EV and capture white balance act before film exposure. Edit-panel Exposure and Temp/Tint are creative finishing controls."},
-      {"path": "web/index.html", "anchor": "Capture white balance requires a RAW original. Use Edit Temp/Tint for a processed file."},
-      {"path": "web/app.js", "anchor": "field.hidden = times.length === 0;"},
-      {"path": "web/film-browser.js", "anchor": "next.development_time = film?.defaultDevelopmentTime || 0;"},
-      {"path": "web/film-browser.js", "anchor": "if (Number.isFinite(film?.defaultExposureEv)) next.exposure_ev = film.defaultExposureEv;"},
-      {"path": "web/index.html", "anchor": "Meter scene automatically"}
+      {
+        "path": "web/index.html",
+        "anchor": "Camera EV and capture white balance act before film exposure. Edit-panel Exposure and Temp/Tint are creative finishing controls."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Capture white balance requires a RAW original. Use Edit Temp/Tint for a processed file."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "field.hidden = times.length === 0;"
+      },
+      {
+        "path": "web/film-browser.js",
+        "anchor": "next.development_time = film?.defaultDevelopmentTime || 0;"
+      },
+      {
+        "path": "web/film-browser.js",
+        "anchor": "if (Number.isFinite(film?.defaultExposureEv)) next.exposure_ev = film.defaultExposureEv;"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Meter scene automatically"
+      }
     ]
   },
   {
@@ -43,19 +148,70 @@
     "title": "Work with negative film, paper, and slides",
     "category": "Film",
     "summary": "Choose a print process for negatives and understand why print controls disappear for slide film.",
-    "keywords": ["negative", "positive", "reversal", "slide", "transparency", "paper", "print", "output", "lock paper", "filtration", "preflash"],
-    "sections": [
-      {"title": "Negative film and paper", "paragraphs": ["Negative stocks use a film-to-print process. Paper choices are restricted to profiles compatible with the selected film’s color or monochrome channel model.", "Use Print exposure to adjust the print stage. In Capture & processing, choose Paper and enable Lock paper when stock changes if you want to keep a compatible paper while trying other stocks. An incompatible paper still has to be replaced."], "steps": ["Choose a negative stock in Film.", "Choose an Output recipe: Clean scan, Neutral print scan, or Soft optical print.", "Expand Capture & processing to choose Paper and any available Print development time.", "Expand Physical film stages for Print glare, Print preflash, Yellow filter, and Magenta filter."]},
-      {"title": "Slide film is scanned directly", "paragraphs": ["Positive or reversal stocks use a direct transparency scan with no negative-to-paper stage. Paper, print exposure, print development, and other print-only controls are hidden for these stocks.", "Output recipes are modeled starting points for scan softness, sharpening, and print effects where applicable. They are not measured emulations of particular commercial scanners."]}
+    "keywords": [
+      "negative",
+      "positive",
+      "reversal",
+      "slide",
+      "transparency",
+      "paper",
+      "print",
+      "output",
+      "lock paper",
+      "filtration",
+      "preflash"
     ],
-    "related": ["film-exposure-and-processing", "film-halation-diffusion-scan"],
+    "sections": [
+      {
+        "title": "Negative film and paper",
+        "paragraphs": [
+          "Negative stocks use a film-to-print process. Paper choices are restricted to profiles compatible with the selected film’s color or monochrome channel model.",
+          "Use Print exposure to adjust the print stage. In Capture & processing, choose Paper and enable Lock paper when stock changes if you want to keep a compatible paper while trying other stocks. An incompatible paper still has to be replaced."
+        ],
+        "steps": [
+          "Choose a negative stock in Film.",
+          "Choose an Output recipe: Clean scan, Neutral print scan, or Soft optical print.",
+          "Expand Capture & processing to choose Paper and any available Print development time.",
+          "Expand Physical film stages for Print glare, Print preflash, Yellow filter, and Magenta filter."
+        ]
+      },
+      {
+        "title": "Slide film is scanned directly",
+        "paragraphs": [
+          "Positive or reversal stocks use a direct transparency scan with no negative-to-paper stage. Paper, print exposure, print development, and other print-only controls are hidden for these stocks.",
+          "Output recipes are modeled starting points for scan softness, sharpening, and print effects where applicable. They are not measured emulations of particular commercial scanners."
+        ]
+      }
+    ],
+    "related": [
+      "film-exposure-and-processing",
+      "film-halation-diffusion-scan"
+    ],
     "sources": [
-      {"path": "film_pipeline.py", "anchor": "# Reversal film has no negative-to-paper stage and is scanned directly."},
-      {"path": "film_pipeline.py", "anchor": "Return print-stage profiles with the film's channel model."},
-      {"path": "web/film-browser.js", "anchor": "if (next.workflow_mode === 'authentic' && !next.paper_locked && film?.targetPrint) next.paper = film.targetPrint;"},
-      {"path": "web/app.js", "anchor": "$('paperField').hidden = positive;"},
-      {"path": "film_pipeline.py", "anchor": "# Coherent output-chain starting points. These are modeled recipes, not claims"},
-      {"path": "web/index.html", "anchor": "Lock paper when stock changes"}
+      {
+        "path": "film_pipeline.py",
+        "anchor": "# Reversal film has no negative-to-paper stage and is scanned directly."
+      },
+      {
+        "path": "film_pipeline.py",
+        "anchor": "Return print-stage profiles with the film's channel model."
+      },
+      {
+        "path": "web/film-browser.js",
+        "anchor": "if (next.workflow_mode === 'authentic' && !next.paper_locked && film?.targetPrint) next.paper = film.targetPrint;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('paperField').hidden = positive;"
+      },
+      {
+        "path": "film_pipeline.py",
+        "anchor": "# Coherent output-chain starting points. These are modeled recipes, not claims"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Lock paper when stock changes"
+      }
     ]
   },
   {
@@ -63,18 +219,66 @@
     "title": "Adjust film grain and format",
     "category": "Film",
     "summary": "Control grain relative to the stock and choose the simulated film size.",
-    "keywords": ["grain", "size", "texture", "35mm", "medium format", "645", "6x6", "6x7", "4x5", "particle", "noise"],
-    "sections": [
-      {"title": "Set the format and grain", "paragraphs": ["Film format sets the physical long edge used by the simulation. The choices are 35 mm, 645, 6 × 6, 6 × 7, and 4 × 5; this setting is separate from cropping the photo.", "Grain size multiplies the chosen stock’s baseline particle area. The readout shows the resulting area in µm², so the same multiplier can show a different area after you change stocks."], "steps": ["In Film profile, choose Film format.", "Expand Physical film stages.", "Enable Grain size and adjust its slider, or clear its checkbox to disable grain.", "Inspect the image at 1:1 and wait for preview detail to finish before judging texture."]},
-      {"title": "What the number represents", "paragraphs": ["The per-stock grain baselines are derived from film speed as visual starting points. They are not laboratory granularity measurements for each emulsion.", "The Grain size setting belongs to the film simulation. Detail sharpening and noise reduction in Edit are separate adjustments."]}
+    "keywords": [
+      "grain",
+      "size",
+      "texture",
+      "35mm",
+      "medium format",
+      "645",
+      "6x6",
+      "6x7",
+      "4x5",
+      "particle",
+      "noise"
     ],
-    "related": ["film-getting-started", "performance-previews"],
+    "sections": [
+      {
+        "title": "Set the format and grain",
+        "paragraphs": [
+          "Film format sets the physical long edge used by the simulation. The choices are 35 mm, 645, 6 × 6, 6 × 7, and 4 × 5; this setting is separate from cropping the photo.",
+          "Grain size multiplies the chosen stock’s baseline particle area. The readout shows the resulting area in µm², so the same multiplier can show a different area after you change stocks."
+        ],
+        "steps": [
+          "In Film profile, choose Film format.",
+          "Expand Physical film stages.",
+          "Enable Grain size and adjust its slider, or clear its checkbox to disable grain.",
+          "Inspect the image at 1:1 and wait for preview detail to finish before judging texture."
+        ]
+      },
+      {
+        "title": "What the number represents",
+        "paragraphs": [
+          "The per-stock grain baselines are derived from film speed as visual starting points. They are not laboratory granularity measurements for each emulsion.",
+          "The Grain size setting belongs to the film simulation. Detail sharpening and noise reduction in Edit are separate adjustments."
+        ]
+      }
+    ],
+    "related": [
+      "film-getting-started",
+      "performance-previews"
+    ],
     "sources": [
-      {"path": "film_pipeline.py", "anchor": "# The simulation uses the physical long edge to derive micrometres per pixel."},
-      {"path": "film_pipeline.py", "anchor": "# field, so these are explicit speed-derived baselines rather than claims of"},
-      {"path": "film_pipeline.py", "anchor": "Resolve the stock baseline multiplied by the user's grain amount."},
-      {"path": "web/index.html", "anchor": "Judge sharpening and noise reduction at 1:1."},
-      {"path": "web/index.html", "anchor": "id=\"grain_on\" checked"}
+      {
+        "path": "film_pipeline.py",
+        "anchor": "# The simulation uses the physical long edge to derive micrometres per pixel."
+      },
+      {
+        "path": "film_pipeline.py",
+        "anchor": "# field, so these are explicit speed-derived baselines rather than claims of"
+      },
+      {
+        "path": "film_pipeline.py",
+        "anchor": "Resolve the stock baseline multiplied by the user's grain amount."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Judge sharpening and noise reduction at 1:1."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "id=\"grain_on\" checked"
+      }
     ]
   },
   {
@@ -82,18 +286,66 @@
     "title": "Adjust halation, diffusion, and scan character",
     "category": "Film",
     "summary": "Refine the film’s physical effects and the selected output recipe.",
-    "keywords": ["halation", "glow", "bloom", "diffusion", "couplers", "glare", "scan", "sharpness", "softness", "scanner", "preflash"],
-    "sections": [
-      {"title": "Physical film stages", "paragraphs": ["Open Film → Physical film stages while Film is enabled. Couplers, Halation, Grain size, and Print glare each have an enable checkbox and an amount control. Turning off a stage disables its amount slider.", "Capture diffusion changes the modeled camera stage. Print glare and Print preflash belong to the print stage and are unavailable for direct slide scans."], "steps": ["Choose the stock and Output recipe before refining the stage controls.", "Change one stage at a time and compare the result.", "Use each stage’s checkbox to compare its contribution without replacing the selected stock."]},
-      {"title": "Scan controls", "paragraphs": ["Scan softness adds lens blur to the selected output recipe. Scan sharpness scales that recipe’s sharpening; Scan sharpening enables or disables it.", "These are adjustments to modeled output recipes, not selections of measured scanner brands. Evaluate fine texture and sharpness with completed 1:1 preview detail."]}
+    "keywords": [
+      "halation",
+      "glow",
+      "bloom",
+      "diffusion",
+      "couplers",
+      "glare",
+      "scan",
+      "sharpness",
+      "softness",
+      "scanner",
+      "preflash"
     ],
-    "related": ["film-negative-paper-and-slides", "film-grain-and-format", "performance-previews"],
+    "sections": [
+      {
+        "title": "Physical film stages",
+        "paragraphs": [
+          "Open Film → Physical film stages while Film is enabled. Couplers, Halation, Grain size, and Print glare each have an enable checkbox and an amount control. Turning off a stage disables its amount slider.",
+          "Capture diffusion changes the modeled camera stage. Print glare and Print preflash belong to the print stage and are unavailable for direct slide scans."
+        ],
+        "steps": [
+          "Choose the stock and Output recipe before refining the stage controls.",
+          "Change one stage at a time and compare the result.",
+          "Use each stage’s checkbox to compare its contribution without replacing the selected stock."
+        ]
+      },
+      {
+        "title": "Scan controls",
+        "paragraphs": [
+          "Scan softness adds lens blur to the selected output recipe. Scan sharpness scales that recipe’s sharpening; Scan sharpening enables or disables it.",
+          "These are adjustments to modeled output recipes, not selections of measured scanner brands. Evaluate fine texture and sharpness with completed 1:1 preview detail."
+        ]
+      }
+    ],
+    "related": [
+      "film-negative-paper-and-slides",
+      "film-grain-and-format",
+      "performance-previews"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "These controls modify the selected output recipe. Scanner brand names are intentionally omitted until measured reference scans exist."},
-      {"path": "film_pipeline.py", "anchor": "\"lens_blur\": recipe[\"scanner_lens_blur\"] + p[\"scan_softness\"],"},
-      {"path": "web/app.js", "anchor": "$('halation_amount').disabled = !profileEnabled || !S.params.halation_on;"},
-      {"path": "web/app.js", "anchor": "$('scan_sharpness').disabled = !profileEnabled || !S.params.scan_sharpen;"},
-      {"path": "film_pipeline.py", "anchor": "\"active\": p[\"camera_diffusion_strength\"] > 0,"}
+      {
+        "path": "web/index.html",
+        "anchor": "These controls modify the selected output recipe. Scanner brand names are intentionally omitted until measured reference scans exist."
+      },
+      {
+        "path": "film_pipeline.py",
+        "anchor": "\"lens_blur\": recipe[\"scanner_lens_blur\"] + p[\"scan_softness\"],"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('halation_amount').disabled = !profileEnabled || !S.params.halation_on;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('scan_sharpness').disabled = !profileEnabled || !S.params.scan_sharpen;"
+      },
+      {
+        "path": "film_pipeline.py",
+        "anchor": "\"active\": p[\"camera_diffusion_strength\"] > 0,"
+      }
     ]
   },
   {
@@ -101,18 +353,66 @@
     "title": "Compare with a reference image",
     "category": "Film",
     "summary": "Align a scan or other reference, measure the difference, and apply a starting match.",
-    "keywords": ["reference", "match", "scan", "calibration", "overlay", "split", "opacity", "measure", "color match"],
-    "sections": [
-      {"title": "Load and align", "paragraphs": ["Reference Match is in the Film panel. Use a reference with corresponding image content so alignment and comparison are meaningful."], "steps": ["Expand Reference Match and choose a Reference image.", "Choose Overlay or Split, then set Opacity / split.", "Use Scale, Horizontal, and Vertical to align the reference with your photo.", "Click Measure to inspect the comparison, or Starting match to apply an initial adjustment."]},
-      {"title": "What Starting match changes", "paragraphs": ["Starting match turns off automatic scene metering and adjusts Camera EV. For RAW photos it also sets custom capture white balance; for processed photos it adjusts yellow and magenta print filtration.", "This is a starting adjustment based on measured image statistics, not a guarantee of an exact film or color match. Review the image after applying it and use Undo if needed. Clear removes the reference overlay."], "tips": ["The Calibration target button downloads an image you can use in a reference workflow."]}
+    "keywords": [
+      "reference",
+      "match",
+      "scan",
+      "calibration",
+      "overlay",
+      "split",
+      "opacity",
+      "measure",
+      "color match"
     ],
-    "related": ["film-exposure-and-processing", "film-negative-paper-and-slides"],
+    "sections": [
+      {
+        "title": "Load and align",
+        "paragraphs": [
+          "Reference Match is in the Film panel. Use a reference with corresponding image content so alignment and comparison are meaningful."
+        ],
+        "steps": [
+          "Expand Reference Match and choose a Reference image.",
+          "Choose Overlay or Split, then set Opacity / split.",
+          "Use Scale, Horizontal, and Vertical to align the reference with your photo.",
+          "Click Measure to inspect the comparison, or Starting match to apply an initial adjustment."
+        ]
+      },
+      {
+        "title": "What Starting match changes",
+        "paragraphs": [
+          "Starting match turns off automatic scene metering and adjusts Camera EV. For RAW photos it also sets custom capture white balance; for processed photos it adjusts yellow and magenta print filtration.",
+          "This is a starting adjustment based on measured image statistics, not a guarantee of an exact film or color match. Review the image after applying it and use Undo if needed. Clear removes the reference overlay."
+        ],
+        "tips": [
+          "The Calibration target button downloads an image you can use in a reference workflow."
+        ]
+      }
+    ],
+    "related": [
+      "film-exposure-and-processing",
+      "film-negative-paper-and-slides"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Load a scan, align it, then measure."},
-      {"path": "web/index.html", "anchor": "Starting match adjusts physical capture exposure and capture WB for RAW, or print filtration for processed files."},
-      {"path": "web/app.js", "anchor": "$('startReferenceMatch').onclick = () => {"},
-      {"path": "web/app.js", "anchor": "S.params.auto_exposure = false;"},
-      {"path": "web/index.html", "anchor": "download=\"lighttable-calibration-target.png\""}
+      {
+        "path": "web/index.html",
+        "anchor": "Load a scan, align it, then measure."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Starting match adjusts physical capture exposure and capture WB for RAW, or print filtration for processed files."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('startReferenceMatch').onclick = () => {"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "S.params.auto_exposure = false;"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "download=\"lighttable-calibration-target.png\""
+      }
     ]
   },
   {
@@ -120,19 +420,71 @@
     "title": "Export selected photos",
     "category": "Export",
     "summary": "Choose exactly which photos to export, preview the output, and monitor progress.",
-    "keywords": ["export", "save", "jpeg", "jpg", "download", "selection", "picked", "rated", "batch", "cancel", "progress"],
-    "sections": [
-      {"title": "Make an export", "paragraphs": ["Export creates rendered output files from your photo edits. Use Selected photos when you want the export limited to a specific selection."], "steps": ["Select the photos you want, then click the Export photos button in the top bar. Command/Ctrl+Shift+E also opens Export.", "Check the Photos field. Choose Selected photos, Picked only, Rated 1+, or All except rejected.", "Choose an export preset or set file type, dimensions, quality, and color space.", "Set the destination and inspect Output preview for the filename, dimensions, and path.", "Click Export and follow the progress in the top bar."]},
-      {"title": "Check the scope and result", "paragraphs": ["Picked only, Rated 1+, and All except rejected select matching still photos from the active catalog, and can include photos outside the displayed collection or filter. Selected photos provides explicit control over the set.", "Use Cancel export to request a stop. Export details reports completed, skipped, and cancelled counts, plus warnings and errors; a warning can occur after a photo was successfully written. Video clips are not rendered by the still-photo export workflow."]}
+    "keywords": [
+      "export",
+      "save",
+      "jpeg",
+      "jpg",
+      "download",
+      "selection",
+      "picked",
+      "rated",
+      "batch",
+      "cancel",
+      "progress"
     ],
-    "related": ["export-format-color-space", "export-filenames-and-folders", "export-metadata-sidecars"],
+    "sections": [
+      {
+        "title": "Make an export",
+        "paragraphs": [
+          "Export creates rendered output files from your photo edits. Use Selected photos when you want the export limited to a specific selection."
+        ],
+        "steps": [
+          "Select the photos you want, then click the Export photos button in the top bar. Command/Ctrl+Shift+E also opens Export.",
+          "Check the Photos field. Choose Selected photos, Picked only, Rated 1+, or All except rejected.",
+          "Choose an export preset or set file type, dimensions, quality, and color space.",
+          "Set the destination and inspect Output preview for the filename, dimensions, and path.",
+          "Click Export and follow the progress in the top bar."
+        ]
+      },
+      {
+        "title": "Check the scope and result",
+        "paragraphs": [
+          "Picked only, Rated 1+, and All except rejected select matching still photos from the active catalog, and can include photos outside the displayed collection or filter. Selected photos provides explicit control over the set.",
+          "Use Cancel export to request a stop. Export details reports completed, skipped, and cancelled counts, plus warnings and errors; a warning can occur after a photo was successfully written. Video clips are not rendered by the still-photo export workflow."
+        ]
+      }
+    ],
+    "related": [
+      "export-format-color-space",
+      "export-filenames-and-folders",
+      "export-metadata-sidecars"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "aria-label=\"Export photos\""},
-      {"path": "server.py", "anchor": "def export_candidates() -> list[tuple[str, dict, str]]:"},
-      {"path": "server.py", "anchor": "for n, e, export_base_name in export_candidates():"},
-      {"path": "web/app.js", "anchor": "if (meta && e.shiftKey && e.key.toLowerCase() === 'e')"},
-      {"path": "web/app.js", "anchor": "$('exportDetails').onclick = () => {"},
-      {"path": "server.py", "anchor": "Photo exported, but its recipe sidecar could not be saved:"}
+      {
+        "path": "web/index.html",
+        "anchor": "aria-label=\"Export photos\""
+      },
+      {
+        "path": "server.py",
+        "anchor": "def export_candidates() -> list[tuple[str, dict, str]]:"
+      },
+      {
+        "path": "server.py",
+        "anchor": "for n, e, export_base_name in export_candidates():"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (meta && e.shiftKey && e.key.toLowerCase() === 'e')"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('exportDetails').onclick = () => {"
+      },
+      {
+        "path": "server.py",
+        "anchor": "Photo exported, but its recipe sidecar could not be saved:"
+      }
     ]
   },
   {
@@ -140,18 +492,70 @@
     "title": "Choose export size, format, and color space",
     "category": "Export",
     "summary": "Use export presets and understand bit depth, resizing, and the current color-gamut limits.",
-    "keywords": ["jpeg", "jpg", "png", "heif", "heic", "tiff", "16 bit", "srgb", "p3", "prophoto", "icc", "quality", "full size", "resolution", "preset"],
-    "sections": [
-      {"title": "Formats and presets", "paragraphs": ["The export dialog offers JPEG, HEIF, PNG, and 16-bit TIFF. HEIF is an 8-bit output option on macOS. The quality slider applies to JPEG and HEIF.", "JPG (Large) uses full-size JPEG at quality 92 in sRGB. JPG (Small) uses a 2048-pixel long edge at quality 90 in sRGB. 16-bit TIFF uses full size and ProPhoto RGB. Changing these settings selects Custom."], "steps": ["Open Export and choose a preset across the top.", "Set Dimensions to Full size or a long-edge limit.", "Check Output preview: the exported size reflects rotation and crop, and a long-edge limit downsizes larger images without enlarging smaller ones."]},
-      {"title": "Color space limits", "paragraphs": ["Every export embeds the selected ICC profile. Choose sRGB, Display P3, or ProPhoto RGB in Colour space.", "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors. Encoding one of those results in P3 or ProPhoto does not restore colors already limited by rendering."]}
+    "keywords": [
+      "jpeg",
+      "jpg",
+      "png",
+      "heif",
+      "heic",
+      "tiff",
+      "16 bit",
+      "srgb",
+      "p3",
+      "prophoto",
+      "icc",
+      "quality",
+      "full size",
+      "resolution",
+      "preset"
     ],
-    "related": ["export-photos", "soft-proof", "external-editor"],
+    "sections": [
+      {
+        "title": "Formats and presets",
+        "paragraphs": [
+          "The export dialog offers JPEG, HEIF, PNG, and 16-bit TIFF. HEIF is an 8-bit output option on macOS. The quality slider applies to JPEG and HEIF.",
+          "JPG (Large) uses full-size JPEG at quality 92 in sRGB. JPG (Small) uses a 2048-pixel long edge at quality 90 in sRGB. 16-bit TIFF uses full size and ProPhoto RGB. Changing these settings selects Custom."
+        ],
+        "steps": [
+          "Open Export and choose a preset across the top.",
+          "Set Dimensions to Full size or a long-edge limit.",
+          "Check Output preview: the exported size reflects rotation and crop, and a long-edge limit downsizes larger images without enlarging smaller ones."
+        ]
+      },
+      {
+        "title": "Color space limits",
+        "paragraphs": [
+          "Every export embeds the selected ICC profile. Choose sRGB, Display P3, or ProPhoto RGB in Colour space.",
+          "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors. Encoding one of those results in P3 or ProPhoto does not restore colors already limited by rendering."
+        ]
+      }
+    ],
+    "related": [
+      "export-photos",
+      "soft-proof",
+      "external-editor"
+    ],
     "sources": [
-      {"path": "web/app.js", "anchor": "const EXPORT_MODAL_PRESETS = {"},
-      {"path": "web/index.html", "anchor": "TIFF exports are 16-bit RGB. HEIF is high-efficiency 8-bit output on macOS. Every export embeds its selected ICC profile."},
-      {"path": "web/index.html", "anchor": "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors."},
-      {"path": "export_workflow.py", "anchor": "if long_edge and max(width, height) > int(long_edge):"},
-      {"path": "web/app.js", "anchor": "$('modalExQualityRow').style.display = ['jpeg', 'heif'].includes($('modalExFormat').value) ? '' : 'none';"}
+      {
+        "path": "web/app.js",
+        "anchor": "const EXPORT_MODAL_PRESETS = {"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "TIFF exports are 16-bit RGB. HEIF is high-efficiency 8-bit output on macOS. Every export embeds its selected ICC profile."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Wide-gamut Develop exports preserve source colors when color and local adjustments are off. Film rendering and adjusted Develop exports are limited to sRGB colors."
+      },
+      {
+        "path": "export_workflow.py",
+        "anchor": "if long_edge and max(width, height) > int(long_edge):"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('modalExQualityRow').style.display = ['jpeg', 'heif'].includes($('modalExFormat').value) ? '' : 'none';"
+      }
     ]
   },
   {
@@ -159,18 +563,65 @@
     "title": "Set export folders and filenames",
     "category": "Export",
     "summary": "Choose a destination layout and decide what happens when a filename already exists.",
-    "keywords": ["destination", "folder", "path", "filename", "rename", "overwrite", "skip", "collision", "hierarchy", "sequence", "template"],
-    "sections": [
-      {"title": "Destination layout", "paragraphs": ["One destination folder sends exports to the chosen folder. Subfolder beside each original uses a relative subfolder name for each source photo. Keep source folder hierarchy preserves source-folder organization beneath the export destination."], "steps": ["Open Export and choose Destination layout.", "Use Choose… for a destination folder, or enter a subfolder name such as film-exports for Subfolder beside each original.", "Expand Advanced and edit Filename template.", "Check the filename and destination shown in Output preview before exporting."]},
-      {"title": "Names and existing files", "paragraphs": ["Filename templates support {filename}, {stock}, {date}, {rating}, and {sequence}. For example, {filename}_{stock} includes the source name and film stock.", "Keep both · add a number creates another filename, such as a name ending in -2. Skip existing leaves occupied names alone. Overwrite replaces existing output at the chosen path. Use the output preview to confirm the destination before choosing Overwrite."]}
+    "keywords": [
+      "destination",
+      "folder",
+      "path",
+      "filename",
+      "rename",
+      "overwrite",
+      "skip",
+      "collision",
+      "hierarchy",
+      "sequence",
+      "template"
     ],
-    "related": ["export-photos", "export-metadata-sidecars"],
+    "sections": [
+      {
+        "title": "Destination layout",
+        "paragraphs": [
+          "One destination folder sends exports to the chosen folder. Subfolder beside each original uses a relative subfolder name for each source photo. Keep source folder hierarchy preserves source-folder organization beneath the export destination."
+        ],
+        "steps": [
+          "Open Export and choose Destination layout.",
+          "Use Choose… for a destination folder, or enter a subfolder name such as film-exports for Subfolder beside each original.",
+          "Expand Advanced and edit Filename template.",
+          "Check the filename and destination shown in Output preview before exporting."
+        ]
+      },
+      {
+        "title": "Names and existing files",
+        "paragraphs": [
+          "Filename templates support {filename}, {stock}, {date}, {rating}, and {sequence}. For example, {filename}_{stock} includes the source name and film stock.",
+          "Keep both · add a number creates another filename, such as a name ending in -2. Skip existing leaves occupied names alone. Overwrite replaces existing output at the chosen path. Use the output preview to confirm the destination before choosing Overwrite."
+        ]
+      }
+    ],
+    "related": [
+      "export-photos",
+      "export-metadata-sidecars"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Keep source folder hierarchy"},
-      {"path": "web/app.js", "anchor": "'Subfolder name, e.g. film-exports'"},
-      {"path": "web/index.html", "anchor": "Filename fields: {filename}, {stock}, {date}, {rating}, {sequence}."},
-      {"path": "export_workflow.py", "anchor": "def collision_path(path: Path, policy: str,"},
-      {"path": "export_workflow.py", "anchor": "candidate = path.with_name(f\"{path.stem}-{index}{path.suffix}\")"}
+      {
+        "path": "web/index.html",
+        "anchor": "Keep source folder hierarchy"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "'Subfolder name, e.g. film-exports'"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Filename fields: {filename}, {stock}, {date}, {rating}, {sequence}."
+      },
+      {
+        "path": "export_workflow.py",
+        "anchor": "def collision_path(path: Path, policy: str,"
+      },
+      {
+        "path": "export_workflow.py",
+        "anchor": "candidate = path.with_name(f\"{path.stem}-{index}{path.suffix}\")"
+      }
     ]
   },
   {
@@ -178,19 +629,70 @@
     "title": "Control export metadata, sidecars, and timestamps",
     "category": "Export",
     "summary": "Choose metadata privacy, optional recipe files, and capture-time handling.",
-    "keywords": ["metadata", "privacy", "gps", "location", "copyright", "sidecar", "recipe", "timestamp", "date", "timezone", "capture time"],
-    "sections": [
-      {"title": "Metadata and recipe files", "paragraphs": ["Export → Advanced offers All except location, All metadata, Copyright only, and No metadata. The initial metadata choice is All except location.", "Recipe sidecar controls whether LightTable writes a recipe beside the rendered export. This is separate from the portable edits and XMP sidecar preferences for originals in Settings → Files & Metadata."], "steps": ["Expand Advanced in Export.", "Choose the Metadata policy appropriate for the files you will share.", "Choose whether to write a Recipe sidecar beside each exported photo."]},
-      {"title": "File timestamps", "paragraphs": ["File timestamp can use the time of export or the original capture time. If capture timezone is missing, the default is to keep export time and report a warning. You can instead choose to interpret it in this computer’s local timezone.", "Missing or invalid capture time can also leave the export timestamp unchanged. Check Export details for the reported warning. A file’s filesystem timestamp is separate from the metadata policy selected above."]}
+    "keywords": [
+      "metadata",
+      "privacy",
+      "gps",
+      "location",
+      "copyright",
+      "sidecar",
+      "recipe",
+      "timestamp",
+      "date",
+      "timezone",
+      "capture time"
     ],
-    "related": ["export-photos", "export-filenames-and-folders", "settings-and-defaults"],
+    "sections": [
+      {
+        "title": "Metadata and recipe files",
+        "paragraphs": [
+          "Export → Advanced offers All except location, All metadata, Copyright only, and No metadata. The initial metadata choice is All except location.",
+          "Recipe sidecar controls whether LightTable writes a recipe beside the rendered export. This is separate from the portable edits and XMP sidecar preferences for originals in Settings → Files & Metadata."
+        ],
+        "steps": [
+          "Expand Advanced in Export.",
+          "Choose the Metadata policy appropriate for the files you will share.",
+          "Choose whether to write a Recipe sidecar beside each exported photo."
+        ]
+      },
+      {
+        "title": "File timestamps",
+        "paragraphs": [
+          "File timestamp can use the time of export or the original capture time. If capture timezone is missing, the default is to keep export time and report a warning. You can instead choose to interpret it in this computer’s local timezone.",
+          "Missing or invalid capture time can also leave the export timestamp unchanged. Check Export details for the reported warning. A file’s filesystem timestamp is separate from the metadata policy selected above."
+        ]
+      }
+    ],
+    "related": [
+      "export-photos",
+      "export-filenames-and-folders",
+      "settings-and-defaults"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "<span>Metadata</span><select id=\"modalExMetadata\">"},
-      {"path": "web/index.html", "anchor": "<span>Recipe sidecar</span><select id=\"modalExSidecar\">"},
-      {"path": "web/index.html", "anchor": "<span>File timestamp</span><select id=\"modalExPreserveCaptureTime\">"},
-      {"path": "export_workflow.py", "anchor": "Capture timezone is missing; kept the export file timestamp."},
-      {"path": "export_workflow.py", "anchor": "Capture time or timezone is invalid; kept the export file timestamp."},
-      {"path": "web/index.html", "anchor": "Keep portable LightTable edits beside originals"}
+      {
+        "path": "web/index.html",
+        "anchor": "<span>Metadata</span><select id=\"modalExMetadata\">"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<span>Recipe sidecar</span><select id=\"modalExSidecar\">"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<span>File timestamp</span><select id=\"modalExPreserveCaptureTime\">"
+      },
+      {
+        "path": "export_workflow.py",
+        "anchor": "Capture timezone is missing; kept the export file timestamp."
+      },
+      {
+        "path": "export_workflow.py",
+        "anchor": "Capture time or timezone is invalid; kept the export file timestamp."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Keep portable LightTable edits beside originals"
+      }
     ]
   },
   {
@@ -198,18 +700,65 @@
     "title": "Preview an output with soft proofing",
     "category": "Export",
     "summary": "View a display or modeled paper preview without making it part of the exported photo.",
-    "keywords": ["soft proof", "proofing", "gamut", "paper", "ink", "matte", "gloss", "print", "p3", "srgb"],
-    "sections": [
-      {"title": "Turn on soft proof", "paragraphs": ["Soft-proof controls are in the viewer’s View options (•••). They let you inspect an output preview while editing."], "steps": ["Open View options (•••) below the viewer.", "Enable Preview output profile.", "Choose sRGB display, Display P3 display, Matte paper, or Gloss paper.", "For paper targets, choose whether to Simulate paper and ink. Toggle Show out-of-gamut warning as needed.", "Use the Soft Proof on button in the viewer toolbar to turn the preview off."]},
-      {"title": "Interpret the preview", "paragraphs": ["Matte and Gloss in this interface are modeled paper previews; they are not a selection of your printer’s measured ICC profile. Treat the preview as guidance when comparing contrast and color.", "Soft proof is a viewing state. Choose the file’s actual Colour space separately in Export."]}
+    "keywords": [
+      "soft proof",
+      "proofing",
+      "gamut",
+      "paper",
+      "ink",
+      "matte",
+      "gloss",
+      "print",
+      "p3",
+      "srgb"
     ],
-    "related": ["export-format-color-space", "export-photos"],
+    "sections": [
+      {
+        "title": "Turn on soft proof",
+        "paragraphs": [
+          "Soft-proof controls are in the viewer’s View options (•••). They let you inspect an output preview while editing."
+        ],
+        "steps": [
+          "Open View options (•••) below the viewer.",
+          "Enable Preview output profile.",
+          "Choose sRGB display, Display P3 display, Matte paper, or Gloss paper.",
+          "For paper targets, choose whether to Simulate paper and ink. Toggle Show out-of-gamut warning as needed.",
+          "Use the Soft Proof on button in the viewer toolbar to turn the preview off."
+        ]
+      },
+      {
+        "title": "Interpret the preview",
+        "paragraphs": [
+          "Matte and Gloss in this interface are modeled paper previews; they are not a selection of your printer’s measured ICC profile. Treat the preview as guidance when comparing contrast and color.",
+          "Soft proof is a viewing state. Choose the file’s actual Colour space separately in Export."
+        ]
+      }
+    ],
+    "related": [
+      "export-format-color-space",
+      "export-photos"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "<strong>Soft proof</strong><div id=\"viewProofControls\"></div>"},
-      {"path": "web/index.html", "anchor": "<select id=\"softProofProfile\">"},
-      {"path": "soft_proof.py", "anchor": "\"matte\": (0.68, 0.032, 0.90),"},
-      {"path": "web/app.js", "anchor": "$('softProofPaper').disabled = !S.softProof.enabled || !printTarget;"},
-      {"path": "web/app.js", "anchor": "function exportModalOptions() {"}
+      {
+        "path": "web/index.html",
+        "anchor": "<strong>Soft proof</strong><div id=\"viewProofControls\"></div>"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<select id=\"softProofProfile\">"
+      },
+      {
+        "path": "soft_proof.py",
+        "anchor": "\"matte\": (0.68, 0.032, 0.90),"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('softProofPaper').disabled = !S.softProof.enabled || !printTarget;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "function exportModalOptions() {"
+      }
     ]
   },
   {
@@ -217,18 +766,64 @@
     "title": "Edit a photo in another application",
     "category": "Export",
     "summary": "Send an adjusted TIFF to another editor and set the format and stacking defaults.",
-    "keywords": ["external", "editor", "photoshop", "affinity", "edit in", "tiff", "round trip", "derivative", "stack"],
-    "sections": [
-      {"title": "Open an external editor", "paragraphs": ["Use Edit in… to prepare photos for another pixel editor. The adjusted TIFF is written beside its original, and can be stacked with it in the catalog."], "steps": ["Select a photo and press Command/Ctrl+E to open Edit in another app.", "Choose Application.", "Choose TIFF with current adjustments, then set TIFF colour space and TIFF bit depth.", "Choose whether to Stack rendered file with original.", "Click Edit and wait for rendering to finish before working in the other app."]},
-      {"title": "RAW files and defaults", "paragraphs": ["RAW originals must be rendered as adjusted TIFFs. Processed original is unavailable if the selection contains a RAW file. For processed photos, that option opens the original rather than preparing an adjusted TIFF.", "Set the default application, color space, bit depth, and stacking behavior in Settings → External Editing. Adjusted TIFFs can use 16 or 8 bits and ProPhoto RGB, Display P3, or sRGB."]}
+    "keywords": [
+      "external",
+      "editor",
+      "photoshop",
+      "affinity",
+      "edit in",
+      "tiff",
+      "round trip",
+      "derivative",
+      "stack"
     ],
-    "related": ["export-format-color-space", "settings-and-defaults"],
+    "sections": [
+      {
+        "title": "Open an external editor",
+        "paragraphs": [
+          "Use Edit in… to prepare photos for another pixel editor. The adjusted TIFF is written beside its original, and can be stacked with it in the catalog."
+        ],
+        "steps": [
+          "Select a photo and press Command/Ctrl+E to open Edit in another app.",
+          "Choose Application.",
+          "Choose TIFF with current adjustments, then set TIFF colour space and TIFF bit depth.",
+          "Choose whether to Stack rendered file with original.",
+          "Click Edit and wait for rendering to finish before working in the other app."
+        ]
+      },
+      {
+        "title": "RAW files and defaults",
+        "paragraphs": [
+          "RAW originals must be rendered as adjusted TIFFs. Processed original is unavailable if the selection contains a RAW file. For processed photos, that option opens the original rather than preparing an adjusted TIFF.",
+          "Set the default application, color space, bit depth, and stacking behavior in Settings → External Editing. Adjusted TIFFs can use 16 or 8 bits and ProPhoto RGB, Display P3, or sRGB."
+        ]
+      }
+    ],
+    "related": [
+      "export-format-color-space",
+      "settings-and-defaults"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "<strong id=\"externalEditTitle\">Edit in another app</strong>"},
-      {"path": "web/index.html", "anchor": "The adjusted TIFF is written beside its original."},
-      {"path": "web/app.js", "anchor": "$('externalEditMode').querySelector('[value=\"original\"]').disabled = hasRaw;"},
-      {"path": "web/app.js", "anchor": "if (meta && !e.shiftKey && e.key.toLowerCase() === 'e')"},
-      {"path": "web/index.html", "anchor": "Defaults for rendered files sent to another pixel editor."}
+      {
+        "path": "web/index.html",
+        "anchor": "<strong id=\"externalEditTitle\">Edit in another app</strong>"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "The adjusted TIFF is written beside its original."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "$('externalEditMode').querySelector('[value=\"original\"]').disabled = hasRaw;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "if (meta && !e.shiftKey && e.key.toLowerCase() === 'e')"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Defaults for rendered files sent to another pixel editor."
+      }
     ]
   },
   {
@@ -236,19 +831,75 @@
     "title": "Change preferences and new-photo defaults",
     "category": "Settings",
     "summary": "Adjust the interface, culling behavior, portable edits, and starting edits for new photos.",
-    "keywords": ["settings", "preferences", "defaults", "camera", "raw", "serial", "iso", "font", "background", "lights out", "notifications", "xmp", "portable"],
-    "sections": [
-      {"title": "Interface and behavior", "paragraphs": ["Settings changes save automatically. General controls Auto-advance after picking, rejecting, or rating, completion notifications, and update checks.", "Interface controls the viewer background, font scale, Lights Out, loupe information overlay, and crop guides. These preferences change the workspace appearance without changing exported pixels.", "Files & Metadata controls portable LightTable edits beside originals, automatic XMP writing, RAW/JPEG pairing, and keyword entry. Complete portable edits use .lighttable-state.json; XMP carries compatible edits and metadata."]},
-      {"title": "Defaults for unedited photos", "paragraphs": ["Develop Defaults apply only to photos that do not already have saved edits. They can start Film enabled, choose a workflow and neutral Develop profile, and apply a default preset."], "steps": ["Open Settings → Develop Defaults.", "Choose the starting Film, workflow, profile, and preset settings.", "To set camera-specific RAW defaults, open a RAW photo and adjust its RAW settings.", "Choose matching by camera model, serial number, or camera and ISO, then click Use current RAW settings.", "Use Reset in the Current camera area to remove that camera default."]}
+    "keywords": [
+      "settings",
+      "preferences",
+      "defaults",
+      "camera",
+      "raw",
+      "serial",
+      "iso",
+      "font",
+      "background",
+      "lights out",
+      "notifications",
+      "xmp",
+      "portable"
     ],
-    "related": ["keyboard-midi", "photo-index", "performance-previews", "catalog-health-recovery"],
+    "sections": [
+      {
+        "title": "Interface and behavior",
+        "paragraphs": [
+          "Settings changes save automatically. General controls Auto-advance after picking, rejecting, or rating, completion notifications, and update checks.",
+          "Interface controls the viewer background, font scale, Lights Out, loupe information overlay, and crop guides. These preferences change the workspace appearance without changing exported pixels.",
+          "Files & Metadata controls portable LightTable edits beside originals, automatic XMP writing, RAW/JPEG pairing, and keyword entry. Complete portable edits use .lighttable-state.json; XMP carries compatible edits and metadata."
+        ]
+      },
+      {
+        "title": "Defaults for unedited photos",
+        "paragraphs": [
+          "Develop Defaults apply only to photos that do not already have saved edits. They can start Film enabled, choose a workflow and neutral Develop profile, and apply a default preset."
+        ],
+        "steps": [
+          "Open Settings → Develop Defaults.",
+          "Choose the starting Film, workflow, profile, and preset settings.",
+          "To set camera-specific RAW defaults, open a RAW photo and adjust its RAW settings.",
+          "Choose matching by camera model, serial number, or camera and ISO, then click Use current RAW settings.",
+          "Use Reset in the Current camera area to remove that camera default."
+        ]
+      }
+    ],
+    "related": [
+      "keyboard-midi",
+      "photo-index",
+      "performance-previews",
+      "catalog-health-recovery"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Changes save automatically."},
-      {"path": "web/index.html", "anchor": "Applied only to photos that do not already have saved edits."},
-      {"path": "web/index.html", "anchor": "Tune the editing canvas without changing exported pixels."},
-      {"path": "web/index.html", "anchor": "Complete edits travel in .lighttable-state.json when you copy the folder."},
-      {"path": "web/index.html", "anchor": "Match camera defaults by"},
-      {"path": "web/settings.js", "anchor": "byId('settingsSaveCameraDefault').disabled = !raw;"}
+      {
+        "path": "web/index.html",
+        "anchor": "Changes save automatically."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Applied only to photos that do not already have saved edits."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Tune the editing canvas without changing exported pixels."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Complete edits travel in .lighttable-state.json when you copy the folder."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Match camera defaults by"
+      },
+      {
+        "path": "web/settings.js",
+        "anchor": "byId('settingsSaveCameraDefault').disabled = !raw;"
+      }
     ]
   },
   {
@@ -256,20 +907,78 @@
     "title": "Use keyboard shortcuts and MIDI controls",
     "category": "Settings",
     "summary": "Find shortcuts, choose a keyboard scheme, and map a hardware controller where Web MIDI is available.",
-    "keywords": ["keyboard", "shortcut", "hotkey", "midi", "knob", "fader", "controller", "speed keys", "automation", "classic", "lighttable"],
-    "sections": [
-      {"title": "Keyboard preferences", "paragraphs": ["Settings → Shortcuts & Hardware contains the shortcut scheme and a keyboard reference under Keyboard and MIDI controls. The desktop Help menu also has Keyboard Shortcuts.", "Choose LightTable or Classic; the scheme applies after a reload. Hold-key slider control lets you hold a mapped key while scrolling or using arrow keys. Allow automation controls whether approved local tools can control the window with history and Undo."], "tips": ["Command/Ctrl+Shift+E opens Export; Command/Ctrl+E opens external editing. Text fields keep ordinary typing behavior, so leave a text field before using unmodified editing shortcuts."]},
-      {"title": "MIDI mapping", "paragraphs": ["MIDI support depends on the Web MIDI API in the current runtime. The status can show Unavailable, Off, No devices, or a connected device count. Unavailable means this runtime cannot use the MIDI controls."], "steps": ["Connect a MIDI controller that sends Control Change messages.", "When MIDI is available, open Keyboard and MIDI controls and choose MIDI Learn.", "Click the adjustment slider you want to map, then turn a knob or move a fader.", "Check the mapping message, then use the hardware control to adjust the slider.", "Use Reset MIDI to restore the default mappings."]}
+    "keywords": [
+      "keyboard",
+      "shortcut",
+      "hotkey",
+      "midi",
+      "knob",
+      "fader",
+      "controller",
+      "speed keys",
+      "automation",
+      "classic",
+      "lighttable"
     ],
-    "related": ["settings-and-defaults", "export-photos", "external-editor"],
+    "sections": [
+      {
+        "title": "Keyboard preferences",
+        "paragraphs": [
+          "Settings → Shortcuts & Hardware contains the shortcut scheme and a keyboard reference under Keyboard and MIDI controls. The desktop Help menu also has Keyboard Shortcuts.",
+          "Choose LightTable or Classic; the scheme applies after a reload. Hold-key slider control lets you hold a mapped key while scrolling or using arrow keys. Allow automation controls whether approved local tools can control the window with history and Undo."
+        ],
+        "tips": [
+          "Command/Ctrl+Shift+E opens Export; Command/Ctrl+E opens external editing. Text fields keep ordinary typing behavior, so leave a text field before using unmodified editing shortcuts."
+        ]
+      },
+      {
+        "title": "MIDI mapping",
+        "paragraphs": [
+          "MIDI support depends on the Web MIDI API in the current runtime. The status can show Unavailable, Off, No devices, or a connected device count. Unavailable means this runtime cannot use the MIDI controls."
+        ],
+        "steps": [
+          "Connect a MIDI controller that sends Control Change messages.",
+          "When MIDI is available, open Keyboard and MIDI controls and choose MIDI Learn.",
+          "Click the adjustment slider you want to map, then turn a knob or move a fader.",
+          "Check the mapping message, then use the hardware control to adjust the slider.",
+          "Use Reset MIDI to restore the default mappings."
+        ]
+      }
+    ],
+    "related": [
+      "settings-and-defaults",
+      "export-photos",
+      "external-editor"
+    ],
     "sources": [
-      {"path": "web/app.js", "anchor": "toast('Shortcut scheme applies after a reload');"},
-      {"path": "web/index.html", "anchor": "Hold a mapped key and scroll or use arrow keys."},
-      {"path": "web/index.html", "anchor": "Let approved local tools control this window with visible history and Undo."},
-      {"path": "web/midi.js", "anchor": "pill.title = 'Web MIDI API not supported in this browser';"},
-      {"path": "web/midi.js", "anchor": "if (status !== 0xb0) return;"},
-      {"path": "web/midi.js", "anchor": "showMidiHud(`Turn any knob to map → ${target.label || target.control}`);"},
-      {"path": "app/main.swift", "anchor": "addEditorItem(helpMenu, title: \"Keyboard Shortcuts\","}
+      {
+        "path": "web/app.js",
+        "anchor": "toast('Shortcut scheme applies after a reload');"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Hold a mapped key and scroll or use arrow keys."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Let approved local tools control this window with visible history and Undo."
+      },
+      {
+        "path": "web/midi.js",
+        "anchor": "pill.title = 'Web MIDI API not supported in this browser';"
+      },
+      {
+        "path": "web/midi.js",
+        "anchor": "if (status !== 0xb0) return;"
+      },
+      {
+        "path": "web/midi.js",
+        "anchor": "showMidiHud(`Turn any knob to map → ${target.label || target.control}`);"
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "addEditorItem(helpMenu, title: \"Keyboard Shortcuts\","
+      }
     ]
   },
   {
@@ -277,19 +986,71 @@
     "title": "Enable private photo-content search",
     "category": "Settings",
     "summary": "Build an on-device index of objects, scenes, visible text, and faces.",
-    "keywords": ["ai", "search", "index", "contents", "objects", "scenes", "ocr", "text", "faces", "privacy", "local", "description"],
-    "sections": [
-      {"title": "Build the index", "paragraphs": ["The Photo Index is off by default. Analysis stays on this Mac and does not modify photo folders. Apple Vision provides the core analysis; richer Foundation Models descriptions appear only when that capability is available."], "steps": ["Open Settings → Photo Index.", "Check the On-device capabilities status and turn on Photo contents index.", "Wait for indexing progress to complete. Photos can gain results as they are indexed.", "Use the library search field to search photo contents, visible text, or faces alongside filenames and keywords.", "Open Info → On-device description to inspect the current photo’s generated tags, visible text, and face count."]},
-      {"title": "Pause, rebuild, or delete", "paragraphs": ["Turning the index off pauses analysis and removes generated results from the active search view; existing index data remains local until deleted. Rebuild index reruns indexing when the feature is enabled.", "Delete index removes generated index data after confirmation. Originals and saved edits are unchanged. If Apple Vision says Build required, the current installation lacks the required local analyzer. Foundation Models may be unavailable while basic Vision indexing remains usable."]}
+    "keywords": [
+      "ai",
+      "search",
+      "index",
+      "contents",
+      "objects",
+      "scenes",
+      "ocr",
+      "text",
+      "faces",
+      "privacy",
+      "local",
+      "description"
     ],
-    "related": ["assisted-culling", "settings-and-defaults"],
+    "sections": [
+      {
+        "title": "Build the index",
+        "paragraphs": [
+          "The Photo Index is off by default. Analysis stays on this Mac and does not modify photo folders. Apple Vision provides the core analysis; richer Foundation Models descriptions appear only when that capability is available."
+        ],
+        "steps": [
+          "Open Settings → Photo Index.",
+          "Check the On-device capabilities status and turn on Photo contents index.",
+          "Wait for indexing progress to complete. Photos can gain results as they are indexed.",
+          "Use the library search field to search photo contents, visible text, or faces alongside filenames and keywords.",
+          "Open Info → On-device description to inspect the current photo’s generated tags, visible text, and face count."
+        ]
+      },
+      {
+        "title": "Pause, rebuild, or delete",
+        "paragraphs": [
+          "Turning the index off pauses analysis and removes generated results from the active search view; existing index data remains local until deleted. Rebuild index reruns indexing when the feature is enabled.",
+          "Delete index removes generated index data after confirmation. Originals and saved edits are unchanged. If Apple Vision says Build required, the current installation lacks the required local analyzer. Foundation Models may be unavailable while basic Vision indexing remains usable."
+        ]
+      }
+    ],
+    "related": [
+      "assisted-culling",
+      "settings-and-defaults"
+    ],
     "sources": [
-      {"path": "web/index.html", "anchor": "Analysis stays on this Mac and never modifies photo folders."},
-      {"path": "web/app.js", "anchor": "'Objects, scenes, visible text, and faces';"},
-      {"path": "web/app.js", "anchor": "'Search photos, contents, text, and faces'"},
-      {"path": "web/app.js", "anchor": "indexed ${S.ai.indexed === 1 ? 'photo remains' : 'photos remain'} local until deleted."},
-      {"path": "web/app.js", "anchor": "Delete the generated local photo index? Your originals and edits will not be changed."},
-      {"path": "film_lab_ai/providers.py", "anchor": "the local Vision analyzer has not been built"}
+      {
+        "path": "web/index.html",
+        "anchor": "Analysis stays on this Mac and never modifies photo folders."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "'Objects, scenes, visible text, and faces';"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "'Search photos, contents, text, and faces'"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "indexed ${S.ai.indexed === 1 ? 'photo remains' : 'photos remain'} local until deleted."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "Delete the generated local photo index? Your originals and edits will not be changed."
+      },
+      {
+        "path": "film_lab_ai/providers.py",
+        "anchor": "the local Vision analyzer has not been built"
+      }
     ]
   },
   {
@@ -297,19 +1058,70 @@
     "title": "Review assisted culling suggestions",
     "category": "Settings",
     "summary": "Review local analysis signals and apply pick or reject flags only when you choose.",
-    "keywords": ["cull", "culling", "ai", "selects", "rejects", "sharpness", "eyes", "misfire", "documents", "review", "flags"],
-    "sections": [
-      {"title": "Review signals", "paragraphs": ["Assisted culling uses the private Photo Index. It does not flag photos until you ask it to. A photo matches a group if any of your chosen criteria returns yes; not judged means that signal has no usable verdict."], "steps": ["Enable Photo Index in Settings and wait for photos to be scored.", "Expand Assisted culling in the library sidebar.", "Choose Select criteria such as Subject sharpness, Eye sharpness, or Eyes open, or Reject criteria such as Exposure issues, Misfires, or Documents.", "Use Selects, Rejects, or All to review the matching photos.", "Inspect the suggestions, then use Pick selects or Reject rejects if you want to apply those flags."]},
-      {"title": "Applying flags", "paragraphs": ["The confirmation shows the affected count and warns that existing flags on matching photos will be replaced. Linked RAW/JPEG metadata can also include the paired file when that preference is enabled.", "These are analysis signals for your review, not final judgments about which photographs to keep. Rejecting sets a flag; it does not itself move originals to Trash."]}
+    "keywords": [
+      "cull",
+      "culling",
+      "ai",
+      "selects",
+      "rejects",
+      "sharpness",
+      "eyes",
+      "misfire",
+      "documents",
+      "review",
+      "flags"
     ],
-    "related": ["photo-index", "settings-and-defaults"],
+    "sections": [
+      {
+        "title": "Review signals",
+        "paragraphs": [
+          "Assisted culling uses the private Photo Index. It does not flag photos until you ask it to. A photo matches a group if any of your chosen criteria returns yes; not judged means that signal has no usable verdict."
+        ],
+        "steps": [
+          "Enable Photo Index in Settings and wait for photos to be scored.",
+          "Expand Assisted culling in the library sidebar.",
+          "Choose Select criteria such as Subject sharpness, Eye sharpness, or Eyes open, or Reject criteria such as Exposure issues, Misfires, or Documents.",
+          "Use Selects, Rejects, or All to review the matching photos.",
+          "Inspect the suggestions, then use Pick selects or Reject rejects if you want to apply those flags."
+        ]
+      },
+      {
+        "title": "Applying flags",
+        "paragraphs": [
+          "The confirmation shows the affected count and warns that existing flags on matching photos will be replaced. Linked RAW/JPEG metadata can also include the paired file when that preference is enabled.",
+          "These are analysis signals for your review, not final judgments about which photographs to keep. Rejecting sets a flag; it does not itself move originals to Trash."
+        ]
+      }
+    ],
+    "related": [
+      "photo-index",
+      "settings-and-defaults"
+    ],
     "sources": [
-      {"path": "web/app.js", "anchor": "Nothing is flagged until you ask for it."},
-      {"path": "web/local-ai.js", "anchor": "True when any of the chosen criteria answered yes for this photo."},
-      {"path": "web/index.html", "anchor": "<summary>Assisted culling</summary>"},
-      {"path": "web/app.js", "anchor": "Existing flags on those photos are replaced."},
-      {"path": "web/app.js", "anchor": "const targets = linkedMetadataTargets(cullResults(group));"},
-      {"path": "web/app.js", "anchor": "for (const image of targets) enqueuePhotoPatch(image, { status });"}
+      {
+        "path": "web/app.js",
+        "anchor": "Nothing is flagged until you ask for it."
+      },
+      {
+        "path": "web/local-ai.js",
+        "anchor": "True when any of the chosen criteria answered yes for this photo."
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "<summary>Assisted culling</summary>"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "Existing flags on those photos are replaced."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "const targets = linkedMetadataTargets(cullResults(group));"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "for (const image of targets) enqueuePhotoPatch(image, { status });"
+      }
     ]
   },
   {
@@ -317,19 +1129,85 @@
     "title": "Improve preview speed and check image detail",
     "category": "Troubleshooting",
     "summary": "Choose preview resolution, wait for real detail, and manage generated caches.",
-    "keywords": ["performance", "slow", "blurry", "pixelated", "preview", "resolution", "100%", "1:1", "gpu", "rust", "python", "cache", "purge"],
-    "sections": [
-      {"title": "Check what has finished rendering", "paragraphs": ["A 100% zoom setting does not guarantee that full image detail has arrived. The viewer may show Loading 100% detail…, Refining RAW detail…, or Updating preview detail… while it works. Wait for 100% detail ready when assessing fine detail.", "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."], "steps": ["Open Settings → Performance.", "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.", "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.", "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."]},
-      {"title": "Manage cache storage", "paragraphs": ["Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.", "Preview resolution is separate from the Dimensions setting used for exported files."]}
+    "keywords": [
+      "performance",
+      "slow",
+      "blurry",
+      "pixelated",
+      "preview",
+      "resolution",
+      "100%",
+      "1:1",
+      "gpu",
+      "rust",
+      "python",
+      "cache",
+      "purge"
     ],
-    "related": ["film-grain-and-format", "export-format-color-space", "catalog-health-recovery"],
+    "sections": [
+      {
+        "title": "Check what has finished rendering",
+        "paragraphs": [
+          "A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. The steady status badge shows Applying film…, Refining RAW detail…, or Updating preview detail… as needed, and stays visible until the requested preview is displayed. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.",
+          "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."
+        ],
+        "steps": [
+          "Open Settings → Performance.",
+          "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.",
+          "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.",
+          "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."
+        ]
+      },
+      {
+        "title": "Manage cache storage",
+        "paragraphs": [
+          "Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.",
+          "Preview resolution is separate from the Dimensions setting used for exported files."
+        ]
+      }
+    ],
+    "related": [
+      "film-grain-and-format",
+      "export-format-color-space",
+      "catalog-health-recovery"
+    ],
     "sources": [
-      {"path": "web/preview-detail.js", "anchor": "if (delivered >= source - 1) return '100% detail ready';"},
-      {"path": "web/preview-detail.js", "anchor": "if (refining) return 'Refining RAW detail…';"},
-      {"path": "web/view-performance.js", "anchor": "if (actualSize) return Math.max(64, Math.min(8000, source || 1100));"},
-      {"path": "web/index.html", "anchor": "Auto · fit display"},
-      {"path": "web/settings.js", "anchor": "Purge generated previews and render caches? Originals and edits are not affected."},
-      {"path": "web/app.js", "anchor": "pythonOption.disabled = rustOnly;"}
+      {
+        "path": "web/preview-detail.js",
+        "anchor": "if (delivered >= source - 1) return '100% detail ready';"
+      },
+      {
+        "path": "web/preview-detail.js",
+        "anchor": "if (refining) return 'Refining RAW detail…';"
+      },
+      {
+        "path": "web/view-performance.js",
+        "anchor": "if (actualSize) return Math.max(64, Math.min(8000, source || 1100));"
+      },
+      {
+        "path": "web/index.html",
+        "anchor": "Auto · fit display"
+      },
+      {
+        "path": "web/settings.js",
+        "anchor": "Purge generated previews and render caches? Originals and edits are not affected."
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "pythonOption.disabled = rustOnly;"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "previewProgress.start('Refining RAW detail…');"
+      },
+      {
+        "path": "web/preview-progress.js",
+        "anchor": "export function createPreviewProgress"
+      },
+      {
+        "path": "web/preview-progress.js",
+        "anchor": "export async function waitForRawRefinement"
+      }
     ]
   },
   {

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -11,7 +11,7 @@
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
@@ -20,7 +20,7 @@
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -43,14 +43,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -64,7 +64,7 @@
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -73,7 +73,7 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
@@ -86,7 +86,7 @@
     "editing-curves": {
       "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -95,7 +95,7 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -103,14 +103,14 @@
       "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
@@ -118,7 +118,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -126,21 +126,21 @@
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "7702f31a22aca801cec4d6985a696f77e4d038fb86613ba1953b2590cd855434",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -150,7 +150,7 @@
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -164,28 +164,28 @@
     "editing-remove-heal": {
       "content": "41b396a3d13fa3364bd68d63aec838869e50787b3e2a7ab68a5cf4530af3fbf7",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -193,7 +193,7 @@
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -201,7 +201,7 @@
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -216,29 +216,29 @@
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "film-getting-started": {
-      "content": "40ee07cc67a0c1adc8399b5637ce2013db09cb112ceb00513b673006e42bddf8",
+      "content": "7af7f00182841a2a3a740f0bfd08592ebca2553556c00e9ed7544cf2259f23f7",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
@@ -254,7 +254,7 @@
       "content": "f02ee05d45129d688db98d5b9f91ecb520904e7a508b12926168955ba9bb120d",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -262,7 +262,7 @@
       "content": "58fd1a72df074b9eba7c45f90e5d34f9d817c60977dfbd42a93ef0ada8fe02bb",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
@@ -270,14 +270,14 @@
     "film-reference-match": {
       "content": "1be79ec76df974f733a333725c268d6f7314ee6f96216593dc2c0c128786e3ed",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -302,7 +302,7 @@
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
@@ -310,16 +310,17 @@
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
-      "content": "7310080ae9b9d7bfedfa16f4cc37b14892aa4390165db7e2c8ae9c3be52c14ea",
+      "content": "c0aaafaea42d873402c2b4568063738f9af58924482b9aded7e31cf4952392a5",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
+        "web/preview-progress.js": "617276bc15d8b07945c9b7698f55932f62b77ec41f853c006b1622320814841a",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
       }
@@ -328,14 +329,14 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -351,7 +352,7 @@
     "search-filter-sort": {
       "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/library-filters.js": "ce5a8b7272b19301b684af76675ec25ea87f53f2e76fdaea17ef1c99f1116825",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
@@ -367,7 +368,7 @@
     "shortcut-schemes": {
       "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
@@ -375,7 +376,7 @@
     "smart-collections": {
       "content": "811716ffcdf02245d65b07cf0f3a60a85ba2fa11c540ce4a9d5993086a311bef",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
@@ -383,14 +384,14 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
       }
     },
@@ -399,13 +400,13 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576"
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1"
       }
     },
     "views-and-selection": {
       "content": "7412cdc7f39cc344f7b438ad008a5661ec18d13009da7cbbe2a405bf6a5e710b",
       "sources": {
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576",
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1",
         "web/index.html": "bb3fbd79ca4234b0051724c25a24dc3625ef8fdf9d377c1887b2e3ff0c461aef"
       }
     },
@@ -413,7 +414,7 @@
       "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
         "library_workflow.py": "9dfeb6839e0970471158d6abab48c867f4ec408748fde056d0fd721ec5e5009a",
-        "web/app.js": "0e068af795fa9db3329459b2c6adf1965e552a1bcdc0c178fa401eb1865ab576"
+        "web/app.js": "f10598623f33117392829dfab7ffd982f45e3a0fc2a5921c50566c936a3770b1"
       }
     }
   },

--- a/tests/preview-progress.test.mjs
+++ b/tests/preview-progress.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../web/preview-progress.js', import.meta.url), 'utf8');
+const { createPreviewProgress, waitForRawRefinement } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`);
+const appSource = readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+const renderSource = appSource.match(/^async function doRender\([^]*?^}/m)[0];
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+function clock() {
+  let time = 0, id = 0;
+  const timers = new Map();
+  return {
+    now: () => time,
+    schedule: (fn, delay) => { timers.set(++id, { fn, at: time + delay }); return id; },
+    cancel: id => timers.delete(id),
+    advance(ms) {
+      const end = time + ms;
+      for (;;) {
+        const next = [...timers].sort((a, b) => a[1].at - b[1].at)[0];
+        if (!next || next[1].at > end) break;
+        time = next[1].at; timers.delete(next[0]); next[1].fn();
+      }
+      time = end;
+    },
+  };
+}
+
+test('quick cache hits never show; draft, decode, and final paint share a steady badge', () => {
+  const timer = clock(), updates = [];
+  const progress = createPreviewProgress(state => updates.push(state), timer);
+  progress.start('Applying film…'); timer.advance(40); progress.finish();
+  timer.advance(500);
+  assert.ok(updates.every(state => !state.visible));
+  progress.start('Applying film…'); timer.advance(150);
+  const shown = updates.length - 1;
+  progress.start('Refining RAW detail…'); timer.advance(2000);
+  progress.start('Finishing RAW preview…'); timer.advance(100);
+  progress.finish(); timer.advance(100);
+  progress.start('Updating preview detail…'); timer.advance(1000);
+  assert.ok(updates.slice(shown).every(state => state.visible));
+  progress.finish(); timer.advance(140);
+  assert.equal(updates.at(-1).visible, false);
+});
+
+test('visible work holds for a minimum duration and errors clear busy immediately', () => {
+  const timer = clock(), updates = [];
+  const progress = createPreviewProgress(state => updates.push(state), timer);
+  progress.start('Working'); timer.advance(150); progress.finish();
+  timer.advance(399); assert.equal(updates.at(-1).visible, true);
+  timer.advance(1); assert.equal(updates.at(-1).visible, false);
+  progress.start('Working'); timer.advance(150);
+  progress.finish({ error: 'Could not finish preview' });
+  assert.deepEqual(updates.at(-1), { active: false, visible: true, label: 'Could not finish preview' });
+  progress.start('Next photo'); timer.advance(500);
+  assert.equal(updates.at(-1).label, 'Next photo');
+});
+
+test('RAW polling stops on navigation, failure, or the retry limit', async () => {
+  let current = true, calls = 0;
+  const result = await waitForRawRefinement({
+    isCurrent: () => current,
+    request: async () => { calls++; current = false; return { ready: true }; },
+  });
+  assert.equal(result, false); assert.equal(calls, 1);
+  await assert.rejects(waitForRawRefinement({ isCurrent: () => true,
+    request: async () => ({ error: 'decode failed' }) }), /decode failed/);
+  await assert.rejects(waitForRawRefinement({ isCurrent: () => true,
+    request: async () => ({ ready: false }), maxAttempts: 3, sleep: async () => {} }), /could not finish/);
+});
+
+// Run the actual orchestration with only HTTP and display boundaries stubbed.
+// A slow decode spans several polls; no new render may invalidate its generation.
+function renderHarness() {
+  const S = { seq: 0, params: { profile_enabled: true }, renderState: 'ready',
+    presentedPhotoName: 'photo.dng', optics: {}, heals: [] };
+  const requests = [], displays = [], progress = [], nodes = new Map();
+  const noop = () => {};
+  let finishDecode, finishPaint;
+  const context = {
+    S, performance, console, setTimeout, clearTimeout, CLIENT_ID: 'review',
+    prefetchTimer: null, refineTimer: null, viewportRegionTimer: null,
+    interactiveRenderPhoto: 'photo.dng', lastContinuousInputAt: -Infinity,
+    INTERACTIVE_PREVIEW_WIDTH: 1100, FULL_RESOLUTION_SETTLE_MS: 200,
+    PERF: { renders: [] }, window: { dispatchEvent: noop },
+    CustomEvent: class { constructor(type, detail) { this.detail = detail; } },
+    cur: () => ({ name: 'photo.dng' }),
+    $: id => { if (!nodes.has(id)) nodes.set(id, { value: id === 'pw' ? '2200' : 'rs' }); return nodes.get(id); },
+    readControls: noop, requestedPreviewWidth: () => 2200,
+    requestedViewportRegion: () => null, nativePreviewActive: () => false,
+    renderRequestKey: () => 'key', presentationCache: { get: noop, set: noop },
+    previewGeometryKey: noop, shouldPreservePresentationGeometry: () => true,
+    previewProgress: { start: label => progress.push(label), finish: () => progress.push('done') },
+    waitForRawRefinement: options => waitForRawRefinement({ ...options, sleep: async () => {} }),
+    api: async (path, body) => {
+      requests.push({ path, generation: body.generation });
+      if (path === '/api/refine') {
+        if (requests.filter(r => r.path === path).length < 4) return { ready: false };
+        return new Promise(resolve => { finishDecode = () => resolve({ ready: true }); });
+      }
+      return { refining: body.generation === 1, cached: false, ms: 10 };
+    },
+    setBaseImage: async (m, generation) => {
+      displays.push(generation);
+      return new Promise(resolve => { finishPaint = () => resolve({ presentedAt: performance.now(), uploadedAt: performance.now() }); });
+    },
+    setRenderPresentation: noop, drawGrade: noop, syncOpticsPanel: noop,
+    syncBrowserOriginal: noop, prefetch: noop,
+  };
+  vm.runInNewContext(`${renderSource}\nglobalThis.render = doRender;`, context);
+  return { ...context, requests, displays, progress,
+    finishDecode: () => finishDecode(), finishPaint: () => finishPaint() };
+}
+
+test('actual RAW render waits on one generation, retains accurate pixels, and finishes after paint', async () => {
+  const app = renderHarness();
+  const rendered = app.render();
+  await tick();
+  assert.deepEqual(app.requests.map(r => r.path), ['/api/render', ...Array(4).fill('/api/refine')]);
+  assert.ok(app.requests.every(r => r.generation === 1));
+  assert.deepEqual(app.displays, [], 'draft must not replace existing accurate pixels');
+  assert.ok(!app.progress.includes('done'));
+  app.finishDecode(); await tick();
+  assert.equal(app.requests.at(-1).path, '/api/render');
+  assert.equal(app.requests.at(-1).generation, 2);
+  assert.deepEqual(app.displays, [2]);
+  assert.ok(!app.progress.includes('done'), 'HTTP response is not presentation completion');
+  app.finishPaint(); await rendered;
+  assert.equal(app.progress.at(-1), 'done');
+});
+
+test('obsolete RAW completion neither renders nor hides progress for the new photo', async () => {
+  const app = renderHarness();
+  const rendered = app.render(); await tick();
+  app.S.seq++;
+  app.finishDecode(); await rendered;
+  assert.equal(app.requests.filter(r => r.path === '/api/render').length, 1);
+  assert.ok(!app.progress.includes('done'));
+});

--- a/tests/test_preview_progress.py
+++ b/tests/test_preview_progress.py
@@ -1,0 +1,14 @@
+"""Run the browser progress and RAW refinement orchestration regressions."""
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+@unittest.skipUnless(shutil.which('node'), 'Node.js required')
+class PreviewProgressTests(unittest.TestCase):
+    def test_preview_progress(self):
+        result = subprocess.run(
+            ['node', '--test', str(Path(__file__).with_name('preview-progress.test.mjs'))],
+            capture_output=True, text=True, timeout=20)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/web/app.js
+++ b/web/app.js
@@ -13,6 +13,7 @@ import { createAppState, cloneValue } from '/web/state.js';
 import { createEditSaveQueue } from '/web/edit-save-queue.js';
 import { createPhotoUndoHistory } from '/web/photo-undo.js';
 import { previewDetailLabel } from '/web/preview-detail.js';
+import { createPreviewProgress, waitForRawRefinement } from '/web/preview-progress.js';
 import { installCaptureTime, captureSortValue } from '/web/capture-time.js';
 import { TRANSFER_GROUPS, transferChoices, transferPatch, regenerateTransferMasks,
   cropGeometry, restoreCropGeometry } from '/web/edit-transfer.js';
@@ -2656,12 +2657,11 @@ $('editOverlay').addEventListener('pointerleave', () => {
 });
 
 /* ------------------------------------------------------------ film render */
-let spinTimer = null;
-function spin(on) {
-  clearTimeout(spinTimer);
-  if (on) spinTimer = setTimeout(() => $('cmp').classList.add('loading'), 90);
-  else $('cmp').classList.remove('loading');
-}
+const previewProgress = createPreviewProgress((progress) => {
+  S.previewProgress = progress;
+  $('zoomwrap').setAttribute('aria-busy', String(progress.active));
+  syncPreviewDetailStatus();
+});
 
 function previewGeometryKey(name, rotate = 0) {
   const quarterTurns = ((Math.round((+rotate || 0) / 90) % 4) + 4) % 4;
@@ -2674,16 +2674,21 @@ function shouldPreservePresentationGeometry(phase, previousKey, nextKey) {
 
 function syncPreviewDetailStatus() {
   const image = cur(), detail = S.previewDetail?.name === image?.name ? S.previewDetail : {};
-  const label = previewDetailLabel({ ...detail, state: S.renderState,
+  const detailLabel = previewDetailLabel({ ...detail, state: S.renderState,
     source: Math.max(+image?.width || 0, +image?.height || 0), actual: S.zoomMode === '100' });
+  const progress = S.previewProgress;
+  const label = progress?.visible ? progress.label : progress?.active ? '' : detailLabel;
   $('previewDetailStatus').textContent = image ? label : '';
   $('previewDetailStatus').hidden = !image || !label;
-  $('zoom1').title = label || 'View actual pixels (100%) to assess sharpness and noise';
+  $('previewDetailStatus').classList.toggle('working', Boolean(progress?.visible && progress?.active));
+  $('zoom1').title = detailLabel || 'View actual pixels (100%) to assess sharpness and noise';
 }
 function setRenderPresentation(state, name = cur()?.name, message = '') {
   if (name && cur()?.name !== name) return;
   S.renderState = state;
   S.renderName = name || null;
+  if (state === 'pending') previewProgress.start('Loading preview…');
+  else if (state === 'empty') previewProgress.finish({ immediate: true });
   syncPreviewDetailStatus();
   if (state === 'ready') {
     S.hasPresentedImage = true;
@@ -2706,7 +2711,6 @@ function setRenderPresentation(state, name = cur()?.name, message = '') {
 let automaticPreviewTimer = null;
 let automaticPreviewRequest = null;
 let renderTimer = null;
-let refineTimer = null;
 let settleRenderTimer = null;
 let lastInteractiveRenderAt = -Infinity;
 let lastContinuousInputAt = -Infinity;
@@ -3311,7 +3315,6 @@ function renderPhysicalPreview() {
 
 async function doRender(scheduledAt = performance.now(), options = {}) {
   clearTimeout(prefetchTimer);
-  clearTimeout(refineTimer);
   // A pending helper is left alone. Its own generation guard drops a
   // superseded fetch, while the early return below happens before the
   // generation is bumped, so cancelling here stranded the sampling surface.
@@ -3339,7 +3342,9 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
     requestStartedAt - lastContinuousInputAt < FULL_RESOLUTION_SETTLE_MS;
   $('rstat').textContent = 'rendering…';
   $('rstat').className = 'busy';
-  spin(true);
+  previewProgress.start(phase === 'refinement' ? 'Finishing RAW preview…'
+    : phase === 'settled' && S.presentedPhotoName === im.name ? 'Updating preview detail…'
+    : S.params.profile_enabled ? 'Applying film…' : 'Loading preview…');
   try {
     const request = {
       name: im.name, params: S.params, w, engine: $('engine').value,
@@ -3368,9 +3373,14 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       });
     }
     if (my !== S.seq) return;
-    if (m.cancelled) return;
-    spin(false);
+    if (m.cancelled) {
+      previewProgress.finish({ immediate: true });
+      $('rstat').textContent = '';
+      $('rstat').className = '';
+      return;
+    }
     if (m.error) {
+      previewProgress.finish({ error: 'Could not render preview' });
       $('rstat').textContent = 'error: ' + m.error;
       $('rstat').className = '';
       if (S.renderState === 'pending' && S.renderName === im.name) {
@@ -3406,6 +3416,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
         return doRender(scheduledAt, { ...options, skipPresentationCache: true });
       }
       if (imageTiming.failed) {
+        previewProgress.finish({ error: 'Could not display preview' });
         $('rstat').textContent = imageTiming.error || 'preview unavailable';
         $('rstat').className = '';
         setRenderPresentation('error', im.name, 'Could not display this photo');
@@ -3420,6 +3431,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
     }
     const paintedAt = keepAccuratePixels ? performance.now()
       : (imageTiming.presentedAt || await afterVisiblePaint());
+    if (my !== S.seq) return;
     imageTiming ||= {
       decodeMs: 0, uploadMs: 0, uploadedAt: paintedAt, presentation: 'draft-skipped',
     };
@@ -3464,6 +3476,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
     $('rstat').textContent = status + (m.refining ? ' · refining RAW…' : '');
     $('rstat').className = '';
     if (phase === 'interactive' && w !== requestedWidth) {
+      previewProgress.start(m.refining ? 'Preparing RAW detail…' : 'Updating preview detail…');
       const renderWhenIdle = () => {
         const idleFor = performance.now() - lastContinuousInputAt;
         if (idleFor < FULL_RESOLUTION_SETTLE_MS) {
@@ -3482,15 +3495,17 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       settleRenderTimer = setTimeout(
         renderWhenIdle, FULL_RESOLUTION_SETTLE_MS);
     } else if (m.refining) {
-      api('/api/refine', { name: im.name, params: S.params, w, client: CLIENT_ID, generation: my }).catch(() => {});
-      refineTimer = setTimeout(() => {
-        if (my === S.seq && cur() && cur().name === im.name) {
-          doRender(performance.now(), {
-            width: w, requestedWidth, phase: 'refinement',
-          });
-        }
-      }, 350);
-    }
+      previewProgress.start('Refining RAW detail…');
+      const refinementRequest = { name: im.name, params: { ...request.params },
+        w, client: CLIENT_ID, generation: my };
+      const ready = await waitForRawRefinement({
+        request: () => api('/api/refine', refinementRequest),
+        isCurrent: () => my === S.seq && cur()?.name === im.name,
+      });
+      if (ready) return doRender(scheduledAt, {
+        width: w, requestedWidth, phase: 'refinement',
+      });
+    } else previewProgress.finish();
     prefetch(m.refining || phase === 'interactive');
   } catch (e) {
     const failedAt = performance.now();
@@ -3512,8 +3527,8 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       });
     }
     if (my === S.seq) {
-      spin(false);
-      $('rstat').textContent = 'server unreachable on :' + location.port;
+      previewProgress.finish({ error: 'Could not finish preview' });
+      $('rstat').textContent = failure.error || 'Could not finish preview';
       $('rstat').className = '';
       if (S.renderState === 'pending' && S.renderName === im.name) {
         setRenderPresentation('error', im.name, 'Could not reach the renderer');
@@ -6275,7 +6290,6 @@ async function go(i) {
     postNative('nativePreloadReset', { epoch: generation });
   }
   clearTimeout(renderTimer);
-  clearTimeout(refineTimer);
   clearTimeout(settleRenderTimer);
   setRenderPresentation('pending', im.name);
   if (!isStateLoaded(im)) {

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -1891,7 +1891,8 @@
           "title": "What the previews include",
           "paragraphs": [
             "Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.",
-            "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file."
+            "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.",
+            "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The steady status badge explains the work still in progress. Wait for it to finish before judging fine detail."
           ],
           "tips": [
             "If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."
@@ -2576,7 +2577,7 @@
         {
           "title": "Check what has finished rendering",
           "paragraphs": [
-            "A 100% zoom setting does not guarantee that full image detail has arrived. The viewer may show Loading 100% detail…, Refining RAW detail…, or Updating preview detail… while it works. Wait for 100% detail ready when assessing fine detail.",
+            "A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. The steady status badge shows Applying film…, Refining RAW detail…, or Updating preview detail… as needed, and stays visible until the requested preview is displayed. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.",
             "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."
           ],
           "steps": [

--- a/web/preview-progress.js
+++ b/web/preview-progress.js
@@ -1,0 +1,58 @@
+// One visible status spans draft, RAW decode, and final presentation. Quick
+// cache hits stay silent; closely spaced stages never flash the badge off/on.
+export function createPreviewProgress(publish, {
+  now = () => performance.now(), schedule = setTimeout, cancel = clearTimeout,
+  showDelay = 150, minimumVisible = 400, hideDelay = 140,
+} = {}) {
+  let showTimer = null, hideTimer = null, shownAt = 0;
+  let state = { active: false, visible: false, label: '' };
+  const emit = () => publish({ ...state });
+  return {
+    start(label) {
+      cancel(hideTimer);
+      hideTimer = null;
+      state = { ...state, active: true, label };
+      if (!state.visible && showTimer === null) {
+        showTimer = schedule(() => {
+          showTimer = null;
+          shownAt = now();
+          state.visible = true;
+          emit();
+        }, showDelay);
+      }
+      emit();
+    },
+    finish({ immediate = false, error = '' } = {}) {
+      cancel(showTimer);
+      cancel(hideTimer);
+      showTimer = hideTimer = null;
+      state.active = false;
+      const hide = () => {
+        hideTimer = null;
+        state = { active: false, visible: Boolean(error), label: error };
+        emit();
+      };
+      if (error || immediate || !state.visible) return hide();
+      state.label = 'Preview ready';
+      emit();
+      hideTimer = schedule(hide, Math.max(hideDelay, minimumVisible - (now() - shownAt)));
+    },
+  };
+}
+
+// Poll the readiness endpoint with the SAME render generation. Requesting a
+// new render on every poll invalidates and can cancel the active RAW decode.
+export async function waitForRawRefinement({ request, isCurrent,
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+  maxAttempts = 360, interval = 500,
+}) {
+  for (let attempt = 0; attempt < maxAttempts && isCurrent(); attempt++) {
+    const result = await request();
+    if (!isCurrent()) return false;
+    if (result.error) throw new Error(result.error);
+    if (result.ready) return true;
+    if (attempt + 1 < maxAttempts) await sleep(interval);
+  }
+  if (isCurrent()) throw new Error('RAW preview could not finish. Try the photo again.');
+  return false;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -657,9 +657,6 @@ input[type=checkbox]:disabled { opacity:.4; }
 .tag { position:absolute; bottom:10px; padding:4px 8px; border-radius:var(--radius-s); background:rgba(0,0,0,.68); color:#fff; font-size:11px; font-weight:600; pointer-events:none; }
 .tag-l { left:10px; } .tag-r { right:10px; }
 .speed-hud { position:absolute; z-index:7; top:12px; left:50%; transform:translateX(-50%); padding:6px 12px; border-radius:var(--radius); background:rgba(16,16,16,.8); color:#fff; font-size:12px; font-weight:600; font-variant-numeric:tabular-nums; white-space:pre; pointer-events:none; box-shadow:0 2px 10px rgba(0,0,0,.4); backdrop-filter:blur(6px); }
-.cmp.loading { opacity:.76; }
-.cmp.loading::after { content:""; position:absolute; z-index:3; top:50%; left:50%; width:28px; height:28px; margin:-14px; border:2px solid rgba(255,255,255,.18); border-top-color:#fff; border-radius:50%; animation:spin .7s linear infinite; }
-@keyframes spin { to { transform:rotate(360deg); } }
 #cropLayer { position:absolute; inset:0; z-index:4; display:none; cursor:crosshair; touch-action:none; }
 #cropLayer.on { display:block; }
 .crop-dimmer { position:absolute; background:rgb(var(--crop-dim-rgb,0 0 0) / var(--crop-dim-alpha,.62)); pointer-events:none; }
@@ -1970,6 +1967,9 @@ body { display:flex; flex-direction:column; }
 .preview-detail-status { position:absolute; left:12px; bottom:12px; z-index:15;
   max-width:calc(100% - 24px); padding:5px 8px; border-radius:4px;
   color:#eee; background:rgba(18,18,18,.85); font-size:11px; pointer-events:none; }
+.preview-detail-status.working::before { content:""; display:inline-block;
+  width:6px; height:6px; margin-right:7px; vertical-align:1px;
+  border-radius:50%; background:currentColor; }
 
 .capture-time-status { white-space:pre-wrap; overflow-wrap:anywhere; max-height:220px;
   overflow:auto; font-size:11px; line-height:1.5; color:var(--ink-2); margin:10px 0; }


### PR DESCRIPTION
Turning Film on for a RAW photo could repeatedly flash the loading spinner and interrupt the accurate RAW decode by issuing a new render generation every 350 ms. Keep one steady status badge across preview stages, preserve the photo’s brightness, and poll RAW readiness with the same generation before requesting the finished preview. Loading clears only after presentation completes.

Update bundled Help to explain why an early preview can appear before final detail. Reviewed the shared-source Help references; unrelated workflow explanations remain accurate.

Validation: 91 Python tests passed, one skipped, including browser progress/refinement regressions and Help checks. A real RAW photo was verified in the browser editor: continuous status, unchanged opacity, and completion after final presentation. Native installation is handled separately by the requested fixed-main personal build.
