### PR TITLE
Hide the empty original-image overlay in comparison views

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -629,6 +629,7 @@ input[type=checkbox]:disabled { opacity:.4; }
 .native-preview-shell #cv { opacity:0; }
 .native-preview-shell.webgl-preview-fallback #cv { opacity:1; }
 #orig { position:absolute; inset:0; width:100%; height:100%; clip-path:inset(0 var(--clip,100%) 0 0); }
+#orig:not([src]) { display:none; }
 #referenceImg { position:absolute; z-index:2; inset:0; width:100%; height:100%; max-width:none; max-height:none; object-fit:fill; transform-origin:center; pointer-events:none; }
 #editOverlay { position:absolute; z-index:5; inset:0; width:100%; height:100%; max-width:none; max-height:none; pointer-events:none; touch-action:none; }
 #editOverlay.active { pointer-events:auto; cursor:crosshair; }


### PR DESCRIPTION
The WebGL comparison renderer removes the source from the legacy original-image element. Browsers can then draw a broken-image icon and its alt text over the photo. Hide that unused element while it has no source.

Verified in the real comparison view during the website screenshot recapture. The branch includes current main; its five RAW-preview tests, JavaScript syntax check, and Help check pass.
