### PR TITLE
Verify processing and preview pixels against independent references

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   unit:
     runs-on: macos-14
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,11 +41,34 @@ jobs:
           cp -R "$RUNNER_TEMP/spektrafilm-rust/data" engine/data
           cp -R "$RUNNER_TEMP/spektrafilm-python/src/spektrafilm" vendor/spektrafilm/src/spektrafilm
 
-      # The engine-parity script needs the built Rust binary and profile data,
-      # so it stays out of this job; `tests/engine_parity.py` is run from the
-      # release script instead.
       - name: Unit and contract tests
         run: PYTHONPATH=".:vendor/spektrafilm/src" python -m unittest discover -s tests -p 'test_*.py' -t tests --verbose
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: build/processing-cargo
+          key: processing-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-engine/Cargo.lock', 'rust-engine/**/Cargo.toml') }}
+      - name: Prepare the pinned browser test runtime
+        run: |
+          npm install --prefix "$RUNNER_TEMP/processing-browser" --no-save playwright@1.62.1
+          "$RUNNER_TEMP/processing-browser/node_modules/.bin/playwright" install chromium
+          echo "LIGHTTABLE_PLAYWRIGHT_MODULE=$RUNNER_TEMP/processing-browser/node_modules/playwright/index.mjs" >> "$GITHUB_ENV"
+      - name: Independent film, export, and application pixel gates
+        run: python scripts/check-processing.py --suites film,export,webgl,app
+      # A hosted runner is not evidence of an actual Metal/display session.
+      # The native gate is required by the local full command documented in
+      # PROCESSING-CORRECTNESS.md; unavailable native renderers fail that gate.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: processing-correctness
+          path: build/processing-correctness
+          if-no-files-found: warn
+          retention-days: 14
 
   installers:
     runs-on: ubuntu-latest

--- a/PROCESSING-CORRECTNESS.md
+++ b/PROCESSING-CORRECTNESS.md
@@ -1,0 +1,126 @@
+# Processing correctness
+
+Run from the repository with the normal Python runtime, reference profiles,
+Rust/Cargo, Node, and Playwright installed:
+
+```sh
+.venv/bin/python scripts/check-processing.py --film-gpu
+```
+
+This builds the current Rust source in `build/processing-cargo`, generates
+synthetic fixtures, executes independent references, and checks the production
+engines, exports, browser application, and actual Metal display frames. It uses
+an isolated photo library and runtime; it does not edit a personal catalog or
+replace the installed application.
+
+The command exits nonzero for a numerical mismatch, missing runtime, unavailable
+GPU/display, timeout, or incomplete suite. It never converts a missing native
+display into a passing skip. All requested suites must finish before the report
+can say PASS. On macOS, run outside restrictive process sandboxes in an unlocked
+graphical login with Metal available.
+
+## Evidence
+
+`build/processing-correctness/` contains:
+
+- `report.md`: suite outcomes and failures.
+- `report.json`: source hashes, revision, dirty-tree state, individual metrics,
+  tolerances, runtime identity, and artifact paths.
+- `junit.xml`: CI results; blocked suites are failures.
+- Per-case reference, actual, and amplified difference PNGs for RGB comparisons.
+- Floating-point stage arrays, requests, logs, grain statistics, and submitted
+  native drawable records. Film arrays retain their physical units.
+- Full browser-app screenshots and separate pixel-scored canvas captures.
+
+Never bless a failing output by updating a screenshot golden or increasing a
+tolerance until it passes. Locate the first divergent stage. If a reference
+contract changes intentionally, explain the model change and derive a new
+tolerance before comparing results.
+
+## What each suite establishes
+
+| Suite | Implementation under test | Independent reference and coverage |
+| --- | --- | --- |
+| `film` | Freshly built Rust resident engine, CPU diagnostic taps | Python spectral runtime at film exposure, developed film density, print exposure, developed print density, and scanned RGB; separate NumPy exposure and measured characteristic-curve checks. Isolates exposure, development gamma, dye couplers, halation, diffusion, print exposure/preflash/filters, scanner blur/sharpen/glare, reversal, and B&W development times. |
+| `film --film-gpu` | Actual WGPU film output | Verified CPU output for deterministic recipes; backend identity must say WGPU. A CPU fallback fails. Intermediate GPU buffers are not exposed, so GPU stage-by-stage equivalence is not claimed. |
+| `export` | Actual `render_cli.py` subprocesses and current Rust resident export | Independent NumPy sRGB, linear-light exposure, rotation/crop and Lanczos equations; RGB16 precision and ICC profiles. Python grading/masks independently check Rust postprocessing from the same float film base. |
+| `webgl` | Production `web/gl.js` in Chromium | Python CPU grading for individual positive/negative controls, detail/noise/sharpening, all curve channels and HSL bands, Point Color, tonal color grading and combined operation order. Scores synchronous framebuffer output and composited canvas screenshots, with navigation, portrait geometry, and compare restoration. |
+| `app` | Complete server and browser application | Real UI commands and slider/save/render paths, Film on/off, print exposure, and portrait/landscape navigation. Requires the intended saved recipe and matching ready photo. Scores the actual frame against the CLI render endpoint with an explicit reference recipe, and the visible scaled canvas against its rendered pixels. |
+| `native` | Production `NativePreview.swift` and `NativePreview.metal` in a real AppKit window | Python grading against the actual MTKView drawable submitted for display, including image edges. Exercises PNG/FLRA input, all shared grade cases, cached A/B/A navigation, compare sweeps/restoration, and portrait/landscape sizing. Requires GPU completion and drawable presentation. |
+
+The native helper compiles the production renderer and shader; it is not a
+replacement for the full native product journey. Run the existing
+`scripts/run-product-journey.sh pr` as well when changing native bridge wiring,
+window layout, or packaging. The complete browser application is exercised by
+the `app` suite; the Metal helper isolates native rendering correctness.
+
+## Reference contracts and tolerances
+
+Film stage errors use log10 exposure or optical density. Scanned RGB and
+preview tolerances are measured as 8-bit code values, even when input/output
+arrays are float. The exact limits are stored alongside every result; RGB
+preview defaults are mean <= 0.75, p95 <= 2, maximum <= 5. Maximum error matters:
+a few badly rendered border pixels must not disappear into an image-wide mean.
+
+RGB8 encoding has a half-code quantization bound. Lossless RGB16 exports use
+limits near one 16-bit code. GPU and curve texture rounding need separate
+documented limits from float CPU stages. Comparisons reject NaN, infinity,
+empty output, wrong dimensions, wrong channels, and missing artifacts.
+
+Grain is stochastic. Different samplers cannot be expected to generate the same
+individual particles. The suite instead requires exact repeatability within an
+engine and tests flat-field means and variance against analytical
+Poisson/binomial expectations. With GPU enabled it also checks CPU/GPU scan
+noise moments. Statistical regions exclude the known blur support between
+flat fields; ordinary preview image comparisons retain image edges.
+
+Browser element screenshots can include background outside a canvas whose CSS
+origin is fractional. The app check computes the photo rectangle from DOM
+geometry and compares bilinear presentation there; it does not align images by
+their contents or trim mismatched pixels to obtain a pass.
+
+These are software-equivalence tests for the declared model and fixtures, not
+proof that a simulation matches a particular physical negative, chemical bath,
+scanner, printer, or monitor. The two spectral implementations share measured
+profile data, so agreement cannot establish that the profile data are correct.
+Real-camera RAW demosaicing/WB, all stock combinations, native lens/heal/mask
+presentation, operating-system display calibration, and stochastic perceptual
+quality need additional fixtures or real-device comparisons.
+
+Active optical diffusion now uses the exact CPU PSF convolution on both render
+backends. Other supported stages remain on the selected GPU backend, but the
+diffusion recipe renders the full frame before viewport trimming. This removes
+the previous preview/export halo mismatch and can increase latency when the
+effect is enabled. The default diffusion strength is zero.
+
+## CI and focused runs
+
+Pull requests and main run the film CPU, export, WebGL, and complete browser
+app gates in `.github/workflows/python-tests.yml`, and upload failure artifacts.
+Hosted macOS runners do not stand in for a verified physical Metal/display
+session. The full local command additionally requires native and film GPU proof.
+
+```sh
+# Hosted/CPU-compatible subset (explicitly omits native and film GPU proof).
+python scripts/check-processing.py --suites film,export,webgl,app
+
+# Focus on a native shader change.
+python scripts/check-processing.py --suites native --output build/native-pixels
+
+# Scorer and reference self-tests; real engine comparisons are separate gates.
+python -m unittest discover -s tests -p 'test_processing_*.py' -v
+```
+
+Install a reproducible browser test runtime if one is not already configured:
+
+```sh
+npm install --prefix build/processing-browser --no-save playwright@1.62.1
+build/processing-browser/node_modules/.bin/playwright install chromium
+export LIGHTTABLE_PLAYWRIGHT_MODULE="$PWD/build/processing-browser/node_modules/playwright/index.mjs"
+```
+
+`LIGHTTABLE_BROWSER_EXECUTABLE` optionally selects the test Chromium executable;
+otherwise Playwright's installed browser is used. Pinned film runtime/data
+preparation is shared with the existing Python CI setup. The untracked legacy
+`engine/spektrafilm-rs` binary is deliberately not used as the film gate's
+implementation under test.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ and contract tests, Rust tests, renderer parity checks, and real macOS
 [product journeys](JOURNEY-TESTING.md). Run the checks that exercise your change
 and report what you verified.
 
+The [processing correctness pipeline](PROCESSING-CORRECTNESS.md) compares film
+stages, exports, and displayed previews with independent numerical references,
+and saves per-case pixel differences and CI reports.
+
 ## Project documentation
 
 - [Film profiles and provenance](FILM-PROFILES.md)

--- a/app/NativePreview.metal
+++ b/app/NativePreview.metal
@@ -147,6 +147,17 @@ float3 sampleEditedSource(texture2d<float> image, texture2d<float> fallback, sam
     return clamp(color, 0.0, 1.0);
 }
 
+float3 sampleEditedNeighbor(texture2d<float> image, texture2d<float> fallback, sampler linearSampler,
+                            float2 outputCoordinate, constant GradeUniforms &grade,
+                            float2 texel, float redCyan, float blueYellow) {
+    // CPU grading replicates the outermost pixel for blur/sharpen taps. Clamp
+    // in output space, before optical mapping: genuine empty areas created by
+    // rotation/distortion must still become black in sampleEditedSource.
+    float2 coordinate = clamp(outputCoordinate, texel * 0.5, 1.0 - texel * 0.5);
+    return sampleEditedSource(image, fallback, linearSampler, coordinate,
+                              grade, texel, redCyan, blueYellow);
+}
+
 float3 applyHeals(float3 color, float2 uv,
                   texture2d<float> image, texture2d<float> fallback, sampler linearSampler,
                   constant GradeUniforms &grade,
@@ -339,13 +350,13 @@ float3 localGrade(float3 color, float4 tone, float4 localColorValue,
                   float2 texel) {
     if (detail.x != 0.0 || detail.y != 0.0) {
         float3 blur = (color
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
                                  grade, texel, grade.detail1.z, grade.detail1.w)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
                                  grade, texel, grade.detail1.z, grade.detail1.w)
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, texel.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(0.0, texel.y),
                                  grade, texel, grade.detail1.z, grade.detail1.w)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, texel.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(0.0, texel.y),
                                  grade, texel, grade.detail1.z, grade.detail1.w)) / 5.0;
         float3 localDetail = color - blur;
         color = clamp(color + localDetail * detail.x * 1.1, 0.0, 1.0);
@@ -464,13 +475,13 @@ fragment float4 nativePreviewFragment(
 
     if (luminanceNoise != 0.0 || colorNoise != 0.0) {
         float3 blur = (color
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, texel.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, texel.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)) / 5.0;
         float luminance = dot(color, LUMA);
         float blurLuminance = dot(blur, LUMA);
@@ -489,13 +500,13 @@ fragment float4 nativePreviewFragment(
 
     if (texture != 0.0 || clarity != 0.0) {
         float3 blur = (color
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(texel.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, texel.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, texel.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(0.0, texel.y),
                                  grade, texel, redCyan, blueYellow)) / 5.0;
         float3 detail = color - blur;
         color = clamp(color + detail * texture * 1.1, 0.0, 1.0);
@@ -506,13 +517,13 @@ fragment float4 nativePreviewFragment(
     if (sharpness != 0.0) {
         float2 radius = texel * sharpenRadius;
         float3 blur = (color
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(radius.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(radius.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(radius.x, 0.0),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(radius.x, 0.0),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv + float2(0.0, radius.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv + float2(0.0, radius.y),
                                  grade, texel, redCyan, blueYellow)
-            + sampleEditedSource(image, fallback, linearSampler, uv - float2(0.0, radius.y),
+            + sampleEditedNeighbor(image, fallback, linearSampler, uv - float2(0.0, radius.y),
                                  grade, texel, redCyan, blueYellow)) / 5.0;
         float3 detail = color - blur;
         float luminanceDetail = dot(detail, LUMA);

--- a/rust-engine/src/region.rs
+++ b/rust-engine/src/region.rs
@@ -126,6 +126,16 @@ fn kernel_support(p: &RuntimeParams, width: u32, height: u32) -> Option<(u32, u3
     if (p.io.upscale_factor - 1.0).abs() > 1e-6 || p.io.crop {
         return None;
     }
+    // Exact diffusion uses the full-frame sampled PSF rather than the GPU
+    // Gaussian/downsample lattice. Preserve the viewport trim but render the
+    // full frame so the preview has the same halos as export.
+    if [&p.camera.diffusion_filter, &p.enlarger.diffusion_filter]
+        .into_iter()
+        .take(if p.io.scan_film { 1 } else { 2 })
+        .any(|filter| filter.active && filter.strength > 0.0 && filter.spatial_scale > 0.0)
+    {
+        return None;
+    }
     let pixel_um =
         spektrafilm_core::stages::filming::pixel_size_um(p.camera.film_format_mm, width, height);
     let mut margin = 0;
@@ -311,14 +321,12 @@ mod tests {
         }
     }
     #[test]
-    fn diffusion_crops_preserve_both_resampling_lattices() {
+    fn exact_diffusion_keeps_full_frame_and_preserves_requested_trim() {
         let mut p = pointwise();
         p.camera.diffusion_filter.active = true;
         p.camera.diffusion_filter.spatial_scale = 0.15;
         p.enlarger.diffusion_filter.active = true;
         p.enlarger.diffusion_filter.spatial_scale = 0.25;
-        let pixel_um =
-            spektrafilm_core::stages::filming::pixel_size_um(p.camera.film_format_mm, 6000, 4000);
         let region = plan(
             Rect {
                 x: 2711,
@@ -333,14 +341,9 @@ mod tests {
             true,
         )
         .unwrap();
-        assert!(region.accelerated);
-        for filter in [&p.camera.diffusion_filter, &p.enlarger.diffusion_filter] {
-            let diffusion = filter.gpu_plan(pixel_um as f64, 6000, 4000).unwrap();
-            assert_eq!(region.render.x % diffusion.d, 0);
-            assert_eq!(region.render.y % diffusion.d, 0);
-            assert_eq!(region.render.width % diffusion.d, 0);
-            assert_eq!(region.render.height % diffusion.d, 0);
-        }
+        assert!(!region.accelerated);
+        assert_eq!(region.render, Rect { x: 0, y: 0, width: 6000, height: 4000 });
+        assert_eq!(region.trim, Rect { x: 2711, y: 1987, width: 200, height: 150 });
     }
     #[test]
     fn diffusion_with_frame_sized_support_keeps_full_frame() {

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/pipeline.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/pipeline.rs
@@ -17,7 +17,7 @@ use spektrafilm_math::spectral::TcLut;
 /// pixel data to that path as a raw little-endian f64 blob. Used to
 /// bisect the Python ↔ Rust drift one stage at a time without
 /// modifying call sites. Silent no-op when the env var is unset.
-fn dump_if_env(var: &str, image: &ImageBuf) {
+pub(crate) fn dump_if_env(var: &str, image: &ImageBuf) {
     let Ok(path) = std::env::var(var) else {
         return;
     };
@@ -64,6 +64,28 @@ fn apply_film_specific_params(film: &Profile, params: &mut RuntimeParams) {
         params.film_render.dir_couplers.gamma_interlayer_r_to_gb = [0.353, 0.302];
         params.film_render.dir_couplers.gamma_interlayer_g_to_rb = [0.154, 0.353];
         params.film_render.dir_couplers.gamma_interlayer_b_to_rg = [0.168, 0.226];
+    }
+
+    // Match Python's profile-specific antihalation baseline. Leaving the
+    // generic defaults here made modern strong-AH stocks (e.g. Portra) bloom
+    // about three times too strongly and used the still-film radius for cine
+    // stocks. User amount/spatial-scale controls remain independent multipliers.
+    if film.info.support == "film" {
+        let sigma = match film.info.usage.as_str() {
+            "still" => Some(65.0),
+            "cine" => Some(50.0),
+            _ => None,
+        };
+        let strength = match film.info.antihalation.as_str() {
+            "strong" => Some([0.015, 0.005, 0.0]),
+            "weak" => Some([0.08, 0.02, 0.0]),
+            "no" => Some([0.30, 0.10, 0.015]),
+            _ => None,
+        };
+        if let (Some(sigma), Some(strength)) = (sigma, strength) {
+            params.film_render.halation.halation_first_sigma_um = [sigma; 3];
+            params.film_render.halation.halation_strength = strength;
+        }
     }
 
     // Monochrome grain is derived from the film, never user-set — clear it
@@ -724,6 +746,19 @@ impl Pipeline {
         color_ref: &crate::color_reference::ColorReference,
         film_cache_key: Option<&str>, metered_ev: Option<f32>, native_rotation: Option<spektrafilm_gpu::NativeOutputSpec>,
     ) -> Option<spektrafilm_gpu::FilmChainOutput> {
+        // The resident sum-of-Gaussians diffusion is a continuous-PSF
+        // approximation, whereas export samples and normalizes the measured
+        // 2D PSF on the pixel grid. They diverge strongly for subpixel cores
+        // (up to 59/255 at highlight edges). Use the per-stage path for active
+        // diffusion: its exact convolution runs on CPU, with other supported
+        // stages still dispatched to this GPU backend.
+        if [&self.params.camera.diffusion_filter, &self.params.enlarger.diffusion_filter]
+            .into_iter()
+            .take(if self.params.io.scan_film { 1 } else { 2 })
+            .any(|filter| filter.active && filter.strength > 0.0 && filter.spatial_scale > 0.0)
+        {
+            return None;
+        }
         // Bake the exposure scale (auto-exposure × manual EV compensation)
         // into the front-pass matrix. Both upsamplers (hanatos and mallett)
         // are homogeneous in the input RGB, so scaling the matrix is

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/stages/filming.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/stages/filming.rs
@@ -338,21 +338,13 @@ pub fn expose(
     }
 
     // Diffusion filter (camera): lens diffusion-filter PSF on linear raw.
-    // GPU uses a downsampled sum-of-Gaussians (fast preview); CPU keeps the
-    // exact FFT convolution (export parity).
+    // Use the same sampled PSF on every backend. The former GPU Gaussian
+    // approximation produced substantially different preview halos when the
+    // sharp core was smaller than one pixel.
     let df = &params.camera.diffusion_filter;
     if df.active {
         let dm = df.to_model();
-        raw = if backend.is_gpu() {
-            spektrafilm_model::diffusion::apply_diffusion_filter_blur(
-                &raw,
-                &dm,
-                pix_um as f64,
-                backend,
-            )
-        } else {
-            spektrafilm_model::diffusion::apply_diffusion_filter_um(&raw, &dm, pix_um as f64)
-        };
+        raw = spektrafilm_model::diffusion::apply_diffusion_filter_um(&raw, &dm, pix_um as f64);
     }
 
     // Lens blur

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/stages/printing.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-core/src/stages/printing.rs
@@ -262,16 +262,8 @@ pub fn expose_calibrated(
             lin.height,
         );
         let dm = edf.to_model();
-        lin = if backend.is_gpu() {
-            spektrafilm_model::diffusion::apply_diffusion_filter_blur(
-                &lin,
-                &dm,
-                pix_um as f64,
-                backend,
-            )
-        } else {
-            spektrafilm_model::diffusion::apply_diffusion_filter_um(&lin, &dm, pix_um as f64)
-        };
+        // Preview and export must use the same discretely sampled PSF.
+        lin = spektrafilm_model::diffusion::apply_diffusion_filter_um(&lin, &dm, pix_um as f64);
         lin.data.par_iter_mut().for_each(|v| {
             let x = *v as f64;
             *v = spektrafilm_math::precision::from_f64((x.max(0.0) + 1e-10).log10());
@@ -356,6 +348,7 @@ pub fn process_with_calibration(
         preflash,
         bw_print_correction,
     );
+    crate::pipeline::dump_if_env("SPEKTRAFILM_DUMP_PRINT_LOG_RAW", &log_raw);
     develop(&log_raw, print, params, backend)
 }
 

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-gpu/src/wgpu_backend.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-gpu/src/wgpu_backend.rs
@@ -17,7 +17,7 @@ fn scalars_to_f32(v: &[spektrafilm_math::precision::Scalar]) -> std::borrow::Cow
     std::borrow::Cow::Borrowed(v)
 }
 
-/// FIR Gaussian-blur half-width `ceil(3σ)`, hard-capped so a pathological σ
+/// FIR Gaussian-blur half-width `round(3σ)`, matching Python/SciPy, capped so a pathological σ
 /// can never build a multi-thousand-tap kernel that hangs the GPU (a
 /// monster kernel froze the display once). Callers that need a blur wider
 /// than this must downsample first (the diffusion filter does). 256 → at
@@ -27,7 +27,7 @@ const MAX_BLUR_RADIUS: u32 = 256;
 
 #[inline]
 fn fir_blur_radius(sigma: f32) -> u32 {
-    ((3.0_f32 * sigma).ceil() as u32).min(MAX_BLUR_RADIUS)
+    ((3.0_f32 * sigma + 0.5) as u32).min(MAX_BLUR_RADIUS)
 }
 
 #[cfg(all(feature = "wgpu-backend", feature = "precision-f64"))]

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-math/src/gaussian.rs
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-math/src/gaussian.rs
@@ -130,9 +130,7 @@ fn fir_blur_1d(
                 for x in 0..w {
                     let mut sum = ZERO;
                     for (ki, &kv) in kernel.iter().enumerate() {
-                        let sx = (x as isize + ki as isize - radius as isize)
-                            .max(0)
-                            .min(w as isize - 1) as usize;
+                        let sx = reflect_index(x as isize + ki as isize - radius as isize, w);
                         sum += row_src[sx] * kv;
                     }
                     row_dst[x] = sum;
@@ -145,14 +143,24 @@ fn fir_blur_1d(
                 for x in 0..w {
                     let mut sum = ZERO;
                     for (ki, &kv) in kernel.iter().enumerate() {
-                        let sy = (y as isize + ki as isize - radius as isize)
-                            .max(0)
-                            .min(h as isize - 1) as usize;
+                        let sy = reflect_index(y as isize + ki as isize - radius as isize, h);
                         sum += src[sy * w + x] * kv;
                     }
                     row_dst[x] = sum;
                 }
             });
+    }
+}
+
+/// Half-sample symmetry, scipy.ndimage mode='reflect': d c b a | a b c d.
+/// Repeated reflection also handles a blur wider than a one-pixel image.
+fn reflect_index(index: isize, size: usize) -> usize {
+    let period = 2 * size as isize;
+    let wrapped = index.rem_euclid(period);
+    if wrapped >= size as isize {
+        (period - 1 - wrapped) as usize
+    } else {
+        wrapped as usize
     }
 }
 
@@ -293,6 +301,34 @@ fn make_gaussian_kernel(sigma: Scalar, radius: usize) -> Vec<Scalar> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn corner_impulse_matches_scipy_reflect() {
+        // scipy.ndimage.gaussian_filter(impulse, .8, mode="reflect", truncate=3)
+        // Independent reference locks both edge semantics and kernel support.
+        let mut input = vec![from_f64(0.0); 20];
+        input[0] = from_f64(1.0);
+        let expected = [
+            0.529443326262087, 0.18222860114177347, 0.01595663598688972, 0.0, 0.0,
+            0.18222860114177344, 0.06272109105337778, 0.005492099551709124, 0.0, 0.0,
+            0.01595663598688972, 0.005492099551709125, 0.00048090932379052034, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0,
+        ];
+        let actual = gaussian_blur_channel(&input, 5, 4, 0.8);
+        for (got, want) in actual.iter().zip(expected) {
+            assert!((*got - from_f64(want)).abs() < from_f64(2e-7), "{got} vs {want}");
+        }
+    }
+
+    #[test]
+    fn reflection_handles_images_smaller_than_kernel() {
+        // Same SciPy reference, shape (1,3), sigma=1.2; reflected samples
+        // must wrap repeatedly rather than index outside the image.
+        let actual = gaussian_blur_channel(&[from_f64(1.0), ZERO, ZERO], 3, 1, 1.2);
+        for (got, want) in actual.iter().zip([0.5674439709005277, 0.3191462543634573, 0.11340977473601502]) {
+            assert!((*got - from_f64(want)).abs() < from_f64(2e-7), "{got} vs {want}");
+        }
+    }
 
     #[test]
     fn test_gaussian_kernel_normalized() {

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/gaussian_blur_h.wgsl
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/gaussian_blur_h.wgsl
@@ -1,7 +1,7 @@
 // Separable Gaussian blur — horizontal pass.
 //
 // Each thread reads `2*radius+1` samples from a row of the input image and
-// writes the convolved value to the output. Boundary handling clamps indices.
+// writes the convolved value to the output. Reflect edges like CPU/SciPy.
 //
 // Pair this with `gaussian_blur_v.wgsl` for the full 2D blur. Kernel weights
 // are pre-computed on CPU (see `gaussian_kernel` in spektrafilm-math).
@@ -32,7 +32,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     for (var k = 0u; k < kernel_size; k++) {
         let dx = i32(k) - i32(params.radius);
         let sx_signed = i32(x) + dx;
-        let sx = u32(clamp(sx_signed, 0i, w_i32 - 1i));
+        let period = 2i * w_i32;
+        let wrapped = ((sx_signed % period) + period) % period;
+        let sx = u32(select(wrapped, period - 1i - wrapped, wrapped >= w_i32));
         let idx = (y * params.width + sx) * 3u;
         let w = kernel_buf[k];
         sum.x += w * input[idx];

--- a/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/gaussian_blur_v.wgsl
+++ b/rust-engine/vendor/spektrafilm/crates/spektrafilm-shaders/wgsl/gaussian_blur_v.wgsl
@@ -27,7 +27,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     for (var k = 0u; k < kernel_size; k++) {
         let dy = i32(k) - i32(params.radius);
         let sy_signed = i32(y) + dy;
-        let sy = u32(clamp(sy_signed, 0i, h_i32 - 1i));
+        let period = 2i * h_i32;
+        let wrapped = ((sy_signed % period) + period) % period;
+        let sy = u32(select(wrapped, period - 1i - wrapped, wrapped >= h_i32));
         let idx = (sy * params.width + x) * 3u;
         let w = kernel_buf[k];
         sum.x += w * input[idx];

--- a/scripts/check-processing.py
+++ b/scripts/check-processing.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Fail-closed processing correctness gate with independent reference artifacts."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import importlib
+import json
+import os
+from pathlib import Path
+import platform
+import signal
+import subprocess
+import sys
+import time
+import traceback
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path[:0] = [str(ROOT), str(ROOT / 'tests')]
+MODULES = {'film': 'processing_reference', 'export': 'processing_export',
+           'webgl': 'processing_webgl', 'app': 'processing_app',
+           'native': 'native_processing_preview'}
+
+
+def passed(suite):
+    records = suite.get('records')
+    return (suite.get('status', 'pass') == 'pass' and isinstance(records, list)
+            and bool(records) and all(record.get('status') == 'pass' for record in records))
+
+
+def provenance():
+    def git(*args):
+        result = subprocess.run(['git', *args], cwd=ROOT, capture_output=True,
+                                text=True, timeout=15, check=True)
+        return result.stdout.strip()
+    paths = ['film_pipeline.py', 'grade.py', 'edits.py', 'render_cli.py',
+             'color_pipeline.py', 'web/gl.js', 'app/NativePreview.swift', 'app/NativePreview.metal']
+    paths += [str(path.relative_to(ROOT)) for path in (ROOT / 'tests').glob('*processing*') if path.is_file()]
+    paths += [str(path.relative_to(ROOT)) for path in (ROOT / 'rust-engine').rglob('*.rs')
+              if 'target' not in path.parts]
+    paths += ['scripts/check-processing.py', 'server.py', 'web/app.js']
+    return {'revision': git('rev-parse', 'HEAD'), 'workingTree': git('status', '--short'),
+            'host': platform.platform(), 'python': sys.version,
+            'sha256': {path: hashlib.sha256((ROOT / path).read_bytes()).hexdigest() for path in paths}}
+
+
+def write_reports(report, output):
+    (output / 'report.json').write_text(json.dumps(report, indent=2, allow_nan=False) + '\n')
+    suite_xml = ET.Element('testsuite', name='LightTable processing correctness')
+    count = failures = 0
+    lines = [f"# Processing correctness: {report['status'].upper()}", '',
+             f"Revision: `{report['provenance']['revision']}`", '',
+             'A pass establishes agreement with the named software references for these fixtures.',
+             'It does not establish a match to physical film, every RAW decoder, or an untested display.', '',
+             '| Suite | Result | Checks |', '| --- | --- | ---: |']
+    for name, suite in report['suites'].items():
+        records = suite.get('records') or []
+        status = 'pass' if passed(suite) else suite.get('status', 'fail')
+        if status == 'pass' and not passed(suite):
+            status = 'fail'
+        lines.append(f'| {name} | {status} | {len(records)} |')
+        for record in records:
+            count += 1
+            element = ET.SubElement(suite_xml, 'testcase', classname=name,
+                                    name=record.get('name', 'unnamed'))
+            if record.get('status') != 'pass':
+                failures += 1
+                ET.SubElement(element, 'failure', message=record.get('error') or
+                              record.get('reason') or 'Pixel/reference mismatch').text = json.dumps(record, indent=2)
+        if not passed(suite) and (not records or all(r.get('status') == 'pass' for r in records)):
+            count += 1
+            failures += 1
+            case = ET.SubElement(suite_xml, 'testcase', classname=name, name='required-suite')
+            ET.SubElement(case, 'failure', message=suite.get('error') or suite.get('reason') or
+                          'Suite unavailable or incomplete').text = json.dumps(suite, indent=2)
+    suite_xml.set('tests', str(count))
+    suite_xml.set('failures', str(failures))
+    ET.ElementTree(suite_xml).write(output / 'junit.xml', encoding='utf-8', xml_declaration=True)
+    lines.extend(['', '## Failures', ''])
+    for name, suite in report['suites'].items():
+        if passed(suite):
+            continue
+        lines.append(f"- **{name}**: {suite.get('error') or suite.get('reason') or 'numerical mismatches'}")
+        for record in suite.get('records', []):
+            if record.get('status') != 'pass':
+                lines.append(f"  - `{record.get('name')}`: {record.get('error') or record.get('reason') or record.get('metrics')}")
+    if not failures:
+        lines.append('None.')
+    lines.extend(['', 'Per-case references, actual outputs, tolerances, and difference images are linked in report.json.', ''])
+    (output / 'report.md').write_text('\n'.join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--suites', default=','.join(MODULES), help='Comma separated: film,export,webgl,app,native')
+    parser.add_argument('--output', type=Path, default=ROOT / 'build/processing-correctness')
+    parser.add_argument('--film-gpu', action='store_true', help='Also require film CPU/GPU parity')
+    parser.add_argument('--timeout', type=int, default=1200, help='Hard timeout in seconds per suite')
+    parser.add_argument('--worker', choices=MODULES, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    if args.worker:
+        try:
+            module = importlib.import_module(MODULES[args.worker])
+            result = module.run(output, **({'gpu': args.film_gpu} if args.worker == 'film' else {}))
+            if isinstance(result, list):
+                result = {'records': result}
+            if not passed(result):
+                result['status'] = result.get('status') if result.get('status') in ('blocked', 'fail') else 'fail'
+            else:
+                result['status'] = 'pass'
+        except Exception as error:
+            traceback.print_exc()
+            result = {'status': 'fail', 'error': str(error), 'records': []}
+        (output / 'suite.json').write_text(json.dumps(result, indent=2, allow_nan=False) + '\n')
+        return 0 if passed(result) else 1
+    selected = args.suites.split(',')
+    if not selected or len(set(selected)) != len(selected) or any(s not in MODULES for s in selected):
+        parser.error('Select each required suite at most once: ' + ','.join(MODULES))
+    if not 1 <= args.timeout <= 7200:
+        parser.error('--timeout must be 1..7200')
+    report = {'schema': 1, 'startedAt': datetime.now(timezone.utc).isoformat(),
+              'provenance': provenance(), 'requestedSuites': selected,
+              'unrequestedSuites': [s for s in MODULES if s not in selected],
+              'filmGpuRequired': args.film_gpu,
+              'suites': {name: {'status':'pending', 'records':[], 'error':'Required suite has not completed'}
+                         for name in selected}, 'status':'incomplete'}
+    started = time.monotonic()
+    write_reports(report, output)
+    for name in selected:
+        print(f'Checking {name}...', flush=True)
+        directory = output / name
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / 'suite.json'
+        # An old report must never stand in for a crashed worker.
+        path.unlink(missing_ok=True)
+        command = [sys.executable, str(Path(__file__).resolve()), '--worker', name, '--output', str(directory)]
+        if args.film_gpu:
+            command.append('--film-gpu')
+        try:
+            with (directory / 'runner.log').open('w') as log:
+                child = subprocess.Popen(command, cwd=ROOT, env=dict(os.environ, MPLBACKEND='Agg'),
+                    stdout=log, stderr=subprocess.STDOUT, start_new_session=(os.name == 'posix'))
+                try:
+                    child.wait(timeout=args.timeout)
+                except (subprocess.TimeoutExpired, KeyboardInterrupt):
+                    # Stop the entire test process group, including its server,
+                    # compiler/browser/renderer children, on the hard bound.
+                    if os.name == 'posix':
+                        os.killpg(child.pid, signal.SIGTERM)
+                    else:
+                        child.terminate()
+                    try:
+                        child.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        if os.name == 'posix':
+                            os.killpg(child.pid, signal.SIGKILL)
+                        else:
+                            child.kill()
+                        child.wait(timeout=5)
+                    raise
+            suite = json.loads(path.read_text()) if path.is_file() else {
+                'status': 'fail', 'error': f'Worker exited {child.returncode} without a report', 'records': []}
+            if child.returncode and passed(suite):
+                suite.update(status='fail', error=f'Worker exited {child.returncode}')
+        except (subprocess.TimeoutExpired, ValueError, OSError) as error:
+            suite = {'status': 'fail', 'error': str(error), 'records': []}
+        report['suites'][name] = suite
+        report['status'] = 'pass' if all(passed(s) for s in report['suites'].values()) else 'fail'
+        report['seconds'] = round(time.monotonic() - started, 3)
+        write_reports(report, output)
+        print(f"{name}: {suite.get('status')} ({len(suite.get('records', []))} checks)", flush=True)
+    print(f"{report['status'].upper()}: {output / 'report.md'}", flush=True)
+    return 0 if report['status'] == 'pass' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/native_processing_preview.py
+++ b/tests/native_processing_preview.py
@@ -1,0 +1,156 @@
+"""Numerical proof of the production Metal renderer's submitted display frames.
+
+Requires macOS, swiftc, Metal and a graphical login. Missing prerequisites are a
+blocking failure, never a skipped/pass result. This is a real renderer/window,
+not the complete LightTable app: it cannot prove bridge wiring or UI placement.
+The Swift helper reads the drawable captured before each production render,
+after GPU completion; it never calls the offscreen snapshot() renderer.
+"""
+from __future__ import annotations
+
+import functools
+import http.server
+import json
+import plistlib
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+import grade
+from processing_support import compare_images, grade_cases, target_rgb8
+
+
+def _blocked(message):
+    return [{"name": "native-renderer-availability", "status": "blocked", "error": message}]
+
+
+def run(output_dir: Path) -> list[dict]:
+    """Compare grade.apply CLI/export pixels to genuine submitted Metal frames."""
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    swiftc = shutil.which("swiftc")
+    if sys.platform != "darwin" or not swiftc:
+        return _blocked("Native display proof requires macOS with swiftc, Metal, and a graphical session")
+    inputs = output_dir / "inputs"
+    captures = output_dir / "submitted-drawables"
+    inputs.mkdir(exist_ok=True)
+    captures.mkdir(exist_ok=True)
+    source_a = target_rgb8()
+    source_b = np.ascontiguousarray(255 - source_a[:, ::-1, [2, 0, 1]])
+    portrait = np.ascontiguousarray(np.rot90(source_a))
+    for name, pixels in (("a", source_a), ("b", source_b), ("portrait", portrait)):
+        Image.fromarray(pixels).save(inputs / f"{name}.png")
+    height, width = source_a.shape[:2]
+    rgba = np.concatenate((source_a, np.full((height, width, 1), 255, np.uint8)), axis=2)
+    (inputs / "a.flra").write_bytes(struct.pack("<4sIII", b"FLRA", width, height, width * 4) + rgba.tobytes())
+    actions, references = [], {}
+
+    def add(name, source, values, kind="grade", **extra):
+        name = "native-" + name
+        h, w = source.shape[:2]
+        actions.append({"name": name, "width": w, "height": h,
+                        "grade": values, "type": kind, **extra})
+        references[name] = grade.apply(source.astype(np.float32) / 255, values)
+
+    add("png-identity", source_a, {}, "load", surface={"url": "a.png"})
+    add("flra-identity", source_a, {}, "load", surface={"url": "a.flra", "format": "rgba8",
+        "width": width, "height": height, "rowBytes": width * 4, "headerBytes": 16})
+    for case in grade_cases():
+        add(case["name"], source_a, case["grade"])
+
+    navigation_grade = {"exposure": 0.4, "contrast": 0.2}
+    for name, source, url, values in (
+        ("navigation-a", source_a, "a.png", navigation_grade),
+        ("navigation-b", source_b, "b.png", {"saturation": -0.4}),
+        ("navigation-a-restored", source_a, "a.png", navigation_grade),
+    ):
+        add(name, source, values, "load", surface={"url": url})
+    for index, position in enumerate((0.1, 0.9, 0.25, 0.75, 0.5, 0.98, 0.02, 1.0, 0.0)):
+        name = f"compare-{index}-{position:g}"
+        add(name, source_a, navigation_grade, "compare", position=position)
+        before = ((np.arange(width) + 0.5) / width <= position) if position else np.zeros(width, dtype=bool)
+        references["native-" + name][:, before] = source_b[:, before].astype(np.float32) / 255
+    add("portrait-orientation-and-size", portrait, {}, "load", surface={"url": "portrait.png"})
+    add("landscape-size-restored", source_a, {}, "load", surface={"url": "a.png"})
+    manifest = output_dir / "manifest.json"
+    manifest.write_text(json.dumps(actions, indent=2))
+
+    class QuietHandler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0),
+        functools.partial(QuietHandler, directory=str(inputs)))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="lighttable-native-processing-") as temporary:
+            temporary = Path(temporary)
+            bundle = temporary / "ProcessingPreview.app" / "Contents"
+            resources = bundle / "Resources"
+            resources.mkdir(parents=True)
+            executable = bundle / "MacOS" / "ProcessingPreview"
+            executable.parent.mkdir()
+            (bundle / "Info.plist").write_bytes(plistlib.dumps({
+                "CFBundleExecutable": "ProcessingPreview", "CFBundlePackageType": "APPL",
+                "CFBundleIdentifier": "com.lighttable.test.processing-preview",
+            }))
+            shutil.copy(ROOT / "app" / "NativePreview.metal", resources)
+            compiled = subprocess.run([swiftc, "-swift-version", "5", "-module-cache-path",
+                str(temporary / "module-cache"), str(ROOT / "app" / "NativePreview.swift"),
+                str(Path(__file__).with_suffix(".swift")), "-o", str(executable)],
+                capture_output=True, text=True, timeout=120)
+            (output_dir / "compile.log").write_text(compiled.stdout + compiled.stderr)
+            if compiled.returncode:
+                return _blocked(f"Production NativePreview compilation failed; see {output_dir / 'compile.log'}")
+            executed = subprocess.run([str(executable), f"http://127.0.0.1:{server.server_port}/",
+                str(manifest), str(captures)], capture_output=True, text=True, timeout=90)
+            (output_dir / "renderer.log").write_text(executed.stdout + executed.stderr)
+            if executed.returncode:
+                return _blocked(f"Native display capture failed: {executed.stdout}{executed.stderr}")
+    except subprocess.TimeoutExpired as error:
+        return _blocked(f"Native renderer build/capture timed out after {error.timeout} seconds")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    evidence = json.loads((captures / "drawables.json").read_text())
+    records = []
+    frames = {frame["name"]: frame for frame in evidence["frames"]}
+    for action in actions:
+        name, h, w = action["name"], action["height"], action["width"]
+        raw = np.frombuffer((captures / (name + ".bgra")).read_bytes(), dtype=np.uint8)
+        actual = raw.reshape(h, w, 4)[..., [2, 1, 0]].astype(np.float32) / 255
+        # Fixed shared tolerances are in 8-bit code values: mean .75, p95 2,
+        # max 5. No image registration, trimming, color fitting, or per-case
+        # tolerance escalation is allowed to hide orientation/processing errors.
+        record = compare_images(name, references[name], actual, output_dir)
+        record.update(reference="grade.apply from exact PNG/FLRA RGB8 input",
+                      proof="production renderer submitted MTKView drawable",
+                      device=evidence["device"], display_evidence=frames[name],
+                      grade=action["grade"])
+        if name == "native-navigation-a-restored" and not frames[name]["texture_cache_hit"]:
+            record.update(status="fail", error="A/B/A navigation did not exercise cached A restoration")
+        records.append(record)
+    (output_dir / "results.json").write_text(json.dumps(records, indent=2))
+    return records
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path)
+    args = parser.parse_args()
+    results = run(args.output_dir)
+    print(json.dumps(results, indent=2))
+    raise SystemExit(0 if results and all(row["status"] == "pass" for row in results) else 1)

--- a/tests/native_processing_preview.swift
+++ b/tests/native_processing_preview.swift
@@ -1,0 +1,144 @@
+// Compiled with the production NativePreview.swift by native_processing_preview.py.
+// Read back submitted MTKView drawables: snapshot() would silently rerender and
+// miss stale drawable, navigation, and compare restoration failures.
+import AppKit
+import MetalKit
+
+@main
+struct NativeProcessingPreview {
+    static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() { fputs("FAIL: \(message)\n", stderr); exit(1) }
+    }
+
+    static func wait(_ description: String, _ condition: () -> Bool) {
+        let deadline = Date().addingTimeInterval(10)
+        while !condition() && Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.005))
+        }
+        require(condition(), "timed out: \(description)")
+    }
+
+    static func main() throws {
+        require(CommandLine.arguments.count == 4, "expected base URL, manifest, output directory")
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            fputs("BLOCKED: a macOS graphical session with a Metal device is required\n", stderr)
+            exit(1)
+        }
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        app.finishLaunching()
+        guard let renderer = NativePreviewRenderer(), let readQueue = device.makeCommandQueue() else {
+            fputs("BLOCKED: production Metal renderer could not be created\n", stderr)
+            exit(1)
+        }
+        let base = URL(string: CommandLine.arguments[1])!
+        let manifest = try JSONSerialization.jsonObject(with: Data(contentsOf:
+            URL(fileURLWithPath: CommandLine.arguments[2]))) as! [[String: Any]]
+        let output = URL(fileURLWithPath: CommandLine.arguments[3], isDirectory: true)
+        let window = NSWindow(contentRect: NSRect(x: 80, y: 80, width: 512, height: 384),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.title = "LightTable processing correctness — production Metal renderer"
+        window.contentView!.addSubview(renderer.view)
+        // This flag permits test-only readback. Shader, uploads, load/cache,
+        // automatic drawable sizing, and draw lifecycle are production code.
+        renderer.view.framebufferOnly = false
+        window.orderFrontRegardless()
+        defer { window.orderOut(nil) }
+        var completed = -1
+        var presented = Set<Int>()
+        renderer.onInteractionPresented = { sample in
+            let frame = sample["frame"] as? Int ?? -1
+            if sample["measurement"] as? String == "gpu-completed" { completed = frame }
+            if sample["measurement"] as? String == "drawable-presented" { presented.insert(frame) }
+        }
+        var records = [[String: Any]]()
+        var previousSize = CGSize.zero
+        var originalLoaded = false
+
+        for (index, item) in manifest.enumerated() {
+            let name = item["name"] as! String
+            let width = item["width"] as! Int, height = item["height"] as! Int
+            let size = CGSize(width: width, height: height)
+            if size != previousSize {
+                let scale = window.backingScaleFactor
+                renderer.setFrame(NSRect(x: 0, y: 0, width: Double(width) / scale,
+                                         height: Double(height) / scale), visible: true)
+                // Finish any resize-triggered display before identifying the
+                // drawable which the next explicitly requested action submits.
+                RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+                renderer.view.releaseDrawables()
+                previousSize = size
+            }
+            if item["type"] as? String == "compare", !originalLoaded {
+                renderer.recordInteraction(["frame": -2])
+                renderer.loadOriginal(NativeSurfaceDescription(payload: ["url": "b.png"], baseURL: base)!, generation: 1)
+                wait("original image upload") { completed == -2 }
+                originalLoaded = true
+            }
+
+            guard let drawable = renderer.view.currentDrawable else {
+                fputs("BLOCKED: MTKView drawable unavailable; a graphical session is required\n", stderr)
+                exit(1)
+            }
+            renderer.recordInteraction(["frame": index])
+            var cacheHit = false
+            if item["type"] as? String == "load" {
+                renderer.beginNavigation(generation: index + 1)
+                renderer.recordInteraction(["frame": index])
+                let surface = NativeSurfaceDescription(payload: item["surface"] as! [String: Any], baseURL: base)!
+                var loadFinished = false
+                var loadError: String?
+                renderer.load(surface, generation: index + 1, grade: item["grade"] as? [String: Any] ?? [:]) { result in
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success(let timings): cacheHit = timings.textureCacheHit
+                        case .failure(let error): loadError = error.localizedDescription
+                        }
+                        loadFinished = true
+                    }
+                }
+                wait("loading \(name)") { loadFinished }
+                require(loadError == nil, "\(name): \(loadError ?? "")")
+            } else if item["type"] as? String == "compare" {
+                renderer.updateComparePosition(item["position"] as! Double)
+            } else {
+                renderer.updateGrade(item["grade"] as? [String: Any] ?? [:])
+            }
+            wait("submitted drawable for \(name)") { completed == index }
+            require(drawable.texture.width == width && drawable.texture.height == height,
+                    "\(name): drawable \(drawable.texture.width)x\(drawable.texture.height), expected \(width)x\(height), view size \(renderer.view.drawableSize)")
+            require(renderer.view.currentDrawable?.drawableID != drawable.drawableID,
+                    "\(name): presented drawable was reused")
+
+            let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .bgra8Unorm, width: width, height: height, mipmapped: false)
+            descriptor.storageMode = .shared
+            let readback = device.makeTexture(descriptor: descriptor)!
+            let command = readQueue.makeCommandBuffer()!
+            let blit = command.makeBlitCommandEncoder()!
+            blit.copy(from: drawable.texture, to: readback)
+            blit.endEncoding()
+            command.commit()
+            command.waitUntilCompleted()
+            require(command.status == .completed, "\(name): display readback failed")
+            var pixels = [UInt8](repeating: 0, count: width * height * 4)
+            readback.getBytes(&pixels, bytesPerRow: width * 4,
+                              from: MTLRegionMake2D(0, 0, width, height), mipmapLevel: 0)
+            try Data(pixels).write(to: output.appendingPathComponent(name + ".bgra"))
+            records.append(["name": name, "width": width, "height": height,
+                            "drawable_id": String(drawable.drawableID), "gpu_completed": true,
+                            "texture_cache_hit": cacheHit, "frame": index])
+        }
+        // Presentation callbacks are observational: GPU-completed output is
+        // proven even if an occluded layer never reports physical presentation.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        for index in records.indices {
+            records[index]["drawable_presented_callback"] = presented.contains(index)
+        }
+        let report: [String: Any] = ["device": device.name, "frames": records,
+            "proof": "submitted MTKView drawable readback; not a full-app screenshot"]
+        try JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted, .sortedKeys])
+            .write(to: output.appendingPathComponent("drawables.json"))
+        print("Captured \(records.count) production Metal drawables on \(device.name)")
+    }
+}

--- a/tests/processing_app.mjs
+++ b/tests/processing_app.mjs
@@ -1,0 +1,104 @@
+// End-to-end: real server, real app UI, presented WebGL frame, CLI render API.
+import fs from 'node:fs';
+import {pathToFileURL} from 'node:url';
+const config = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const {chromium} = await import(pathToFileURL(config.module).href);
+const browser = await chromium.launch({headless: true, executablePath: config.browser || undefined,
+  args: ['--enable-unsafe-swiftshader', '--force-color-profile=srgb']});
+for (const signal of ['SIGTERM', 'SIGINT']) process.on(signal, async () => {await browser.close(); process.exit(1);});
+try {
+  const page = await browser.newPage({viewport: {width: 1440, height: 1000}, deviceScaleFactor: 1});
+  page.on('request', request => {
+    if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/state') {
+      const state = request.postDataJSON();
+      process.stdout.write(JSON.stringify({event:'save', name:state.name,
+        film:state.params?.profile_enabled, print:state.params?.print_exposure,
+        exposure:state.grade?.exposure}) + '\n');
+    }
+  });
+  // Establish the normal HttpOnly instance cookie without starting app scripts.
+  await page.request.get(config.baseUrl);
+  const images = (await (await page.request.get(config.baseUrl + '/api/images')).json()).images;
+  if (!images || images.length !== 2) throw Error('Expected exactly two isolated fixture photos');
+  for (const image of images) {
+    const response = await page.request.post(config.baseUrl + '/api/state', {headers:{Origin:config.baseUrl}, data:{name:image.name,
+      params:config.cases[0].params, grade:{}, masks:[], heals:[], optics:{}, crop:null}});
+    if (!response.ok()) throw Error(await response.text());
+  }
+  await page.goto(config.baseUrl, {waitUntil: 'domcontentloaded'});
+  await page.waitForFunction(() => window.__lightTablePerf?.renders.length > 0, null, {timeout: 120000});
+  await page.evaluate(async () => {
+    const {GradeRenderer} = await import('/web/gl.js');
+    const draw = GradeRenderer.prototype.draw;
+    window.processingFrames = 0;
+    GradeRenderer.prototype.draw = function(...args) {
+      draw.apply(this, args);
+      if (this.canvas.id !== 'cv' || !this.ready) return;
+      const gl = this.gl;
+      if (gl.getParameter(gl.FRAMEBUFFER_BINDING) !== null) return;
+      const pixels = new Uint8Array(this.canvas.width * this.canvas.height * 4);
+      gl.readPixels(0, 0, this.canvas.width, this.canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+      if (gl.getError()) throw Error('App framebuffer readback failed');
+      window.processingFrame = {width: this.canvas.width, height: this.canvas.height,
+        pixels: Array.from(pixels), grade: structuredClone(args[0]), frame:processingFrames + 1};
+      window.processingFrames++;
+    };
+  });
+  const results = [];
+  const post = async (path, body) => page.evaluate(async ({path, body}) => {
+    const response = await fetch(path, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body)});
+    const result = await response.json();
+    if (!response.ok || result.error || result.ok === false) throw Error(JSON.stringify(result));
+    return result;
+  }, {path, body});
+  for (const [index, test] of config.cases.entries()) {
+    process.stdout.write(JSON.stringify({event:'case', name:test.name}) + '\n');
+    const name = images[test.photo || 0].name;
+    await post('/api/ui/command', {command:'goto', args:{name}});
+    await page.waitForFunction(name => __lightTablePerf.renders.at(-1)?.image === name &&
+      !document.querySelector('#zoomwrap').classList.contains('photo-pending'), name, {timeout:120000});
+    const filmEnabled = await page.locator('#filmProfileToggle').getAttribute('aria-checked');
+    if (filmEnabled !== String(test.params.profile_enabled)) await post('/api/ui/command', {command:'filmToggle'});
+    await post('/api/ui/command', {command:'slider', args:{key:'print_exposure', value:test.params.print_exposure}});
+    // Actual slider event takes the normal app UI -> grade -> preview -> save route.
+    const before = await page.evaluate(() => processingFrames);
+    await post('/api/ui/command', {command:'slider', args:{key:'exposure', value:test.exposure}});
+    await page.waitForFunction(({before, exposure}) => processingFrames > before &&
+      Math.abs(processingFrame.grade.exposure - exposure) < 0.0001 &&
+      !document.querySelector('#zoomwrap').classList.contains('photo-pending'),
+      {before, exposure:test.exposure}, {timeout:120000});
+    // Poll authoritative saved state, so the CLI reference uses the accepted recipe.
+    let saved;
+    for (let attempt = 0; attempt < 120; attempt++) {
+      saved = await page.evaluate(async name => (await (await fetch(`/api/state?name=${encodeURIComponent(name)}`)).json()), name);
+      if (Math.abs(saved.grade?.exposure - test.exposure) < 0.0001 &&
+          Object.entries(test.params).every(([key,value]) => JSON.stringify(saved.params?.[key]) === JSON.stringify(value))) break;
+      await page.waitForTimeout(250);
+    }
+    if (Math.abs(saved.grade?.exposure - test.exposure) >= 0.0001) throw Error('Grade did not persist');
+    for (const [key, value] of Object.entries(test.params)) {
+      if (JSON.stringify(saved.params[key]) !== JSON.stringify(value)) throw Error(`Recipe drift: ${key} expected ${JSON.stringify(value)}, got ${JSON.stringify(saved.params[key])}`);
+    }
+    const state = await post('/api/ui/command', {command:'slider', args:{key:'exposure', value:test.exposure}});
+    const ui = state.result?.result || state.result || state;
+    if (ui.current !== name || ui.render?.name !== name || ui.render?.state !== 'ready' || ui.render?.backend !== 'webgl') {
+      throw Error(`Wrong/stale app presentation: ${JSON.stringify(state)}`);
+    }
+    const frame = await page.evaluate(() => processingFrame);
+    fs.writeFileSync(test.raw, Buffer.from(frame.pixels));
+    delete frame.pixels;
+    // This is the real CLI render endpoint, which runs Python postprocessing.
+    const reference = await page.request.post(config.baseUrl + '/api/render/file',
+      {data:{name, w:frame.width, format:'png', state:{params:test.params,
+        grade:{exposure:test.exposure}, masks:[], heals:[], optics:{}, crop:null}}, timeout:120000});
+    if (!reference.ok()) throw Error(`CLI reference: ${await reference.text()}`);
+    fs.writeFileSync(test.reference, await reference.body());
+    await page.screenshot({path:test.screenshot});
+    const canvas = page.locator('#cv');
+    if (!await canvas.isVisible()) throw Error('App preview canvas is hidden');
+    const bounds = await canvas.boundingBox();
+    await canvas.screenshot({path:test.display, timeout:15000});
+    results.push({name:test.name, photo:name, bounds, ...frame});
+  }
+  fs.writeFileSync(config.result, JSON.stringify({records:results}));
+} finally { await browser.close(); }

--- a/tests/processing_app.py
+++ b/tests/processing_app.py
@@ -1,0 +1,126 @@
+"""Check the real application UI against its CPU CLI rendering endpoint."""
+from __future__ import annotations
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+import numpy as np
+from PIL import Image
+from processing_support import compare_images, target_rgb8, run_browser
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(output_dir):
+    from bench.benchmark import server_environment, stop_process, find_playwright_module, find_playwright_browser
+    import film_pipeline as fp
+    from processing_export import ensure_resident
+    output = Path(output_dir).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    photos = output / 'photos'
+    photos.mkdir(exist_ok=True)
+    Image.fromarray(target_rgb8()).save(photos / 'a.png')
+    Image.fromarray(target_rgb8(96, 128)).save(photos / 'b.png')
+    with socket.socket() as listener:
+        listener.bind(('127.0.0.1', 0))
+        port = listener.getsockname()[1]
+    env = server_environment(photos, port, output / 'cache')
+    env['SPEKTRAFILM_BACKEND'] = 'cpu'
+    base = f'http://127.0.0.1:{port}'
+    params = fp.clean_params({'grain_on':False, 'halation_on':False, 'glare_on':False,
+        'auto_exposure':False, 'camera_diffusion_strength':0, 'scan_softness':0,
+        'scan_sharpen':False, 'linear_input':False})
+    cases = [
+        {'name':'film-off-slider', 'params':{**params, 'profile_enabled':False}, 'exposure':0.45},
+        {'name':'film-on-slider', 'params':params, 'exposure':-0.35},
+        {'name':'print-exposure-slider', 'params':{**params, 'print_exposure':1.6}, 'exposure':0.2},
+        {'name':'navigate-portrait', 'params':{**params, 'profile_enabled':False}, 'exposure':0.3, 'photo':1},
+        {'name':'return-landscape', 'params':{**params, 'profile_enabled':False}, 'exposure':-0.2},
+    ]
+    for case in cases:
+        case.update(raw=str(output / f"{case['name']}.rgba"),
+                    reference=str(output / f"{case['name']}-cli.png"),
+                    display=str(output / f"{case['name']}-display.png"),
+                    screenshot=str(output / f"{case['name']}-app.png"))
+    module = find_playwright_module()
+    if not module or not shutil.which('node'):
+        raise RuntimeError('Application gate requires Node and Playwright')
+    browser = find_playwright_browser()
+    config = output / 'config.json'
+    config.write_text(json.dumps({'baseUrl':base, 'module':str(module),
+        'browser':os.environ.get('LIGHTTABLE_BROWSER_EXECUTABLE') or (str(browser) if browser else None),
+        'cases':cases, 'result':str(output / 'frames.json')}))
+    binary, build_record = ensure_resident(output)
+    if binary is None:
+        return {'records':[build_record]}
+    # A private runtime layout selects exactly the newly built engine through
+    # normal production discovery, without overwriting any developer install.
+    with tempfile.TemporaryDirectory(prefix='lighttable-processing-app-') as temporary, \
+            (output / 'server.log').open('w') as log:
+        runtime = Path(temporary)
+        env = server_environment(photos, port, runtime / 'cache')
+        env['SPEKTRAFILM_BACKEND'] = 'cpu'
+        for source_file in ROOT.glob('*.py'):
+            shutil.copy2(source_file, runtime / source_file.name)
+        shutil.copy2(ROOT / 'media-formats.json', runtime / 'media-formats.json')
+        for name in ('web', 'profiles', 'vendor', 'film_lab_ai', 'scripts', 'lighttable_cli'):
+            (runtime / name).symlink_to(ROOT / name, target_is_directory=True)
+        (runtime / 'engine').mkdir()
+        (runtime / 'engine/data').symlink_to(ROOT / 'engine/data', target_is_directory=True)
+        (runtime / 'engine/lighttable-engine').symlink_to(binary)
+        server = subprocess.Popen([sys.executable, str(runtime / 'server.py')], cwd=runtime,
+                                  env=env, stdout=log, stderr=subprocess.STDOUT)
+        try:
+            deadline = time.monotonic() + 90
+            while time.monotonic() < deadline:
+                if server.poll() is not None:
+                    raise RuntimeError('Isolated application server exited; see server.log')
+                try:
+                    with urllib.request.urlopen(base + '/api/images', timeout=2) as response:
+                        if len(json.load(response).get('images', [])) == 2:
+                            break
+                except (OSError, ValueError):
+                    pass
+                time.sleep(0.2)
+            else:
+                raise RuntimeError('Isolated application server did not become ready within 90 seconds')
+            result = run_browser([shutil.which('node'), str(ROOT / 'tests/processing_app.mjs'), str(config)],
+                cwd=ROOT, timeout=600)
+            (output / 'browser.log').write_text(result.stdout + result.stderr)
+            if result.returncode:
+                raise RuntimeError(f'Application pixel journey failed: {result.stderr[-1600:]}')
+        finally:
+            stop_process(server)
+    frames = json.loads((output / 'frames.json').read_text())['records']
+    records = [build_record]
+    for case, frame in zip(cases, frames, strict=True):
+        reference = np.asarray(Image.open(case['reference']).convert('RGB')).astype(float) / 255
+        actual = np.fromfile(case['raw'], dtype=np.uint8).reshape(frame['height'], frame['width'], 4)
+        record = compare_images(case['name'], reference, actual[::-1, :, :3] / 255, output / 'pixels')
+        record.update(photo=frame['photo'], reference='Actual /api/render/file CLI route (Python CPU grade)',
+                      screenshot=case['screenshot'], grade=frame['grade'])
+        records.append(record)
+        display = np.asarray(Image.open(case['display']).convert('RGB')).astype(float) / 255
+        # CSS canvas presentation scales the rendered RGB8 image bilinearly.
+        bounds = frame['bounds']
+        width, height = round(bounds['width']), round(bounds['height'])
+        # Element screenshots round their clip outward. A fractional canvas
+        # origin can include a row/column of background outside the photo.
+        # Compare the rasterized photo rectangle computed from DOM geometry;
+        # no image registration or data-dependent border trimming is used.
+        x = math.floor(bounds['x'] + 0.5) - math.floor(bounds['x'])
+        y = math.floor(bounds['y'] + 0.5) - math.floor(bounds['y'])
+        display = display[y:y+height, x:x+width]
+        expected_display = np.asarray(Image.fromarray(actual[::-1, :, :3]).resize(
+            (width, height), Image.Resampling.BILINEAR)).astype(float) / 255
+        records.append(compare_images(case['name'] + '-visible-canvas', expected_display,
+                                      display, output / 'display'))
+    return {'records':records, 'coverage':'Full browser app, server, UI slider/save, navigation, CLI pixel parity'}

--- a/tests/processing_export.py
+++ b/tests/processing_export.py
@@ -85,8 +85,14 @@ def _check(name, condition, **details):
 
 
 def _subprocess_environment():
+    # The CLI runs in a fresh interpreter. CI prepares the pinned runtime in
+    # vendor rather than installing it, so the parent's sys.path is insufficient.
+    pythonpath = os.pathsep.join(filter(None, [
+        str(APP), str(APP / "vendor" / "spektrafilm" / "src"),
+        os.environ.get("PYTHONPATH"),
+    ]))
     return dict(os.environ, SPEKTRAFILM_BACKEND="cpu", NUMBA_NUM_THREADS="2",
-                RAYON_NUM_THREADS="2", PYTHONHASHSEED="0")
+                RAYON_NUM_THREADS="2", PYTHONHASHSEED="0", PYTHONPATH=pythonpath)
 
 
 def _read_export(path):

--- a/tests/processing_export.py
+++ b/tests/processing_export.py
@@ -1,0 +1,359 @@
+"""Real export files, checked against analytical and separate-code references.
+
+The no-film CLI checks use only NumPy equations for sRGB, exposure and geometry.
+Resident postprocessing is isolated by comparing Rust grade/masks with Python
+grade/edits on an ungraded float film render. That baseline is NOT a film oracle;
+the film stage gate owns independent validation of the film model itself.
+"""
+from __future__ import annotations
+
+import base64
+from contextlib import contextmanager
+import hashlib
+from io import BytesIO
+import json
+import os
+from pathlib import Path
+import queue
+import subprocess
+import sys
+import threading
+import time
+
+import numpy as np
+from PIL import Image, ImageCms
+import tifffile
+
+from processing_support import compare_images, file_digest, grade_cases, target_rgb8
+
+APP = Path(__file__).resolve().parents[1]
+FLOAT_TOLERANCE = {"mean": 0.05, "p95": 0.1, "max": 0.5}
+RGB16_TOLERANCE = {"mean": 0.0021, "p95": 0.0021, "max": 0.0041}
+
+
+def srgb_encode(linear):
+    linear = np.clip(np.asarray(linear, dtype=np.float64), 0, 1)
+    return np.where(linear <= 0.0031308, linear * 12.92,
+                    1.055 * np.power(linear, 1 / 2.4) - 0.055)
+
+
+def srgb_decode(encoded):
+    encoded = np.clip(np.asarray(encoded, dtype=np.float64), 0, 1)
+    return np.where(encoded <= 0.04045, encoded / 12.92,
+                    np.power((encoded + 0.055) / 1.055, 2.4))
+
+
+def analytical_exposure(encoded, stops):
+    return srgb_encode(srgb_decode(encoded) * 2 ** stops)
+
+
+def reference_resize(image, long_edge):
+    """Separable, antialiased Lanczos-3; no application/Pillow resize calls."""
+    image = np.asarray(image, dtype=np.float64)
+    height, width = image.shape[:2]
+    if not long_edge or max(height, width) <= long_edge:
+        return image.copy()
+    scale = long_edge / max(height, width)
+    output_width, output_height = max(1, round(width * scale)), max(1, round(height * scale))
+
+    def weights(source, destination):
+        ratio = source / destination
+        kernel_scale = max(1, ratio)
+        centers = (np.arange(destination) + 0.5) * ratio
+        distance = ((np.arange(source)[None, :] + 0.5) - centers[:, None]) / kernel_scale
+        kernel = np.sinc(distance) * np.sinc(distance / 3)
+        kernel[np.abs(distance) >= 3] = 0
+        return kernel / kernel.sum(axis=1, keepdims=True)
+
+    horizontal = np.einsum("hsc,ws->hwc", image, weights(width, output_width))
+    result = np.einsum("shc,ys->yhc", horizontal, weights(height, output_height))
+    return np.clip(result, 0, 1)
+
+
+def reference_geometry(image, *, rotate=0, crop=None, long_edge=None):
+    result = np.rot90(image, (-round(rotate / 90)) % 4)
+    if crop:
+        height, width = result.shape[:2]
+        x, y = round(crop["x"] * width), round(crop["y"] * height)
+        result = result[y:min(height, y + max(1, round(crop["h"] * height))),
+                        x:min(width, x + max(1, round(crop["w"] * width)))]
+    return reference_resize(result, long_edge)
+
+
+def _check(name, condition, **details):
+    return {"name": name, "status": "pass" if condition else "fail", **details}
+
+
+def _subprocess_environment():
+    return dict(os.environ, SPEKTRAFILM_BACKEND="cpu", NUMBA_NUM_THREADS="2",
+                RAYON_NUM_THREADS="2", PYTHONHASHSEED="0")
+
+
+def _read_export(path):
+    if path.suffix == ".tif":
+        with tifffile.TiffFile(path) as document:
+            pixels = document.asarray()
+            tag = document.pages[0].tags.get(34675)
+            profile = bytes(tag.value) if tag else b""
+    else:
+        with Image.open(path) as document:
+            pixels = np.asarray(document.convert("RGB"))
+            profile = document.info.get("icc_profile", b"")
+    floating = pixels.astype(np.float64)
+    if np.issubdtype(pixels.dtype, np.integer):
+        floating /= np.iinfo(pixels.dtype).max
+    return pixels, floating, profile
+
+
+def _profile_record(name, profile):
+    try:
+        parsed = ImageCms.ImageCmsProfile(BytesIO(profile))
+        description = ImageCms.getProfileDescription(parsed).strip()
+        valid = (profile[36:40] == b"acsp" and profile[16:20] == b"RGB "
+                 and "srgb" in description.lower())
+    except (OSError, ValueError) as error:
+        description, valid = str(error), False
+    return _check(name, valid, description=description, bytes=len(profile),
+                  sha256=hashlib.sha256(profile).hexdigest())
+
+
+def run_cli(output_dir: Path) -> list[dict]:
+    """Exercise render_cli.py as an actual worker, including its final encoder."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    # More than 256 input codes per channel catches hidden 8-bit intermediates.
+    pixels16 = np.round(np.linspace(0, 1, 96 * 128 * 3).reshape(96, 128, 3)
+                        * 65535).astype(np.uint16)
+    pixels16[24:48, 0:32] = (53001, 9123, 2701)
+    source = output_dir / "rgb16-source.tif"
+    tifffile.imwrite(source, pixels16, photometric="rgb", metadata=None)
+    source_float = pixels16.astype(np.float64) / 65535
+    crop = {"x": 0.135, "y": 0.217, "w": 0.617, "h": 0.571}
+    cases = [
+        {"name": "identity-rgb16"},
+        {"name": "linear-srgb-transfer", "linear": True},
+        {"name": "exposure-positive", "exposure": 0.7},
+        {"name": "exposure-negative", "exposure": -1.25},
+        {"name": "rotate-crop", "rotate": 90, "crop": crop},
+        {"name": "exposure-rotate-crop-resize", "exposure": 0.65,
+         "rotate": 270, "crop": crop, "long_edge": 47},
+        {"name": "png-encoding", "format": "png", "exposure": -0.35},
+        {"name": "tiff-eight-bit", "bit_depth": 8},
+    ]
+    records = []
+    for case in cases:
+        name = "cli-" + case["name"]
+        destination = output_dir / (name + (".png" if case.get("format") == "png" else ".tif"))
+        job = {"params": {"profile_enabled": False,
+                          "linear_input": case.get("linear", False),
+                          "rotate": case.get("rotate", 0)},
+               "grade": {"exposure": case.get("exposure", 0)},
+               "crop": case.get("crop"), "longEdge": case.get("long_edge"),
+               "format": case.get("format", "tif"),
+               "bitDepth": case.get("bit_depth", 16), "outputSpace": "srgb",
+               "metadata": "none", "watermark": {"enabled": False}}
+        job_path = output_dir / (name + ".json")
+        job_path.write_text(json.dumps(job, indent=2))
+        expected = srgb_encode(source_float) if case.get("linear") else source_float
+        if case.get("exposure"):
+            expected = analytical_exposure(expected, case["exposure"])
+        expected = reference_geometry(expected, rotate=case.get("rotate", 0),
+                                      crop=case.get("crop"), long_edge=case.get("long_edge"))
+        command = [sys.executable, str(APP / "render_cli.py"), str(source),
+                   str(destination), str(job_path)]
+        try:
+            result = subprocess.run(command, cwd=APP, env=_subprocess_environment(),
+                                    capture_output=True, text=True, timeout=120, check=True)
+            response = json.loads(result.stdout.splitlines()[-1])
+            raw, actual, profile = _read_export(destination)
+            # Rounding to 8-bit codes permits at most half a code per sample;
+            # this is a quantization bound, independent of fixture statistics.
+            tolerance = ({"mean": 0.501, "p95": 0.501, "max": 0.501}
+                         if raw.dtype == np.uint8 else RGB16_TOLERANCE)
+            record = compare_images(name, expected, actual, output_dir, tolerance)
+            record.update(reference="independent NumPy sRGB/exposure/Lanczos equations",
+                          command=command, output=str(destination.resolve()),
+                          output_sha256=file_digest(destination), dtype=str(raw.dtype))
+            records.append(record)
+            expected_dtype = np.uint8 if (case.get("format") == "png" or case.get("bit_depth") == 8) else np.uint16
+            records.append(_check(name + "-format", raw.dtype == expected_dtype
+                                  and response.get("ok") is True
+                                  and (response.get("height"), response.get("width")) == actual.shape[:2],
+                                  dtype=str(raw.dtype), shape=list(raw.shape)))
+            records.append(_profile_record(name + "-icc", profile))
+            if case["name"] == "identity-rgb16":
+                records.append(_check(name + "-precision", np.array_equal(raw, pixels16)
+                                      and np.unique(raw[..., 0]).size > 256,
+                                      unique_red_codes=int(np.unique(raw[..., 0]).size),
+                                      reference="exact original RGB16 codes"))
+        except (OSError, ValueError, subprocess.SubprocessError) as error:
+            detail = getattr(error, "stderr", "") or str(error)
+            records.append(_check(name, False, error=str(detail)[-3000:], command=command))
+    return records
+
+
+@contextmanager
+def resident(binary, log_path):
+    """One bounded resident worker; stdout reader avoids platform select limits."""
+    with open(log_path, "w") as log:
+        process = subprocess.Popen([str(binary)], stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE, stderr=log, text=True,
+                                   bufsize=1, env=_subprocess_environment(), cwd=APP)
+        lines = queue.Queue()
+        def read_lines():
+            for line in process.stdout:
+                lines.put(line)
+            lines.put(None)
+        reader = threading.Thread(target=read_lines, daemon=True)
+        reader.start()
+        request_id = 0
+        def request(payload):
+            nonlocal request_id
+            request_id += 1
+            process.stdin.write(json.dumps(dict(payload, id=request_id)) + "\n")
+            process.stdin.flush()
+            try:
+                line = lines.get(timeout=120)
+            except queue.Empty as error:
+                raise TimeoutError("resident render exceeded 120 seconds") from error
+            if not line:
+                raise RuntimeError(f"resident exited; see {log_path}")
+            response = json.loads(line)
+            if response.get("id") != request_id or not response.get("ok"):
+                raise RuntimeError(f"resident render failed: {response}")
+            return response
+        try:
+            yield request
+        finally:
+            if process.stdin:
+                process.stdin.close()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+            reader.join(timeout=2)
+            if process.stdout:
+                process.stdout.close()
+
+
+def mask_cases():
+    bitmap = np.arange(12 * 16, dtype=np.uint8).reshape(12, 16)
+    return [
+        {"name": "linear-mask", "masks": [{"type": "linear", "start": [.12, .3],
+         "end": [.81, .7], "opacity": .7, "grade": {"exposure": .65}}]},
+        {"name": "radial-mask", "masks": [{"type": "radial", "center": [.37, .62],
+         "radius": .32, "feather": .6, "grade": {"saturation": -.6, "temp": .2}}]},
+        {"name": "mask-components-ranges", "masks": [{"opacity": .8,
+         "lumaLow": .12, "lumaHigh": .83, "colorHue": 35, "colorRange": 50,
+         "colorAmount": .5, "grade": {"exposure": -.4, "contrast": .2},
+         "components": [{"type": "linear", "start": [.1, .1], "end": [.8, .9]},
+                        {"type": "radial", "center": [.4, .6], "radius": .3,
+                         "feather": .5, "combine": "subtract"}]}]},
+        {"name": "bitmap-mask", "masks": [{"type": "subject", "opacity": .65,
+         "bitmap": {"width": 16, "height": 12,
+                    "data": base64.b64encode(bitmap.tobytes()).decode()},
+         "grade": {"exposure": .5}}]},
+        {"name": "global-before-local", "grade": {"contrast": .5, "exposure": .3},
+         "masks": [{"type": "linear", "start": [.1, .4], "end": [.9, .6],
+                    "invert": True, "grade": {"exposure": -.8, "saturation": -.4}}]},
+    ]
+
+
+def ensure_resident(output_dir: Path):
+    """Build this checkout, with an isolated Cargo target and a provenance record."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = APP / "build" / "processing-cargo"
+    command = ["cargo", "build", "--manifest-path", str(APP / "rust-engine" / "Cargo.toml"), "--locked"]
+    build = subprocess.run(command, cwd=APP, env=dict(os.environ, CARGO_TARGET_DIR=str(target)),
+                           capture_output=True, text=True, timeout=900)
+    (output_dir / "build.log").write_text(build.stdout + build.stderr)
+    if build.returncode:
+        return None, _check("resident-source-build", False, error=build.stderr[-3000:], command=command)
+    binary = target / "debug" / ("lighttable-engine.exe" if os.name == "nt" else "lighttable-engine")
+    return binary, _check("resident-source-build", binary.is_file(), command=command,
+                          binary=str(binary), sha256=file_digest(binary))
+
+
+def run_resident(output_dir: Path) -> list[dict]:
+    import edits
+    import film_pipeline as film
+    import grade
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    binary, build_record = ensure_resident(output_dir)
+    records = [build_record]
+    if binary is None:
+        return records
+    source = output_dir / "resident-source.tif"
+    tifffile.imwrite(source, target_rgb8().astype(np.uint16) * 257, photometric="rgb", metadata=None)
+    params = film.clean_params({"input_color_space": "sRGB", "linear_input": False,
+                                "workflow_mode": "creative", "auto_exposure": False,
+                                "grain_on": False, "halation_on": False, "glare_on": False,
+                                "couplers_on": False, "scan_sharpen": False,
+                                "output_recipe": "clean_scan"})
+    base = {"input": str(source), "data_dir": str(APP / "engine" / "data"),
+            "film": params["stock"], "paper": params["paper"],
+            "params": film.rust_params_json(params), "bit_depth": 32}
+    with resident(binary, output_dir / "resident.log") as render:
+        baseline_path = output_dir / "film-baseline-float.tif"
+        response = render(dict(base, output=str(baseline_path)))
+        baseline = tifffile.imread(baseline_path)
+        records.append(_check("resident-float-intermediate", baseline.dtype == np.float32
+                              and np.isfinite(baseline).all()
+                              and np.unique(baseline[..., 0]).size > 256
+                              and "cpu" in response["backend"].lower(),
+                              dtype=str(baseline.dtype), backend=response["backend"],
+                              unique_red_codes=int(np.unique(baseline[..., 0]).size)))
+        for case in grade_cases() + mask_cases():
+            name = "resident-" + case["name"]
+            path = output_dir / (name + ".tif")
+            request = dict(base, output=str(path), grade=grade.clean(case.get("grade", {})))
+            if case.get("masks"):
+                request["masks"] = edits.clean_masks(case["masks"])
+            expected = grade.apply(baseline.copy(), case.get("grade", {}))
+            expected = edits.apply_masks(expected, case.get("masks"))
+            try:
+                response = render(request)
+                actual = tifffile.imread(path)
+                record = compare_images(name, expected, actual, output_dir, FLOAT_TOLERANCE)
+                record.update(reference="Python grade.py/edits.py on identical ungraded float film output",
+                              backend=response["backend"], output=str(path), recipe=case)
+                records.append(record)
+            except (OSError, ValueError, RuntimeError, TimeoutError) as error:
+                records.append(_check(name, False, error=str(error)))
+        geometry = {"rotate": 90, "crop": {"x": .13, "y": .17, "w": .63, "h": .59},
+                    "long_edge": 43}
+        path = output_dir / "resident-grade-rotate-crop-resize-rgb16.tif"
+        response = render(dict(base, output=str(path), bit_depth=16, rotate_quarters_ccw=3,
+                               grade={"exposure": .65}, crop=geometry["crop"], long_edge=43))
+        # Rotation is before grading. Exposure is pointwise, so this oracle
+        # also verifies grade-before-resize (these operations do not commute).
+        expected = reference_geometry(analytical_exposure(baseline, .65), **geometry)
+        actual_raw = tifffile.imread(path)
+        actual = actual_raw.astype(np.float64) / 65535
+        records.append(compare_images("resident-grade-rotate-crop-resize-rgb16", expected,
+                                      actual, output_dir, FLOAT_TOLERANCE))
+        records.append(_check("resident-final-rgb16", actual_raw.dtype == np.uint16,
+                              dtype=str(actual_raw.dtype), shape=list(actual_raw.shape)))
+    return records
+
+
+def run(output_dir: Path) -> dict:
+    started = time.monotonic()
+    output_dir = Path(output_dir).resolve()
+    records = run_cli(output_dir / "cli")
+    try:
+        records.extend(run_resident(output_dir / "resident"))
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError, TimeoutError) as error:
+        records.append(_check("resident-export-execution", False, error=str(error)))
+    return {"records": records, "seconds": time.monotonic() - started,
+            "scope": "Analytical CLI delivery plus independent resident grade/local-mask and geometry checks",
+            "limitations": ["The resident ungraded film image is a postprocessing input, not a film truth reference.",
+                            "JPEG/HEIF compression, RAW demosaicing and physical monitor calibration are outside this gate."]}

--- a/tests/processing_reference.py
+++ b/tests/processing_reference.py
@@ -1,0 +1,482 @@
+"""Numerical film-processing checks against independent Python and NumPy oracles.
+
+The Python spectral implementation is an independent implementation of the same
+model, sharing the measured stock data. Agreement is not validation against a
+physical film scan. Stage units are log10 exposure or optical density, never RGB
+code values. The CLI is forced to CPU for its diagnostic stage buffers; GPU
+resident processing is checked separately at its actual final output.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import numpy as np
+
+APP = Path(__file__).resolve().parents[1]
+STAGES = {
+    "film_exposure": "SPEKTRAFILM_DUMP_FILM_LOG_RAW",
+    "film_development": "SPEKTRAFILM_DUMP_FILM_DENSITY",
+    "print_exposure": "SPEKTRAFILM_DUMP_PRINT_LOG_RAW",
+    "print_development": "SPEKTRAFILM_DUMP_PRINT_DENSITY",
+}
+BASE_PARAMS = {
+    "stock": "kodak_portra_400", "paper": "kodak_portra_endura",
+    "workflow_mode": "creative", "linear_input": True,
+    "auto_exposure": False, "grain_on": False, "halation_on": False,
+    "glare_on": False, "couplers_on": False,
+    "camera_diffusion_strength": 0.0, "scan_softness": 0.0,
+    "scan_sharpen": False, "output_recipe": "clean_scan",
+}
+CASES = {
+    "negative_baseline": {},
+    "exposure_plus_one": {"exposure_ev": 1.0},
+    "density_gamma": {"gamma": 1.2},
+    "dye_couplers": {"couplers_on": True},
+    "halation": {"halation_on": True, "halation_amount": 2.0},
+    "halation_weak": {"stock": "kodak_gold_200", "halation_on": True, "halation_amount": 2.0},
+    "halation_cine": {"stock": "kodak_vision3_250d", "halation_on": True, "halation_amount": 2.0},
+    "camera_diffusion": {"camera_diffusion_strength": 0.75},
+    "print_exposure": {"print_exposure": 1.6},
+    "print_preflash": {"print_preflash": 0.08},
+    "print_filters": {"print_y_filter_shift": 10.0, "print_m_filter_shift": -8.0},
+    "scanner_blur": {"scan_softness": 0.8},
+    "scanner_sharpen": {"scan_sharpen": True, "scan_sharpness": 1.5},
+    "scanner_glare": {"glare_on": True, "glare_amount": 2.0},
+    "reversal": {"stock": "fujifilm_velvia_100"},
+}
+BW_CASES = {
+    "development_short": {"stock": "kodak_doublex", "paper": "kodak_2302", "development_time": 4.0},
+    "development_long": {"stock": "kodak_doublex", "paper": "kodak_2302", "development_time": 12.0},
+}
+
+
+def target_linear(width=192, height=128):
+    """Quantized ramps, grey steps, color patches, impulses, and edge detail."""
+    x = np.linspace(0.003, 0.97, width)
+    y = np.linspace(0.1, 1.0, height)[:, None]
+    result = np.stack(np.broadcast_arrays(x * y, np.sqrt(x) * y,
+                                          (1 - 0.8 * x) * y), axis=-1)
+    patches = [(0, 0, 0), (.003, .003, .003), (.018, .018, .018),
+               (.18, .18, .18), (.5, .5, .5), (1, 1, 1),
+               (.8, .08, .04), (.04, .7, .1), (.05, .1, .85),
+               (.75, .45, .27), (.12, .36, .22), (.1, .35, .75)]
+    for index, color in enumerate(patches):
+        left = index * width // len(patches)
+        right = (index + 1) * width // len(patches)
+        result[height // 8:height // 3, left:right] = color
+    result[height // 2:3 * height // 4, :width // 3] = .004
+    result[height // 2 + 2:3 * height // 4 - 2, width // 6] = 1
+    result[0, 0] = (1, .9, .7)
+    # Both oracles get EXACTLY the same uint16 TIFF input, including black.
+    return np.rint(np.clip(result, 0, 1) * 65535).astype(np.uint16) / 65535.0
+
+
+def difference_metrics(reference, actual):
+    """Refuse invalid arrays before aggregating; a NaN may never pass a gate."""
+    reference, actual = np.asarray(reference), np.asarray(actual)
+    if reference.shape != actual.shape or reference.size == 0:
+        raise ValueError(f"shape mismatch or empty arrays: {reference.shape} / {actual.shape}")
+    if not np.all(np.isfinite(reference)) or not np.all(np.isfinite(actual)):
+        raise ValueError("non-finite reference or actual processing output")
+    error = np.abs(reference.astype(np.float64) - actual.astype(np.float64))
+    return {"mean": float(error.mean()), "p95": float(np.percentile(error, 95)),
+            "max": float(error.max())}
+
+
+def compare_stage(name, reference, actual, outdir, *, tolerance, units):
+    outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    for label, value in (("reference", reference), ("actual", actual)):
+        np.save(outdir / f"{label}.npy", value, allow_pickle=False)
+    try:
+        metrics = difference_metrics(reference, actual)
+        passed = all(metrics[key] <= limit for key, limit in tolerance.items())
+        error = None
+    except ValueError as exc:
+        metrics, passed, error = {}, False, str(exc)
+    record = {"name": name, "status": "pass" if passed else "fail",
+              "metrics": metrics, "tolerance": tolerance, "units": units,
+              "artifacts": {"reference": str(outdir / "reference.npy"),
+                            "actual": str(outdir / "actual.npy")}}
+    if error:
+        record["error"] = error
+    return record
+
+
+def numpy_develop(log_exposure, exposure_axis, density_curves, gamma=1.0):
+    """Linear interpolation of measured characteristic curves, no engine code."""
+    curves = np.asarray(density_curves, dtype=np.float64)
+    curves = curves - np.nanmin(curves, axis=0)
+    axis = np.asarray(exposure_axis, dtype=np.float64) / gamma
+    out = np.empty_like(log_exposure, dtype=np.float64)
+    for channel in range(3):
+        valid = np.isfinite(curves[:, channel]) & np.isfinite(axis)
+        if valid.sum() < 2 or np.any(np.diff(axis[valid]) <= 0):
+            raise ValueError("density profile needs at least two ordered finite samples")
+        out[..., channel] = np.interp(log_exposure[..., channel], axis[valid],
+                                      curves[valid, channel])
+    return out
+
+
+def measured_curves(profile, requested_time=None):
+    """Read/resolve the model's measured input, independently of either engine."""
+    raw = json.loads(Path(profile).read_text())
+    data = raw["data"]
+    curves = np.asarray(data["density_curves"], dtype=np.float64)
+    if raw["info"].get("channel_model") == "bw":
+        times = np.asarray(data.get("development_time") or [0.0])
+        index = ((len(times) - 1) // 2 if requested_time is None
+                 else int(np.argmin(np.abs(times - requested_time))))
+        curves = np.repeat(curves[:, index:index + 1], 3, axis=1)
+    return np.asarray(data["log_exposure"], dtype=np.float64), curves
+
+
+def grain_variance(density, density_max, density_min, particle_area, pixel_size,
+                   uniformity, blur):
+    """Poisson thinning variance, including the discrete Gaussian blur's L2 norm.
+
+    If N~Poisson(n/s), X|N~Binomial(N,p), then X~Poisson(n*p/s).
+    Grain density is X*(Dmax/n)*s. This derives its variance without calling
+    either engine's RNG or grain code. Independent sublayer averaging cancels
+    the corresponding particle-count division.
+    """
+    total_density = np.asarray(density) + np.asarray(density_min)
+    maximum = np.asarray(density_max) + np.asarray(density_min)
+    probability = np.clip(total_density / maximum, 1e-6, 1 - 1e-6)
+    saturation = 1 - probability * np.asarray(uniformity) * (1 - 1e-6)
+    particles = pixel_size ** 2 / np.asarray(particle_area)
+    variance = probability * maximum ** 2 * saturation / particles
+    if blur > .4:
+        coordinates = np.arange(-int(3 * blur + .5), int(3 * blur + .5) + 1)
+        kernel = np.exp(-.5 * (coordinates / blur) ** 2)
+        kernel /= kernel.sum()
+        variance *= np.sum(kernel ** 2) ** 2
+    return variance
+
+
+def grain_checks(output_dir, binary, gpu=False):
+    """Grain uses moments and exact within-engine repeatability, not seed parity.
+
+    Discrete Poisson/binomial samplers can consume different random streams
+    after even a 1e-7 input perturbation. GPU also uses another sampler. A
+    per-pixel cross-engine threshold would therefore test the seed stream,
+    while these checks test the modeled mean, variance, and stable previews.
+    """
+    from PIL import Image
+    import tifffile
+    fp, digest_params, _ = _runtime()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = np.empty((128, 192, 3), dtype=np.uint16)
+    for index, value in enumerate((.03, .18, .5)):
+        target[:, index * 64:(index + 1) * 64] = round(value * 65535)
+    source = output_dir / "flat-fields.tif"
+    tifffile.imwrite(source, target, photometric="rgb")
+    params = fp.clean_params(BASE_PARAMS | {"grain_on": True, "grain_amount": 20.0})
+    digested = digest_params(fp.build_params(params))
+    grain = digested.film_render.grain
+    axis, curves = measured_curves(APP / "engine/data/profiles/kodak_portra_400.json")
+    maxima = np.nanmax(curves - np.nanmin(curves, axis=0), axis=0)
+    records = []
+    # CPU diagnostic density is used for an absolute analytical variance gate.
+    actual = cli_stages(source, params, output_dir / "cpu", binary=binary)
+    repeat = cli_stages(source, params, output_dir / "cpu-repeat", binary=binary)
+    for stage in ("film_development", "scan"):
+        records.append(compare_stage(f"grain/{stage}/repeatability", actual[stage], repeat[stage],
+                                     output_dir / f"repeat-{stage}",
+                                     tolerance={"mean": 0, "p95": 0, "max": 0}, units="exact float values"))
+    no_grain = numpy_develop(actual["film_exposure"], axis, curves)
+    variance = grain_variance(no_grain, maxima, grain.density_min,
+                              grain.particle_area_um2 * np.asarray(grain.particle_scale),
+                              float(np.float32(35000 / 192)), grain.uniformity, grain.blur)
+    unblurred_variance = grain_variance(no_grain, maxima, grain.density_min,
+                                        grain.particle_area_um2 * np.asarray(grain.particle_scale),
+                                        float(np.float32(35000 / 192)), grain.uniformity, 0)
+    for field in range(3):
+        # Exclude blur support near the flat-field boundary; these are uniform
+        # fields, not a global image histogram that can hide missing grain.
+        area = (slice(8, -8), slice(field * 64 + 8, (field + 1) * 64 - 8))
+        residual = actual["film_development"][area] - no_grain[area]
+        wanted = variance[area].mean(axis=(0, 1))
+        measured = residual.var(axis=(0, 1))
+        ratio = measured / wanted
+        samples = residual.shape[0] * residual.shape[1]
+        # Mean uncertainty uses preblur variance; blurring correlates pixels.
+        mean_z = np.abs(residual.mean(axis=(0, 1))) / np.sqrt(unblurred_variance[area].mean(axis=(0, 1)) / samples)
+        valid = bool(np.all(np.isfinite(ratio)) and np.all((ratio >= .7) & (ratio <= 1.3))
+                     and np.all(mean_z <= 6))
+        records.append({"name": f"grain/flat_field_{field}/analytical_moments",
+                        "status": "pass" if valid else "fail", "units": "optical density",
+                        "metrics": {"variance_ratio_rgb": ratio.tolist(), "mean_error_sigma_rgb": mean_z.tolist()},
+                        "expected_variance_rgb": wanted.tolist(), "actual_variance_rgb": measured.tolist(),
+                        "tolerance": {"variance_ratio": [.7, 1.3], "mean_error_sigma": 6},
+                        "sample_count_per_channel": samples})
+    Image.fromarray(np.rint(np.clip(actual["scan"], 0, 1) * 255).astype(np.uint8)).save(output_dir / "grain-preview.png")
+    np.save(output_dir / "density-with-grain.npy", actual["film_development"], allow_pickle=False)
+    np.save(output_dir / "density-no-grain-reference.npy", no_grain, allow_pickle=False)
+    if gpu:
+        gpu_actual = cli_stages(source, params, output_dir / "gpu", backend="wgpu", binary=binary)
+        gpu_repeat = cli_stages(source, params, output_dir / "gpu-repeat", backend="wgpu", binary=binary)
+        records.append(compare_stage("grain/gpu_scan/repeatability", gpu_actual["scan"], gpu_repeat["scan"],
+                                     output_dir / "gpu-repeatability", tolerance={"mean": 0, "p95": 0, "max": 0}, units="exact float values"))
+        # For GPU, where density taps are unavailable, compare flat-field scan
+        # noise variance and mean to the verified CPU implementation.
+        for field in range(3):
+            area = (slice(8, -8), slice(field * 64 + 8, (field + 1) * 64 - 8))
+            cpu, gpu_pixels = actual["scan"][area], gpu_actual["scan"][area]
+            ratio = gpu_pixels.var(axis=(0, 1)) / cpu.var(axis=(0, 1))
+            bias = np.abs(gpu_pixels.mean(axis=(0, 1)) - cpu.mean(axis=(0, 1))) * 255
+            passed = bool(np.isfinite(ratio).all() and np.all((ratio >= .6) & (ratio <= 1.4)) and np.all(bias <= 1))
+            records.append({"name": f"grain/gpu_flat_field_{field}/cpu_moments", "status": "pass" if passed else "fail",
+                            "metrics": {"variance_ratio_rgb": ratio.tolist(), "mean_bias_255_rgb": bias.tolist()},
+                            "tolerance": {"variance_ratio": [.6, 1.4], "mean_bias_255": 1}})
+    return records
+
+
+def _runtime():
+    """Resolve this checkout's vendored oracle before any editable install."""
+    source = APP / "vendor" / "spektrafilm" / "src"
+    if not (source / "spektrafilm").is_dir():
+        raise RuntimeError("missing vendor/spektrafilm/src Python reference runtime")
+    sys.path.insert(0, str(source))
+    sys.path.insert(0, str(APP))
+    import film_pipeline as fp
+    from spektrafilm.runtime.params_builder import digest_params
+    from spektrafilm.runtime.pipeline import SimulationPipeline
+    return fp, digest_params, SimulationPipeline
+
+
+def python_stages(target, params):
+    fp, digest_params, SimulationPipeline = _runtime()
+    pipeline = SimulationPipeline(digest_params(fp.build_params(params)))
+    outputs = {}
+    value = pipeline.process(target, collect="log_e_film")
+    outputs["film_exposure"] = np.asarray(value).copy()
+    value = pipeline.process(value, inject="log_e_film", collect="cmy_film")
+    outputs["film_development"] = np.asarray(value).copy()
+    if not pipeline.io.scan_film:
+        value = pipeline.process(value, inject="cmy_film", collect="log_e_print")
+        outputs["print_exposure"] = np.asarray(value).copy()
+        value = pipeline.process(value, inject="log_e_print", collect="cmy_print")
+        outputs["print_development"] = np.asarray(value).copy()
+        inject = "cmy_print"
+    else:
+        inject = "cmy_film"
+    # This is also the clipping performed by LightTable's Python bridge,
+    # film_pipeline.render_float, before display/export of scanner output.
+    outputs["scan"] = np.clip(pipeline.process(value, inject=inject), 0, 1).copy()
+    return outputs, pipeline
+
+
+def cli_stages(source, params, outdir, *, backend="cpu", binary=None):
+    """Run the product's resident JSON CLI; backend fallback cannot pass."""
+    fp, _, _ = _runtime()
+    outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    binary = Path(binary or APP / "build/processing-cargo/debug/lighttable-engine").resolve()
+    data = APP / "engine" / "data"
+    if not binary.is_file() or not data.is_dir():
+        raise RuntimeError("requires current-source lighttable-engine build and engine/data; run setup/build first")
+    output = outdir / "output.tif"
+    # Reusing a report directory must never let yesterday's successful TIFF
+    # or stage dump stand in for a missing result from today's engine.
+    for artifact in [output, *(outdir / f"{stage}.f64" for stage in STAGES)]:
+        artifact.unlink(missing_ok=True)
+    request = {"id": 1, "input": str(source), "output": str(output),
+               "bit_depth": 32, "data_dir": str(data), "film": params["stock"],
+               "paper": params["paper"], "scan_film": params["stock"] in fp.POSITIVE_STOCKS,
+               "params": fp.rust_params_json(params)}
+    (outdir / "request.json").write_text(json.dumps(request, indent=2) + "\n")
+    env = dict(os.environ, SPEKTRAFILM_BACKEND=backend, RAYON_NUM_THREADS="2")
+    # Parent process diagnostic variables must not leak into unrelated runs.
+    for name in STAGES.values():
+        env.pop(name, None)
+    if backend == "cpu":
+        for stage, name in STAGES.items():
+            env[name] = str(outdir / f"{stage}.f64")
+    result = subprocess.run([str(binary)], input=json.dumps(request) + "\n",
+                            capture_output=True, text=True, env=env, timeout=180)
+    logs = result.stdout + "\n" + result.stderr
+    (outdir / "cli.log").write_text(logs)
+    if result.returncode:
+        raise RuntimeError(f"CLI exited {result.returncode}: {logs[-1500:]}")
+    responses = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    if len(responses) != 1 or responses[0].get("id") != 1 or not responses[0].get("ok"):
+        raise RuntimeError(f"invalid/failed resident engine response: {responses}")
+    reported_backend = responses[0].get("backend", "")
+    if backend == "wgpu" and "wgpu" not in reported_backend.lower():
+        raise RuntimeError(f"required wgpu unavailable: engine reported {reported_backend!r}")
+    if backend == "cpu" and "cpu" not in reported_backend.lower():
+        raise RuntimeError(f"required CPU backend: engine reported {reported_backend!r}")
+    import tifffile
+    shape = tifffile.imread(source).shape
+    stages = {}
+    if backend == "cpu":
+        stages.update({stage: outdir / f"{stage}.f64" for stage in STAGES
+                       if not stage.startswith("print_") or params["stock"] not in fp.POSITIVE_STOCKS})
+    if not output.is_file():
+        raise RuntimeError(f"missing required final scan TIFF: {output}")
+    arrays = {"scan": tifffile.imread(output)}
+    if arrays["scan"].shape != shape or arrays["scan"].dtype != np.float32:
+        raise RuntimeError("expected full-size RGB float32 TIFF from resident engine")
+    for stage, path in stages.items():
+        if not path.is_file():
+            raise RuntimeError(f"missing required {stage} diagnostic buffer: {path}")
+        raw = np.fromfile(path, dtype="<f8")
+        if raw.size != int(np.prod(shape)):
+            raise RuntimeError(f"{stage}: expected {shape} f64 buffer, got {raw.size} elements")
+        arrays[stage] = raw.reshape(shape)
+    return arrays
+
+
+def run(output_dir, *, cases=None, gpu=False, binary=None):
+    """Run required real engines and return JSON-safe evidence and check records."""
+    from PIL import Image
+    import tifffile
+    fp, _, _ = _runtime()
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    records = []
+    if binary is None:
+        from processing_export import ensure_resident
+        binary, build_record = ensure_resident(output_dir / "build")
+        records.append(build_record)
+        if binary is None:
+            return {"name": "film_reference", "status": "fail", "records": records}
+    elif not Path(binary).is_file():
+        raise RuntimeError(f"explicit engine binary does not exist: {binary}")
+    target = target_linear()
+    source = output_dir / "target.tif"
+    tifffile.imwrite(source, np.rint(target * 65535).astype(np.uint16), photometric="rgb")
+    Image.fromarray(np.rint(target * 255).astype(np.uint8)).save(output_dir / "target.png")
+    actuals = {}
+    started = time.monotonic()
+    for case in cases or CASES:
+        if case not in CASES:
+            raise ValueError(f"unknown reference case: {case}")
+        case_dir = output_dir / case
+        params = fp.clean_params(BASE_PARAMS | CASES[case])
+        try:
+            reference, pipeline = python_stages(target, params)
+            actual = cli_stages(source, params, case_dir / "cpu", binary=binary)
+        except Exception as error:
+            records.append({"name": f"{case}/required_engine_execution", "status": "fail",
+                            "error": f"{type(error).__name__}: {error}"})
+            continue
+        actuals[case] = actual
+        for stage in actual:
+            rgb = stage == "scan"
+            # Stage thresholds guard f32 rounding and LUT interpolation without
+            # allowing display quantization to hide exposure or density errors.
+            if rgb:
+                from processing_support import compare_images
+                records.append(compare_images(f"{case}/{stage}/python_vs_cpu", reference[stage],
+                                               actual[stage], output_dir,
+                                               {"mean": 1, "p95": 2, "max": 8}))
+            else:
+                records.append(compare_stage(f"{case}/{stage}/python_vs_cpu", reference[stage],
+                                             actual[stage], case_dir / stage,
+                                             tolerance={"mean": 0.001, "p95": 0.003, "max": 0.01},
+                                             units="log10 exposure" if stage.endswith("exposure")
+                                             else "optical density"))
+        if not params["grain_on"] and not params["couplers_on"]:
+            axis, curves = measured_curves(APP / "engine/data/profiles" / (params["stock"] + ".json"))
+            expected_density = numpy_develop(actual["film_exposure"], axis, curves, params["gamma"])
+            records.append(compare_stage(f"{case}/film_development/numpy_curve", expected_density,
+                                         actual["film_development"], case_dir / "numpy_development",
+                                         tolerance={"mean": 1e-5, "p95": 3e-5, "max": 1e-4},
+                                         units="optical density"))
+        if gpu and not params["grain_on"]:
+            try:
+                actual_gpu = cli_stages(source, params, case_dir / "gpu", backend="wgpu", binary=binary)
+                comparison = compare_images(f"{case}/scan/cpu_vs_gpu", actual["scan"], actual_gpu["scan"],
+                                            output_dir, {"mean": 1, "p95": 2, "max": 8})
+                if params["camera_diffusion_strength"] > 0:
+                    comparison["execution"] = "GPU backend with exact CPU diffusion convolution; full-frame rendering"
+                records.append(comparison)
+            except Exception as error:
+                records.append({"name": f"{case}/required_gpu_execution", "status": "fail", "error": str(error)})
+    if "negative_baseline" in actuals and "exposure_plus_one" in actuals:
+        baseline = actuals["negative_baseline"]["film_exposure"]
+        expected = np.log10(np.maximum(10 ** baseline - 1e-10, 0) * 2 + 1e-10)
+        records.append(compare_stage("exposure_one_stop/numpy_photometric_law", expected,
+                                     actuals["exposure_plus_one"]["film_exposure"],
+                                     output_dir / "exposure_law",
+                                     tolerance={"mean": 1e-5, "p95": 3e-5, "max": 1e-4},
+                                     units="log10 exposure"))
+    if cases is None:
+        for case, changes in BW_CASES.items():
+            params = fp.clean_params(BASE_PARAMS | changes)
+            try:
+                actual = cli_stages(source, params, output_dir / case / "cpu", binary=binary)
+                axis, curves = measured_curves(APP / "engine/data/profiles" / (params["stock"] + ".json"),
+                                               params["development_time"])
+                expected = numpy_develop(actual["film_exposure"], axis, curves, params["gamma"])
+                records.append(compare_stage(f"{case}/film_development/numpy_measured_time_curve", expected,
+                                             actual["film_development"], output_dir / case / "numpy_development",
+                                             tolerance={"mean": 1e-5, "p95": 3e-5, "max": 1e-4}, units="optical density"))
+            except Exception as error:
+                records.append({"name": f"{case}/required_engine_execution", "status": "fail", "error": str(error)})
+        try:
+            records.extend(grain_checks(output_dir / "grain", binary, gpu=gpu))
+        except Exception as error:
+            records.append({"name": "grain/required_engine_execution", "status": "fail", "error": str(error)})
+    # A parity pass is not meaningful if the tested control did nothing. These
+    # checks require a measurable effect at the stage controlled by each knob.
+    affected_stages = {
+        "exposure_plus_one": "film_exposure", "density_gamma": "film_development",
+        "dye_couplers": "film_development", "halation": "film_exposure",
+        "camera_diffusion": "film_exposure", "print_exposure": "print_development",
+        "print_preflash": "print_development", "print_filters": "print_development",
+        "scanner_blur": "scan", "scanner_sharpen": "scan", "scanner_glare": "scan",
+    }
+    if "negative_baseline" in actuals:
+        for case, stage in affected_stages.items():
+            if case in actuals:
+                change = difference_metrics(actuals["negative_baseline"][stage], actuals[case][stage])
+                records.append({"name": f"{case}/{stage}/effect_is_observable",
+                                "status": "pass" if change["max"] > 1e-6 else "fail",
+                                "metrics": change, "minimum_max_change": 1e-6})
+    binary_path = Path(binary or APP / "build/processing-cargo/debug/lighttable-engine").resolve()
+    reference_root = APP / "vendor/spektrafilm/src/spektrafilm"
+    reference_digest = hashlib.sha256()
+    reference_files = sorted(reference_root.rglob("*.py"))
+    for path in reference_files:
+        reference_digest.update(path.relative_to(reference_root).as_posix().encode() + b"\0")
+        reference_digest.update(path.read_bytes())
+    return {"name": "film_reference", "status": "pass" if all(r["status"] == "pass" for r in records) else "fail",
+            "records": records, "seconds": time.monotonic() - started,
+            "binary": str(binary_path), "binary_sha256": hashlib.sha256(binary_path.read_bytes()).hexdigest(),
+            "input_sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+            "reference_source": {"path": str(reference_root.resolve()), "files": len(reference_files),
+                                 "sha256": reference_digest.hexdigest()},
+            "profiles": {name: hashlib.sha256((APP / "engine/data/profiles" / (name + ".json")).read_bytes()).hexdigest()
+                         for name in sorted({fp.clean_params(BASE_PARAMS | changes)[key]
+                                             for changes in list(CASES.values()) + list(BW_CASES.values())
+                                             for key in ("stock", "paper")})},
+            "reference": "independent Python spectral model and NumPy characteristic-curve/EV equations",
+            "limitations": ["Shared measured profiles are inputs, not independently remeasured film ground truth.",
+                            "CPU diagnostic buffers expose film exposure/development and print exposure/development; final scan is a float TIFF from the product export path.",
+                            "GPU intermediate stage buffers are not exposed by the resident path.",
+                            "Grain is checked against analytical Poisson-binomial moments and exact within-engine repeatability; cross-engine random sample identity is not required.",
+                            "Active optical diffusion uses an exact CPU convolution with other stages on the selected backend; this can increase preview latency and disables viewport acceleration for the effect.",
+                            "B&W development-time families are checked against their measured characteristic curves, not the Python bridge, which does not route that control."]}
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--case", action="append", choices=CASES)
+    parser.add_argument("--gpu", action="store_true")
+    args = parser.parse_args()
+    result = run(args.output_dir, cases=args.case, gpu=args.gpu)
+    (args.output_dir / "report.json").write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2))
+    raise SystemExit(0 if result["status"] == "pass" else 1)

--- a/tests/processing_support.py
+++ b/tests/processing_support.py
@@ -1,0 +1,116 @@
+"""Shared fixtures and fail-closed numerical scoring for processing gates.
+
+References must come from a separate implementation, never captured goldens.
+All image tolerances are expressed in 8-bit code values, even for float input.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import subprocess
+
+import numpy as np
+from PIL import Image
+
+
+PIXEL_TOLERANCE = {"mean": 0.75, "p95": 2.0, "max": 5.0}
+
+
+def run_browser(command, *, cwd, timeout):
+    """Allow the JS signal handler to close owned browser children on timeout."""
+    child = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, text=True)
+    try:
+        stdout, stderr = child.communicate(timeout=timeout)
+    except (subprocess.TimeoutExpired, KeyboardInterrupt):
+        child.terminate()
+        try:
+            child.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.communicate(timeout=5)
+        raise
+    return subprocess.CompletedProcess(command, child.returncode, stdout, stderr)
+
+
+def target_rgb8(width=128, height=96):
+    """Asymmetric ramps, color patches, edges and noise expose common errors."""
+    y, x = np.mgrid[:height, :width]
+    image = np.stack((x / (width - 1), y / (height - 1),
+                      (x + 2 * y) / (width + 2 * height - 3)), axis=-1)
+    image[height//3:height//2, :width//4] = (0.8, 0.12, 0.04)
+    image[height//2:3*height//4, width//2:3*width//4] = (0.05, 0.25, 0.9)
+    image[:height//6, :width//6] = 0
+    image[-height//6:, -width//6:] = 1
+    noise = np.random.default_rng(8301).normal(0, 0.015, image.shape)
+    image[height//2:, :width//3] += noise[height//2:, :width//3]
+    return np.round(np.clip(image, 0, 1) * 255).astype(np.uint8)
+
+
+def grade_cases():
+    cases = [{"name": "identity", "grade": {}}]
+    for key in ("exposure", "contrast", "highlights", "shadows", "whites",
+                "blacks", "temp", "tint", "vibrance", "saturation", "texture",
+                "clarity", "dehaze", "vignette", "chromaticAberrationRedCyan",
+                "chromaticAberrationBlueYellow"):
+        for value in (-0.65, 0.65):
+            cases.append({"name": f"{key}-{'negative' if value < 0 else 'positive'}",
+                          "grade": {key: value}})
+    for key in ("sharpness", "luminanceNoise", "colorNoise"):
+        cases.append({"name": key, "grade": {key: 0.7}})
+    cases.extend([
+        {"name": "sharpen-controls", "grade": {"sharpness": 0.7,
+         "sharpenRadius": 2.2, "sharpenDetail": 0.6, "sharpenMasking": 0.4}},
+        {"name": "curves", "grade": {"curveL": (np.linspace(0, 1, 256) ** 0.8).tolist(),
+         "curveB": (np.linspace(0, 1, 256) ** 1.2).tolist()}},
+        {"name": "hsl", "grade": {"hsl": {"red": {"h": 0.2, "s": -0.4, "l": 0.1},
+         "blue": {"h": -0.3, "s": 0.2, "l": -0.15}}}},
+        {"name": "point-color", "grade": {"pointColor": [{"hue": 20, "range": 50,
+         "hueShift": 15, "saturation": -0.2, "luminance": 0.1,
+         "uniformHue": 0.3, "uniformSaturation": 0.2, "uniformLuminance": 0.2,
+         "refSaturation": 0.6, "refLuminance": 0.5}]}},
+        {"name": "color-grading", "grade": {"colorGrading": {
+         "shadows": {"hue": 220, "saturation": 0.4},
+         "highlights": {"hue": 30, "saturation": 0.3}, "balance": 0.1, "blending": 0.6}}},
+        {"name": "combined-order", "grade": {"exposure": 0.4, "contrast": 0.2,
+         "highlights": -0.35, "shadows": 0.3, "temp": 0.2, "tint": -0.1,
+         "saturation": -0.2, "dehaze": 0.1}},
+    ])
+    for key in ('curveR', 'curveG'):
+        cases.append({'name':key, 'grade':{key:(np.linspace(0, 1, 256) ** 0.75).tolist()}})
+    for band in ('orange', 'yellow', 'green', 'aqua', 'purple', 'magenta'):
+        cases.append({'name':'hsl-' + band, 'grade':{'hsl':{band:{'h':0.3, 's':-0.4, 'l':0.15}}}})
+    for tone in ('midtones', 'global'):
+        cases.append({'name':'color-grading-' + tone, 'grade':{'colorGrading':{
+            tone:{'hue':180, 'saturation':0.4, 'luminance':0.15}}}})
+    return cases
+
+
+def file_digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def compare_images(name, reference, actual, outdir, tolerance=None):
+    tolerance = dict(PIXEL_TOLERANCE if tolerance is None else tolerance)
+    result = {"name": name, "status": "fail", "tolerance": tolerance,
+              "units": "8-bit code values", "artifacts": {}}
+    reference, actual = np.asarray(reference), np.asarray(actual)
+    if reference.shape != actual.shape or reference.ndim != 3 or reference.shape[-1] != 3:
+        result["error"] = f"RGB shape mismatch: {reference.shape} versus {actual.shape}"
+        return result
+    if not reference.size or not np.isfinite(reference).all() or not np.isfinite(actual).all():
+        result["error"] = "Empty or non-finite pixel output"
+        return result
+    error = np.abs(reference.astype(np.float64) - actual.astype(np.float64)) * 255
+    metrics = {"mean": float(error.mean()), "p95": float(np.percentile(error, 95)),
+               "max": float(error.max())}
+    result.update(metrics=metrics, shape=list(actual.shape),
+                  status="pass" if all(metrics[k] <= tolerance[k] for k in metrics) else "fail")
+    directory = Path(outdir) / name
+    directory.mkdir(parents=True, exist_ok=True)
+    for key, pixels in (("reference", reference), ("actual", actual),
+                        ("difference-8x", error / 255 * 8)):
+        path = directory / f"{key}.png"
+        Image.fromarray(np.round(np.clip(pixels, 0, 1) * 255).astype(np.uint8)).save(path)
+        result["artifacts"][key] = str(path.resolve())
+    return result

--- a/tests/processing_webgl.mjs
+++ b/tests/processing_webgl.mjs
@@ -1,0 +1,66 @@
+// Production WebGL renderer, synchronous framebuffer readback, and composited
+// canvas screenshots. The interactive canvas keeps preserveDrawingBuffer=false.
+import fs from 'node:fs';
+import {pathToFileURL} from 'node:url';
+const config = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const {chromium} = await import(pathToFileURL(config.module).href);
+const browser = await chromium.launch({headless: true,
+  executablePath: config.browser || undefined,
+  args: ['--enable-unsafe-swiftshader', '--force-color-profile=srgb']});
+for (const signal of ['SIGTERM', 'SIGINT']) process.on(signal, async () => {await browser.close(); process.exit(1);});
+try {
+  const page = await browser.newPage({viewport: {width: 640, height: 480}, deviceScaleFactor: 1});
+  const errors = [];
+  page.on('pageerror', e => errors.push(e.message));
+  await page.goto(config.baseUrl);
+  await page.evaluate(async () => {
+    const {GradeRenderer} = await import('/web/gl.js');
+    document.body.innerHTML = '<canvas id="preview"></canvas>';
+    document.body.style.cssText = 'margin:0;background:#333';
+    const canvas = document.querySelector('canvas');
+    canvas.style.display = 'block';
+    window.renderer = new GradeRenderer(canvas);
+    if (!renderer.gl) throw Error('WebGL unavailable');
+  });
+  const records = [];
+  for (const test of config.cases) {
+    const output = await page.evaluate(async (test) => {
+      const image = new Image();
+      image.src = test.source;
+      await image.decode();
+      renderer.setImage(image);
+      renderer.clearOriginalImage();
+      if (test.original) {
+        const original = new Image(); original.src = test.original;
+        await original.decode(); renderer.setOriginalImage(original);
+      }
+      renderer.comparePosition = test.compare || 0;
+      renderer.draw(test.grade);
+      const gl = renderer.gl, canvas = renderer.canvas;
+      const rgba = new Uint8Array(canvas.width * canvas.height * 4);
+      // Read immediately in the draw task, before the nonpersistent buffer retires.
+      gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+      const error = gl.getError();
+      if (error) throw Error(`WebGL error ${error}`);
+      const debug = gl.getExtension('WEBGL_debug_renderer_info');
+      window.drawForCapture = () => renderer.draw(test.grade);
+      return {width: canvas.width, height: canvas.height, pixels: Array.from(rgba),
+        renderer: debug ? gl.getParameter(debug.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER)};
+    }, test);
+    // Keep a live frame available during Playwright's animation-stability check.
+    await page.evaluate(() => {
+      window.captureActive = true;
+      const draw = () => { if (window.captureActive) {drawForCapture(); requestAnimationFrame(draw);} };
+      requestAnimationFrame(draw);
+    });
+    await page.locator('#preview').screenshot({path: test.screenshot, timeout: 15000});
+    await page.evaluate(() => { window.captureActive = false; });
+    fs.writeFileSync(test.raw, Buffer.from(output.pixels));
+    delete output.pixels;
+    records.push({name: test.name, ...output});
+  }
+  if (errors.length) throw Error(errors.join('\n'));
+  fs.writeFileSync(config.result, JSON.stringify({records, browserVersion: browser.version()}));
+} finally {
+  await browser.close();
+}

--- a/tests/processing_webgl.py
+++ b/tests/processing_webgl.py
@@ -1,0 +1,99 @@
+"""Run production browser shaders against independently executed CPU grading."""
+from __future__ import annotations
+
+import functools
+import http.server
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import threading
+
+import numpy as np
+from PIL import Image
+
+import grade
+from processing_support import compare_images, grade_cases, target_rgb8, run_browser
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(output_dir):
+    from bench.benchmark import find_playwright_browser, find_playwright_module
+    module = find_playwright_module()
+    node = shutil.which('node')
+    if not module or not node:
+        raise RuntimeError('WebGL gate requires Node and Playwright; set LIGHTTABLE_PLAYWRIGHT_MODULE')
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source = target_rgb8()
+    reverse = np.ascontiguousarray(source[::-1, ::-1, ::-1])
+    portrait = target_rgb8(96, 128)
+    sources = {'target': source, 'reverse': reverse, 'portrait': portrait}
+    for name, pixels in sources.items():
+        Image.fromarray(pixels).save(output_dir / f'{name}.png')
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def translate_path(self, path):
+            # Serve only checked-in renderer module and generated fixture PNGs.
+            if path == '/web/gl.js':
+                return str(ROOT / 'web/gl.js')
+            return super().translate_path(path)
+
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0),
+        functools.partial(Handler, directory=str(output_dir)))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f'http://127.0.0.1:{server.server_port}'
+    tests = grade_cases()
+    tests.extend([
+        {'name': 'navigate-b', 'grade': {}, 'fixture': 'reverse'},
+        {'name': 'navigate-a', 'grade': {}},
+        {'name': 'portrait', 'grade': {'exposure': 0.4}, 'fixture': 'portrait'},
+        {'name': 'compare-half', 'grade': {'exposure': 0.4}, 'compare': 0.5},
+        {'name': 'compare-off', 'grade': {'exposure': 0.4}},
+    ])
+    for test in tests:
+        test.update(source=f"{base}/{test.get('fixture', 'target')}.png",
+                    screenshot=str(output_dir / f"{test['name']}-display.png"),
+                    raw=str(output_dir / f"{test['name']}.rgba"))
+        if test.get('compare'):
+            test['original'] = f'{base}/reverse.png'
+    result_path = output_dir / 'browser.json'
+    config = output_dir / 'config.json'
+    config.write_text(json.dumps({'baseUrl': base, 'module': str(module),
+        'browser': os.environ.get('LIGHTTABLE_BROWSER_EXECUTABLE') or
+                   (str(find_playwright_browser()) if find_playwright_browser() else None),
+        'cases': tests, 'result': str(result_path)}))
+    try:
+        completed = run_browser([node, str(ROOT / 'tests/processing_webgl.mjs'), str(config)],
+            cwd=ROOT, timeout=240)
+        (output_dir / 'browser.log').write_text(completed.stdout + completed.stderr)
+        if completed.returncode:
+            raise RuntimeError(f'WebGL runner failed: {completed.stderr[-1800:]}')
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    metadata = json.loads(result_path.read_text())
+    records = []
+    for test, result in zip(tests, metadata['records'], strict=True):
+        pixels = sources[test.get('fixture', 'target')].astype(np.float32) / 255
+        expected = grade.apply(pixels, test['grade'])
+        if test.get('compare'):
+            expected[:, :64] = reverse[:, :64] / 255
+        actual = np.fromfile(test['raw'], dtype=np.uint8).reshape(result['height'], result['width'], 4)
+        actual = actual[::-1, :, :3].astype(np.float32) / 255
+        record = compare_images(test['name'], expected, actual, output_dir / 'pixels')
+        record['reference'] = 'Python grade.apply (separate CPU implementation)'
+        records.append(record)
+        display = np.asarray(Image.open(test['screenshot']).convert('RGB')).astype(np.float32) / 255
+        records.append(compare_images(test['name'] + '-compositor', actual, display,
+            output_dir / 'display', {'mean': 0.1, 'p95': 0.0, 'max': 1.0}))
+    return {'records': records, 'browser': metadata['browserVersion'],
+            'renderer': metadata['records'][0]['renderer'],
+            'coverage': 'Production WebGL shader and composited canvas, isolated from full app UI'}

--- a/tests/test_processing_export.py
+++ b/tests/test_processing_export.py
@@ -1,0 +1,35 @@
+"""Reference sanity checks; real worker cases run in the export gate."""
+from pathlib import Path
+import sys
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from processing_export import (analytical_exposure, reference_geometry,
+                               reference_resize, srgb_decode, srgb_encode)
+
+
+class ProcessingExportTests(unittest.TestCase):
+    def test_transfer_function_anchors_and_exposure_are_linear_light(self):
+        np.testing.assert_allclose(srgb_encode([0, .0031308, .18, 1]),
+                                   [0, .040449936, .4613561295, 1], atol=1e-9)
+        np.testing.assert_allclose(srgb_decode(srgb_encode([0, .001, .18, .75, 1])),
+                                   [0, .001, .18, .75, 1], atol=1e-12)
+        expected = srgb_encode(.36)
+        self.assertAlmostEqual(float(analytical_exposure(srgb_encode(.18), 1)), expected)
+        self.assertGreater(abs(expected - srgb_encode(.18) * 2), .1)
+
+    def test_lanczos_keeps_constant_colors_and_rotated_crop_location(self):
+        constant = np.full((24, 36, 3), [.11, .33, .77])
+        resized = reference_resize(constant, 12)
+        self.assertEqual(resized.shape, (8, 12, 3))
+        np.testing.assert_allclose(resized, np.broadcast_to([.11, .33, .77], resized.shape), atol=1e-12)
+        image = np.arange(6 * 8 * 3).reshape(6, 8, 3) / 144
+        result = reference_geometry(image, rotate=90,
+                                    crop={"x": 0, "y": 0, "w": .5, "h": .5})
+        np.testing.assert_array_equal(result, np.rot90(image, 3)[:4, :3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_processing_gate.py
+++ b/tests/test_processing_gate.py
@@ -1,0 +1,43 @@
+"""The scorer must catch realistic silent failures, not just average drift."""
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+import numpy as np
+
+from processing_support import compare_images, target_rgb8
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location('processing_gate', ROOT / 'scripts/check-processing.py')
+gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gate)
+
+
+class ProcessingGateTests(unittest.TestCase):
+    def test_rejects_bad_pixels_shapes_and_missing_work(self):
+        reference = target_rgb8().astype(float) / 255
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(compare_images('same', reference, reference, directory)['status'], 'pass')
+            for name, bad in [('upside-down', reference[::-1]), ('wrong-channels', reference[..., ::-1]),
+                              ('blank', np.zeros_like(reference)), ('nan', reference * np.nan),
+                              ('dimensions', reference[:20])]:
+                self.assertEqual(compare_images(name, reference, bad, directory)['status'], 'fail', name)
+            one_bad_pixel = reference.copy()
+            one_bad_pixel[20, 20] = 1 - one_bad_pixel[20, 20]
+            self.assertEqual(compare_images('localized', reference, one_bad_pixel, directory)['status'], 'fail')
+        for suite in [{}, {'status': 'pass', 'records': []},
+                      {'status': 'blocked', 'records': [{'status': 'pass'}]},
+                      {'records': [{'status': 'skip'}]}]:
+            self.assertFalse(gate.passed(suite))
+
+    def test_blocked_is_a_junit_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            gate.write_reports({'status': 'fail', 'provenance': {'revision': 'fixture'},
+                                'suites': {'native': {'status': 'blocked', 'records': []}}}, path)
+            self.assertIn('failures="1"', (path / 'junit.xml').read_text())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_processing_reference.py
+++ b/tests/test_processing_reference.py
@@ -1,0 +1,117 @@
+"""Checks that the correctness gate rejects invalid output and wrong physics."""
+import json
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import processing_reference
+from processing_reference import (cli_stages, compare_stage, difference_metrics, grain_variance,
+                                  measured_curves, numpy_develop, target_linear)
+
+
+class ProcessingReferenceTests(unittest.TestCase):
+    def test_previous_dumps_cannot_hide_missing_current_output(self):
+        import subprocess
+        import tifffile
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "engine/data").mkdir(parents=True)
+            source = root / "source.tif"
+            tifffile.imwrite(source, np.zeros((2, 3, 3), dtype=np.uint16), photometric="rgb")
+            output = root / "run"
+            output.mkdir()
+            tifffile.imwrite(output / "output.tif", np.zeros((2, 3, 3), dtype=np.float32), photometric="rgb")
+            for stage in processing_reference.STAGES:
+                np.zeros((2, 3, 3)).tofile(output / f"{stage}.f64")
+            response = subprocess.CompletedProcess([], 0, '{"id":1,"ok":true,"backend":"CPU (rayon)"}\n', '')
+            def writes_final_but_omits_stage(*_args, **_kwargs):
+                tifffile.imwrite(output / "output.tif", np.zeros((2, 3, 3), dtype=np.float32), photometric="rgb")
+                return response
+            fake_bridge = SimpleNamespace(rust_params_json=lambda _: {}, POSITIVE_STOCKS=set())
+            with patch.object(processing_reference, "APP", root), \
+                 patch.object(processing_reference, "_runtime", return_value=(fake_bridge, None, None)), \
+                 patch.object(processing_reference.subprocess, "run", side_effect=writes_final_but_omits_stage):
+                with self.assertRaisesRegex(RuntimeError, "missing required film_exposure diagnostic buffer"):
+                    cli_stages(source, {"stock": "test", "paper": "test"}, output, binary=sys.executable)
+            self.assertTrue((output / "output.tif").exists())
+            self.assertFalse(any(output.glob("*.f64")))
+
+    def test_target_contains_black_white_edges_and_identical_uint16_samples(self):
+        target = target_linear()
+        self.assertEqual(target.shape, (128, 192, 3))
+        self.assertTrue(np.any(np.all(target == 0, axis=-1)))
+        self.assertTrue(np.any(np.all(target == 1, axis=-1)))
+        np.testing.assert_array_equal(target, np.rint(target * 65535) / 65535)
+        self.assertGreater(np.max(np.abs(np.diff(target, axis=1))), .8)
+
+    def test_bad_pixels_and_wrong_shape_cannot_pass(self):
+        valid = np.zeros((2, 3, 3))
+        for invalid in (np.full_like(valid, np.nan), np.full_like(valid, np.inf),
+                        np.zeros((3, 2, 3)), np.zeros((0, 0, 3))):
+            with self.subTest(shape=invalid.shape), self.assertRaises(ValueError):
+                difference_metrics(valid, invalid)
+
+    def test_pixel_local_regression_fails_even_when_mean_is_small(self):
+        correct = np.zeros((100, 100, 3))
+        damaged = correct.copy()
+        damaged[50, 50, 1] = .2
+        with tempfile.TemporaryDirectory() as directory:
+            record = compare_stage("damaged", correct, damaged, directory,
+                                   tolerance={"mean": .001, "p95": .001, "max": .01}, units="density")
+            self.assertEqual(record["status"], "fail")
+            self.assertLess(record["metrics"]["mean"], .001)
+            self.assertEqual(record["metrics"]["max"], .2)
+            self.assertTrue(Path(record["artifacts"]["actual"]).is_file())
+
+    def test_curve_oracle_checks_foot_shoulders_channel_order_and_gamma(self):
+        # Deliberately asymmetric measured curves: swapping channels, missing
+        # base subtraction, or applying gamma to density all produce failures.
+        curves = np.array([[.2, .4, .1], [1.2, 2.4, 3.1], [2.2, 4.4, 6.1]])
+        exposures = np.array([[[-2, -2, -2], [-.25, -.25, -.25], [2, 2, 2]]])
+        expected = np.array([[[0, 0, 0], [.5, 1, 1.5], [2, 4, 6]]])
+        np.testing.assert_allclose(numpy_develop(exposures, [-1, 0, 1], curves, gamma=2), expected)
+        self.assertFalse(np.allclose(numpy_develop(exposures, [-1, 0, 1], curves[:, ::-1], gamma=2), expected))
+
+    def test_curve_oracle_rejects_unordered_or_missing_profile_data(self):
+        for axis, curves in (([0, 0], np.ones((2, 3))),
+                             ([0, 1], np.array([[np.nan] * 3, [1] * 3]))):
+            with self.assertRaises(ValueError):
+                numpy_develop(np.ones((1, 1, 3)), axis, curves)
+
+    def test_development_time_uses_nearest_measured_family_not_column_zero(self):
+        profile = {"info": {"channel_model": "bw"}, "data": {
+            "log_exposure": [-1, 0, 1], "development_time": [4, 6.5, 12],
+            "density_curves": [[.1, .2, .3], [.4, .8, 1.2], [.7, 1.4, 2.1]]}}
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profile.json"
+            path.write_text(json.dumps(profile))
+            _, nominal = measured_curves(path)
+            _, long = measured_curves(path, 11)
+            np.testing.assert_array_equal(nominal[:, 0], [.2, .8, 1.4])
+            np.testing.assert_array_equal(long, np.repeat(np.array([[.3], [1.2], [2.1]]), 3, axis=1))
+
+    def test_grain_moment_oracle_agrees_with_independent_random_draws(self):
+        # NumPy's generator samples the actual Poisson -> Binomial construction;
+        # the oracle computes its moments algebraically and never calls an RNG.
+        rng = np.random.default_rng(68191)
+        density, maximum, particles, uniformity = .7, 2.2, 70, .93
+        probability = density / maximum
+        saturation = 1 - probability * uniformity * (1 - 1e-6)
+        seeds = rng.poisson(particles / saturation, 200_000)
+        samples = rng.binomial(seeds, probability) * maximum / particles * saturation
+        expected = grain_variance(density, maximum, 0, 1, np.sqrt(particles), uniformity, 0)
+        self.assertLess(abs(samples.var() / expected - 1), .015)
+        self.assertLess(abs(samples.mean() - density), .001)
+        blurred = grain_variance(density, maximum, 0, 1, np.sqrt(particles), uniformity, .65)
+        self.assertLess(blurred, expected)
+        self.assertGreater(blurred, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
LightTable's native detail filters could create dark image-edge artifacts, and Rust/GPU film output diverged from the CPU reference for optical diffusion, stock antihalation, and Gaussian boundaries. Correct these rendering differences and add an independent pixel-comparison pipeline covering intermediate film stages, CLI exports, the browser app, WebGL, and the actual native Metal drawable.

The pipeline fails on missing renderers, empty results, backend fallback, invalid pixels, or exceeded tolerances, and saves reference/output/difference images plus JSON, Markdown, and JUnit reports. CI runs the film, export, browser, and app suites; the full local command also requires a working Metal display session.

Validation: the full local command, including GPU film parity, passed all 405 checks (126 film, 86 export, 114 WebGL, 11 app, 68 native). The full local regression suite ran 1,129 tests with four skips and no failures. Focused Rust regression tests, help status/check, and diff checks also passed. See PROCESSING-CORRECTNESS.md for coverage and explicit limits.

Optical diffusion uses the exact CPU PSF convolution inside the GPU pipeline, which can cost performance when diffusion is enabled. These tests establish agreement with software references, not measured physical film or every RAW decoder.
