### PR TITLE
Preserve active buttons and improve zoomed Compare controls

### DIFF
--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -305,7 +305,9 @@
       "command click",
       "control click",
       "navigation",
-      "zoom"
+      "zoom",
+      "compare",
+      "snap slider to view"
     ],
     "sections": [
       {
@@ -317,6 +319,17 @@
           "Use the three Photo view buttons at the top. In the LightTable shortcut scheme, G opens Photo Grid, Shift+G opens Culling Grid, and D opens Detail.",
           "In a grid, use the Size slider to change thumbnail size.",
           "Use the left and right arrow keys to move between photos. In Detail, Space toggles Fit and 1:1 when the photo area has focus."
+        ]
+      },
+      {
+        "title": "Compare while zoomed in",
+        "paragraphs": [
+          "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom."
+        ],
+        "steps": [
+          "Turn on Compare, then zoom beyond Fit.",
+          "Click snap slider to view at the top right of the photo area to center the divider in the current view. This also brings an offscreen divider back after panning, without changing your zoom or pan.",
+          "The button hides when you return to Fit or turn Compare off."
         ]
       },
       {
@@ -352,6 +365,14 @@
       {
         "path": "web/app.js",
         "anchor": "if (e.code === 'Space' && S.viewMode === 'detail' && cur() &&"
+      },
+      {
+        "path": "web/app.js",
+        "anchor": "function snapCompareToView() {"
+      },
+      {
+        "path": "web/compare-view.js",
+        "anchor": "export function comparePositionAtViewCenter(image, viewport) {"
       }
     ]
   },

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -5,14 +5,14 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
     },
@@ -20,22 +20,22 @@
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "capture-time": {
       "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
       "sources": {
         "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "catalog-health-recovery": {
       "content": "41e3f81ef36412cf1ec4ce0f431988f484834120a750a45d31a1fef66365c718",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82"
       }
@@ -43,14 +43,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -58,14 +58,14 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-copy-paste-match-exposure": {
@@ -73,21 +73,21 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
     "editing-crop-geometry": {
       "content": "847f666d8a355cae0104998f95f855baf7de6490a8445d2603e67e681623393c",
       "sources": {
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-curves": {
       "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-detail-effects-enhance": {
@@ -95,53 +95,53 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-effects": {
       "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-masks-ai": {
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "7702f31a22aca801cec4d6985a696f77e4d038fb86613ba1953b2590cd855434",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-photo-merge": {
@@ -150,134 +150,134 @@
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-presets": {
       "content": "53107c055d29749d94f8708d4e18b5e246db2eb67b1b68948659c3f46fc65026",
       "sources": {
         "preset_io.py": "16aafa7edd016912ba7538ae223b1b532c3214b507763c22575ba2d0da25c2ea",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-remove-heal": {
       "content": "41b396a3d13fa3364bd68d63aec838869e50787b3e2a7ab68a5cf4530af3fbf7",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "export-filenames-and-folders": {
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "export-format-color-space": {
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "export-metadata-sidecars": {
       "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "export-photos": {
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-getting-started": {
       "content": "97535aed48434a85676c329af61e990b7c9f12cdefb2217b027e40859c376def",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-grain-and-format": {
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-halation-diffusion-scan": {
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-negative-paper-and-slides": {
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -286,7 +286,7 @@
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "import-lightroom-catalog": {
@@ -295,30 +295,30 @@
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "keyboard-midi": {
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
     },
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
       "content": "c0aaafaea42d873402c2b4568063738f9af58924482b9aded7e31cf4952392a5",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/preview-progress.js": "617276bc15d8b07945c9b7698f55932f62b77ec41f853c006b1622320814841a",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82",
@@ -329,15 +329,15 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -352,8 +352,8 @@
     "search-filter-sort": {
       "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/library-filters.js": "ce5a8b7272b19301b684af76675ec25ea87f53f2e76fdaea17ef1c99f1116825",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
@@ -361,22 +361,22 @@
     "settings-and-defaults": {
       "content": "c924f166996e97b4da2d038d431ef735d757dc5cc12fba6e959f5fc39450f006",
       "sources": {
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82"
       }
     },
     "shortcut-schemes": {
       "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
     "smart-collections": {
       "content": "811716ffcdf02245d65b07cf0f3a60a85ba2fa11c540ce4a9d5993086a311bef",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
@@ -384,14 +384,14 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
       }
     },
@@ -400,21 +400,22 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618"
       }
     },
     "views-and-selection": {
-      "content": "7412cdc7f39cc344f7b438ad008a5661ec18d13009da7cbbe2a405bf6a5e710b",
+      "content": "eec672627d176e832438690d1b6bade7c803c188d150ccb7bb54dd27965f8cd2",
       "sources": {
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f",
-        "web/index.html": "767c1f9314f4a0647fbe262197fed4729393048dca0b9def4072c062b972091f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "virtual-copies-and-stacks": {
       "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
         "library_workflow.py": "9dfeb6839e0970471158d6abab48c867f4ec408748fde056d0fd721ec5e5009a",
-        "web/app.js": "9805d5475e6e3c11df65ed1e0df1276819cfe62b6801e2137233535b6fbca13f"
+        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618"
       }
     }
   },

--- a/tests/compare-view.test.mjs
+++ b/tests/compare-view.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { clampComparePosition, compareViewGeometry, comparePositionAtViewCenter } from '../web/compare-view.js';
+
+const viewport = { left: 200, top: 100, width: 800, height: 600 };
+
+test('Fit chrome follows the photo, including its letterboxing', () => {
+  const image = { left: 200, top: 150, width: 800, height: 500 };
+  assert.deepEqual(compareViewGeometry(image, viewport, 0.5), {
+    left: 0, top: 50, width: 800, height: 500, dividerX: 400,
+  });
+});
+
+test('zoomed and vertically panned chrome stays within the visible window', () => {
+  const image = { left: -700, top: -900, width: 2400, height: 1800 };
+  assert.deepEqual(compareViewGeometry(image, viewport, 0.5), {
+    left: 0, top: 0, width: 800, height: 600, dividerX: 300,
+  });
+  const position = comparePositionAtViewCenter(image, viewport);
+  assert.ok(Math.abs(position - 13 / 24) < 1e-12);
+  assert.equal(compareViewGeometry(image, viewport, position).dividerX, 400);
+});
+
+test('snap recovers an offscreen divider without recentering the image', () => {
+  const image = { left: -700, top: -900, width: 2400, height: 1800 };
+  const before = { ...image };
+  assert.equal(compareViewGeometry(image, viewport, 0.9).dividerX, 1260);
+  const snapped = compareViewGeometry(image, viewport, comparePositionAtViewCenter(image, viewport));
+  assert.equal(snapped.dividerX, viewport.width / 2);
+  assert.deepEqual(image, before);
+});
+
+test('snap reaches the visible center at both edges of the maximum 32x zoom', () => {
+  for (const left of [viewport.left, viewport.left - viewport.width * 31]) {
+    const image = { left, top: -500, width: viewport.width * 32, height: 24000 };
+    const position = comparePositionAtViewCenter(image, viewport);
+    assert.ok(position < 0.02 || position > 0.98);
+    assert.equal(compareViewGeometry(image, viewport, position).dividerX, 400);
+  }
+});
+
+test('portrait and resized viewports use the current visible geometry', () => {
+  const image = { left: 350, top: -300, width: 500, height: 1200 };
+  const narrow = { left: 300, top: 80, width: 500, height: 500 };
+  const result = compareViewGeometry(image, narrow, comparePositionAtViewCenter(image, narrow));
+  assert.deepEqual(result, { left: 50, top: 0, width: 450, height: 500, dividerX: 200 });
+  assert.equal(result.left + result.dividerX, narrow.width / 2);
+});
+
+test('empty or nonintersecting views have no divider geometry', () => {
+  assert.equal(compareViewGeometry({ left: 0, top: 0, width: 0, height: 0 }, viewport, 0.5), null);
+  assert.equal(compareViewGeometry({ left: 1200, top: 0, width: 100, height: 100 }, viewport, 0.5), null);
+  assert.equal(comparePositionAtViewCenter({ width: 0 }, viewport), null);
+});
+
+test('drag limits include photo edges without treating zero as the midpoint', () => {
+  assert.equal(clampComparePosition(0), 0);
+  assert.equal(clampComparePosition(-1), 0);
+  assert.equal(clampComparePosition(2), 1);
+  assert.equal(clampComparePosition(NaN), 0.5);
+});

--- a/tests/test_compare_view.py
+++ b/tests/test_compare_view.py
@@ -1,0 +1,20 @@
+"""Run compare viewport geometry checks with the standard Python suite."""
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(shutil.which('node'), 'Node.js is unavailable')
+class CompareViewTests(unittest.TestCase):
+    def test_viewport_geometry(self):
+        result = subprocess.run(
+            ['node', '--test', str(ROOT / 'tests/compare-view.test.mjs')],
+            cwd=ROOT, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -631,7 +631,8 @@ afterVisiblePaint(20).then((paintedAt) => {
         self.assertIn("bar.addEventListener('pointerdown'", javascript)
         self.assertNotIn("cmp.addEventListener('pointerdown'", javascript)
         self.assertIn("if (compareEditingBlocked()) setCompareActive(false);", javascript)
-        self.assertIn(".cmp.comparing .cmp-bar { pointer-events:auto; opacity:1; }", css)
+        self.assertIn('id="compareOverlay" hidden', html)
+        self.assertIn("const bar = $('compareBar');", javascript)
 
     def test_zoom_targets_and_panel_geometry_remain_stable(self):
         javascript = (ROOT / "web" / "app.js").read_text()

--- a/tests/test_photo_tool_flow.py
+++ b/tests/test_photo_tool_flow.py
@@ -12,6 +12,7 @@ HARNESS = r"""
 import {createAppState, cloneValue} from './web/state.js';
 import {OPTICS_DEFAULTS, MAX_HEALS, normalizeMasks, normalizeHeals, normalizeOptics} from './web/editor-panels.js';
 import {cropGeometry, restoreCropGeometry} from './web/edit-transfer.js';
+import {compareViewGeometry} from './web/compare-view.js';
 const S = createAppState({}, OPTICS_DEFAULTS);
 Object.assign(S, {params:{rotate:0}, editingName:'a', viewMode:'detail'});
 let photo = {name:'a', width:1200, height:800};
@@ -138,7 +139,7 @@ class PhotoToolFlowTests(unittest.TestCase):
             'clampCrop', 'previewCrop', 'previewSourceX', 'cropForRatio', 'syncCropPanel',
             'restoreCropChoices', 'rememberCropChoices', 'applyCropRatioChoice', 'setCropRatio',
             'renderedComparePosition', 'compareEditingBlocked', 'syncCompareControl',
-            'renderCompare', 'setCompareActive', 'syncHealPanel',
+            'syncCompareView', 'renderCompare', 'setCompareActive', 'syncHealPanel',
         )]
         cls.script = HARNESS + "\n" + section('const paneScrollPositions', 'function exitPhotoTool')
         cls.script += '\n' + '\n'.join(functions)

--- a/web/app.js
+++ b/web/app.js
@@ -14,6 +14,7 @@ import { createEditSaveQueue } from '/web/edit-save-queue.js';
 import { createPhotoUndoHistory } from '/web/photo-undo.js';
 import { previewDetailLabel } from '/web/preview-detail.js';
 import { createPreviewProgress, waitForRawRefinement } from '/web/preview-progress.js';
+import { clampComparePosition, compareViewGeometry, comparePositionAtViewCenter } from '/web/compare-view.js';
 import { installCaptureTime, captureSortValue } from '/web/capture-time.js';
 import { TRANSFER_GROUPS, transferChoices, transferPatch, regenerateTransferMasks,
   cropGeometry, restoreCropGeometry } from '/web/edit-transfer.js';
@@ -897,6 +898,7 @@ function applyViewNow() {
 
   const isZoomed = !isFit && S.zoom > 1.01;
   cmp.classList.toggle('is-zoomed', isZoomed);
+  syncCompareView();
 
   scheduleNativeViewportLayout();
   scheduleViewportRegionRender();
@@ -7515,10 +7517,33 @@ function syncCompareControl() {
     : 'Toggle split before and after view (\\)';
 }
 
+function syncCompareView() {
+  $('compareSnap').hidden = !S.compareActive || S.zoomMode === 'fit' || S.zoom <= 1;
+  const overlay = $('compareOverlay');
+  const geometry = S.compareActive ? compareViewGeometry(
+    $('cmp').getBoundingClientRect(), $('zoomwrap').getBoundingClientRect(), S.comparePosition) : null;
+  overlay.hidden = !geometry;
+  if (!geometry) return;
+  // This sibling of the transformed photo keeps the line, handle and labels
+  // at their normal screen size, with the handle centred in the visible area.
+  for (const property of ['left', 'top', 'width', 'height']) {
+    overlay.style[property] = `${geometry[property]}px`;
+  }
+  overlay.style.setProperty('--pos', `${geometry.dividerX}px`);
+  $('tagL').hidden = geometry.dividerX <= 0;
+  $('tagR').hidden = geometry.dividerX >= geometry.width;
+}
+
+function snapCompareToView() {
+  if (!S.compareActive || compareEditingBlocked()) return;
+  const position = comparePositionAtViewCenter(
+    $('cmp').getBoundingClientRect(), $('zoomwrap').getBoundingClientRect());
+  if (position !== null) queueComparePosition(position);
+}
+
 function renderCompare() {
   const position = renderedComparePosition();
   const sourcePosition = previewSourceX(position);
-  const v = position * 100;
   if (nativePreviewActive()) {
     postNative('nativeCompare', { position: sourcePosition });
   } else if (S.gl?.drawCompare(sourcePosition)) {
@@ -7526,10 +7551,9 @@ function renderCompare() {
   } else {
     $('cmp').style.setProperty('--clip', (100 - sourcePosition * 100) + '%');
   }
-  $('cmp').style.setProperty('--pos', v + '%');
   $('cmp').classList.toggle('comparing', S.compareActive);
-  $('tagL').style.display = S.compareActive ? '' : 'none';
-  $('tagR').style.display = S.compareActive ? '' : 'none';
+  $('zoomwrap').classList.toggle('comparing', S.compareActive);
+  syncCompareView();
   syncCompareControl();
 }
 
@@ -7554,7 +7578,7 @@ $('compareReturn').onclick = () => setCompareActive(false);
 let compareFrame = null;
 let pendingComparePosition = 0.5;
 function queueComparePosition(value) {
-  pendingComparePosition = clamp(+value || 0.5, 0.02, 0.98);
+  pendingComparePosition = clampComparePosition(value);
   if (compareFrame !== null) return;
   compareFrame = requestAnimationFrame(() => {
     compareFrame = null;
@@ -7565,10 +7589,11 @@ function queueComparePosition(value) {
 }
 
 $('compareBtn').addEventListener('click', () => setCompareActive(!S.compareActive));
+$('compareSnap').addEventListener('click', snapCompareToView);
 
 (function compareDrag() {
   const cmp = $('cmp');
-  const bar = cmp.querySelector('.cmp-bar');
+  const bar = $('compareBar');
   let dragging = false;
   let dragRect = null;
   const update = (event) => {
@@ -8858,7 +8883,7 @@ function finishSpeedKey(key) {
     if (e.button !== 0 || S.speed) return;
     if (S.cropping || S.activePane === 'maskPane' || S.activePane === 'healPane') return;
     if (S.wbPick || S.pointColorPick || S.maskColorPick) return;
-    if (e.target.closest('#cropLayer, #editOverlay, .cmp-bar')) return;
+    if (e.target.closest('#cropLayer, #editOverlay, .cmp-bar, #compareSnap')) return;
     if (S.zoom <= 1 && S.zoomMode === 'fit') return;
     isPanning = true;
     panStartX = e.clientX;
@@ -8888,7 +8913,7 @@ function finishSpeedKey(key) {
   wrap.addEventListener('dblclick', (e) => {
     if (S.cropping || S.activePane === 'maskPane' || S.activePane === 'healPane') return;
     if (S.wbPick || S.pointColorPick || S.maskColorPick) return;
-    if (e.target.closest('#cropLayer, #editOverlay, .cmp-bar')) return;
+    if (e.target.closest('#cropLayer, #editOverlay, .cmp-bar, #compareSnap')) return;
     toggleActualZoomAt(e.clientX, e.clientY);
   });
 }());
@@ -9935,7 +9960,7 @@ $('wbBtn').onclick = (event) => {
 };
 function handleCanvasSample(e) {
   if (!S.maskColorPick && !S.pointColorPick && !S.wbPick) return;
-  if (e.target.closest('#cropLayer, #editOverlay, .cmp-bar')) return;
+  if (e.target.closest('#cropLayer, #editOverlay, .cmp-bar, #compareSnap')) return;
   const cv = $('cv'), r = cv.getBoundingClientRect();
   if (!r.width || !r.height) return;
   const u = clamp((e.clientX - r.left) / r.width, 0, 1);

--- a/web/compare-view.js
+++ b/web/compare-view.js
@@ -1,0 +1,26 @@
+// Compare positions belong to the displayed photo; its controls use screen pixels.
+export function clampComparePosition(value) {
+  const position = Number(value);
+  return Number.isFinite(position) ? Math.max(0, Math.min(1, position)) : 0.5;
+}
+
+export function compareViewGeometry(image, viewport, position) {
+  if (!(image.width > 0 && image.height > 0 && viewport.width > 0 && viewport.height > 0)) return null;
+  const left = Math.max(image.left, viewport.left);
+  const top = Math.max(image.top, viewport.top);
+  const right = Math.min(image.left + image.width, viewport.left + viewport.width);
+  const bottom = Math.min(image.top + image.height, viewport.top + viewport.height);
+  if (right <= left || bottom <= top) return null;
+  return {
+    left: left - viewport.left,
+    top: top - viewport.top,
+    width: right - left,
+    height: bottom - top,
+    dividerX: image.left + clampComparePosition(position) * image.width - left,
+  };
+}
+
+export function comparePositionAtViewCenter(image, viewport) {
+  if (!(image.width > 0 && viewport.width > 0)) return null;
+  return clampComparePosition((viewport.left + viewport.width / 2 - image.left) / image.width);
+}

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -196,7 +196,9 @@
         "command click",
         "control click",
         "navigation",
-        "zoom"
+        "zoom",
+        "compare",
+        "snap slider to view"
       ],
       "sections": [
         {
@@ -208,6 +210,17 @@
             "Use the three Photo view buttons at the top. In the LightTable shortcut scheme, G opens Photo Grid, Shift+G opens Culling Grid, and D opens Detail.",
             "In a grid, use the Size slider to change thumbnail size.",
             "Use the left and right arrow keys to move between photos. In Detail, Space toggles Fit and 1:1 when the photo area has focus."
+          ]
+        },
+        {
+          "title": "Compare while zoomed in",
+          "paragraphs": [
+            "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom."
+          ],
+          "steps": [
+            "Turn on Compare, then zoom beyond Fit.",
+            "Click snap slider to view at the top right of the photo area to center the divider in the current view. This also brings an offscreen divider back after panning, without changing your zoom or pan.",
+            "The button hides when you return to Fit or turn Compare off."
           ]
         },
         {

--- a/web/index.html
+++ b/web/index.html
@@ -183,9 +183,6 @@
             <img id="orig" alt="Original photograph">
             <img id="referenceImg" alt="Film reference" hidden>
             <canvas id="editOverlay" aria-label="Local edit overlay"></canvas>
-            <span class="cmp-bar"></span>
-            <span class="tag tag-l" id="tagL" style="display:none">Original</span>
-            <span class="tag tag-r" id="tagR" style="display:none">Edited</span>
             <div class="speed-hud" id="speedHud" hidden></div>
             <div class="render-badge" id="denoiseBadge" hidden>Denoising…</div>
             <div class="loupe-info" id="loupeInfoOverlay" hidden><strong id="loupeInfoName"></strong><span id="loupeInfoMetadata"></span></div>
@@ -206,6 +203,12 @@
               </div>
             </div>
           </div>
+          <div class="compare-overlay" id="compareOverlay" hidden>
+            <span class="cmp-bar" id="compareBar"></span>
+            <span class="tag tag-l" id="tagL">Original</span>
+            <span class="tag tag-r" id="tagR">Edited</span>
+          </div>
+          <button class="compact compare-snap" id="compareSnap" type="button" hidden>snap slider to view</button>
         </div>
       </div>
 

--- a/web/style.css
+++ b/web/style.css
@@ -113,14 +113,13 @@ button {
   white-space:nowrap;
   transition:background-color .12s ease,border-color .12s ease,color .12s ease;
 }
-button:hover:not(:disabled) { background:var(--btn-face-hover); border-color:var(--btn-line); color:#fff; }
-button:active:not(:disabled) { background:var(--btn-face-active); box-shadow:inset 0 1px 2px rgba(0,0,0,.45); }
+/* Pointer feedback must not replace a toggle's persistent selected styling. */
+button:hover:not(:disabled):not(.on) { background:var(--btn-face-hover); border-color:var(--btn-line); color:#fff; }
+button:active:not(:disabled):not(.on) { background:var(--btn-face-active); box-shadow:inset 0 1px 2px rgba(0,0,0,.45); }
 button:disabled { opacity:.38; }
-button.on,
-#softProofToolbar.on:hover,
-#zoomFit.on:hover { border-color:var(--slider-accent); color:var(--on-ink); background:var(--on-soft); }
+button.on { border-color:var(--slider-accent); color:var(--on-ink); background:var(--on-soft); }
 .quiet { border-color:transparent; background:transparent; color:var(--ink-2); box-shadow:none; }
-.quiet:hover:not(:disabled) { border-color:transparent; background:var(--hover); }
+.quiet:hover:not(:disabled):not(.on) { border-color:transparent; background:var(--hover); }
 .compact { min-height:26px; padding:3px 10px; font-size:11px; }
 .icon-btn { width:28px; min-width:28px; height:28px; min-height:28px; padding:0; border-radius:var(--radius-s); display:inline-grid; place-items:center; }
 .icon-btn.on { border-color:transparent; background:var(--active); color:var(--accent); }

--- a/web/style.css
+++ b/web/style.css
@@ -650,10 +650,12 @@ input[type=checkbox]:disabled { opacity:.4; }
   max-width:none;
   max-height:none;
 }
-.cmp-bar { position:absolute; z-index:6; top:0; bottom:0; left:var(--pos,50%); width:28px; margin-left:-14px; cursor:col-resize; touch-action:none; pointer-events:none; opacity:0; }
-.cmp.comparing .cmp-bar { pointer-events:auto; opacity:1; }
+.compare-overlay { position:absolute; z-index:6; overflow:hidden; pointer-events:none; }
+.cmp-bar { position:absolute; top:0; bottom:0; left:var(--pos,50%); width:28px; margin-left:-14px; cursor:col-resize; touch-action:none; pointer-events:auto; }
 .cmp-bar::before { content:""; position:absolute; top:0; bottom:0; left:50%; width:1px; background:#fff; box-shadow:0 0 0 1px rgba(0,0,0,.5); transform:translateX(-50%); }
 .cmp-bar::after { content:""; position:absolute; top:50%; left:50%; width:10px; height:28px; border:1px solid rgba(255,255,255,.9); border-radius:5px; background:rgba(20,20,20,.72); box-shadow:0 1px 5px rgba(0,0,0,.45); transform:translate(-50%,-50%); }
+.compare-snap { position:absolute; z-index:7; top:12px; right:12px; background:rgba(20,20,20,.88); }
+.zoomwrap.comparing .preview-detail-status { bottom:44px; }
 .tag { position:absolute; bottom:10px; padding:4px 8px; border-radius:var(--radius-s); background:rgba(0,0,0,.68); color:#fff; font-size:11px; font-weight:600; pointer-events:none; }
 .tag-l { left:10px; } .tag-r { right:10px; }
 .speed-hud { position:absolute; z-index:7; top:12px; left:50%; transform:translateX(-50%); padding:6px 12px; border-radius:var(--radius); background:rgba(16,16,16,.8); color:#fff; font-size:12px; font-weight:600; font-variant-numeric:tabular-nums; white-space:pre; pointer-events:none; box-shadow:0 2px 10px rgba(0,0,0,.4); backdrop-filter:blur(6px); }


### PR DESCRIPTION
Active toggle buttons retain their selected appearance during hover and press. This fixes Compare losing its active outline when the pointer moves over it.

When Compare is active and the photo is zoomed beyond Fit, a “snap slider to view” button centers the divider in the visible window without moving the photo. The divider, drag handle, and labels now stay at their normal screen size while zooming and panning. In-app help explains the new control.

Validation: seven geometry tests, fourteen photo-tool flow tests, five UI contract tests, and eighty performance contracts (one skip); source-linked help check passed. Real browser checks covered selected hover/press states, zooming, panning an offscreen divider, snapping, dragging, resizing, and toggling Compare and Crop. Native package and installed-app verification will run as part of the requested personal build after merge.
