### PR TITLE
Keep toolbar buttons steady while edits save

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -1075,7 +1075,8 @@ a.reset:hover { color:#fff; }
 .crop-perspective { margin-top:16px; }
 .crop-perspective .secbody { padding-right:0; padding-left:0; }
 .heal-brush-settings { padding:8px 0 12px; border-bottom:1px solid var(--line-soft); }
-#editSaveStatus { color:var(--muted); font-size:11px; white-space:nowrap; }
+/* Reserve both normal save labels so toolbar buttons stay put between saves. */
+#editSaveStatus { flex-shrink:0; min-width:8ch; color:var(--muted); font-size:11px; text-align:center; white-space:nowrap; }
 #editSaveStatus[data-state="error"] { color:#efb4ad; }
 .view-options { position:relative; }
 .view-options > summary { cursor:pointer; list-style:none; padding:6px 8px; border-radius:var(--radius); color:var(--muted); }


### PR DESCRIPTION
The save-status label now reserves enough width for both “Saved” and “Saving…”, keeping neighboring toolbar buttons in place while edits save. Longer error messages can still expand.

Validation: all 40 save queue and integration tests pass; the source-linked Help check and git diff --check pass. The originating task also measured 0 px movement of adjacent buttons through a real Saved → Saving… → Saved transition.
