### PR TITLE
Show a progress bar while applying film

### DIFF
--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -7,7 +7,7 @@
     "keywords": ["film", "stock", "simulation", "realistic film simulation", "negative", "slide", "browse", "preview", "preset", "film off"],
     "sections": [
       {"title": "Start with a stock", "paragraphs": ["Film applies a modeled film and output process to a still photo. The Film profile switch controls this processing; your Edit adjustments remain active when you switch Film off."], "steps": ["Open a still photo and select Film in the tool rail to open Realistic Film Simulation.", "Turn the Film profile switch on. Physical film stages opens automatically; you can collapse it afterward.", "Choose Stock, or click Preview stocks on this photo… to compare rendered examples.", "Search for a stock name, use Previous or Next to browse, then choose a preview to apply it."]},
-      {"title": "What the previews include", "paragraphs": ["Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.", "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.", "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The steady status badge explains the work still in progress. Wait for it to finish before judging fine detail."], "tips": ["If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."]}
+      {"title": "What the previews include", "paragraphs": ["Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.", "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.", "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The status badge shows a slim animated bar while the preview is processing. Wait for it to finish before judging fine detail."], "tips": ["If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."]}
     ],
     "related": ["film-exposure-and-processing", "film-negative-paper-and-slides", "film-grain-and-format"],
     "sources": [
@@ -18,7 +18,8 @@
       {"path": "web/app.js", "anchor": "filmStages.open = true;"},
       {"path": "web/app.js", "anchor": "option.disabled = profile.rustOnly && !S.rustAvailable;"},
       {"path": "web/index.html", "anchor": "Include Film profile and physical settings"},
-      {"path": "web/app.js", "anchor": "previewProgress.start('Refining RAW detail…');"}
+      {"path": "web/app.js", "anchor": "previewProgress.start('Refining RAW detail…');"},
+      {"path": "web/style.css", "anchor": "@keyframes preview-progress-sweep"}
     ]
   },
   {
@@ -322,7 +323,7 @@
     "summary": "Choose preview resolution, wait for real detail, and manage generated caches.",
     "keywords": ["performance", "slow", "blurry", "pixelated", "preview", "resolution", "100%", "1:1", "gpu", "rust", "python", "cache", "purge"],
     "sections": [
-      {"title": "Check what has finished rendering", "paragraphs": ["A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. The steady status badge shows Applying film…, Refining RAW detail…, or Updating preview detail… as needed, and stays visible until the requested preview is displayed. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.", "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."], "steps": ["Open Settings → Performance.", "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.", "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.", "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."]},
+      {"title": "Check what has finished rendering", "paragraphs": ["A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. A slim animated bar beneath Applying film…, Refining RAW detail…, or Updating preview detail… stays visible until the requested preview is displayed. The bar indicates ongoing work, not a percentage or time remaining. With reduced motion enabled, the bar stays still. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.", "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."], "steps": ["Open Settings → Performance.", "Use Auto · fit display for preview resolution, or choose a smaller fixed resolution to reduce preview work.", "Use GPU · Rust when available. Compatible · Python is an alternate film engine, but some stocks require Rust.", "Judge sharpening, noise reduction, and film grain at 1:1 after detail has settled."]},
       {"title": "Manage cache storage", "paragraphs": ["Performance shows the preview cache location, usage, and budget. Purge cache removes generated previews and render caches after confirmation; originals and edits are unaffected. Previews will need to be generated again.", "Preview resolution is separate from the Dimensions setting used for exported files."]}
     ],
     "related": ["film-grain-and-format", "export-format-color-space", "catalog-health-recovery"],
@@ -334,6 +335,7 @@
       {"path": "web/settings.js", "anchor": "Purge generated previews and render caches? Originals and edits are not affected."},
       {"path": "web/app.js", "anchor": "pythonOption.disabled = rustOnly;"},
       {"path": "web/app.js", "anchor": "previewProgress.start('Refining RAW detail…');"},
+      {"path": "web/style.css", "anchor": "@keyframes preview-progress-sweep"},
       {"path": "web/preview-progress.js", "anchor": "export function createPreviewProgress"},
       {"path": "web/preview-progress.js", "anchor": "export async function waitForRawRefinement"}
     ]

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -236,11 +236,12 @@
       }
     },
     "film-getting-started": {
-      "content": "97535aed48434a85676c329af61e990b7c9f12cdefb2217b027e40859c376def",
+      "content": "52ef664038067e1399e51d5475431e6f7f3ad43f3e683dd52a97928d467e90cb",
       "sources": {
         "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
+        "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
+        "web/style.css": "af86c4af588522294bdf9db437c9daf7119f5a4d010bdbf79cb2538a5827fab8"
       }
     },
     "film-grain-and-format": {
@@ -315,13 +316,14 @@
       }
     },
     "performance-previews": {
-      "content": "c0aaafaea42d873402c2b4568063738f9af58924482b9aded7e31cf4952392a5",
+      "content": "6b8e897b2a3f6c22979324d52b10897faf789f8db599ea7f786e8765a535ef81",
       "sources": {
         "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/preview-progress.js": "617276bc15d8b07945c9b7698f55932f62b77ec41f853c006b1622320814841a",
         "web/settings.js": "1def9f66907cb88d1526c7daf2c5b5085317d9a3f4d4e08c0d73ab2cfada8e82",
+        "web/style.css": "af86c4af588522294bdf9db437c9daf7119f5a4d010bdbf79cb2538a5827fab8",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
       }
     },

--- a/tests/processing_app.mjs
+++ b/tests/processing_app.mjs
@@ -59,14 +59,19 @@ try {
       !document.querySelector('#zoomwrap').classList.contains('photo-pending'), name, {timeout:120000});
     const filmEnabled = await page.locator('#filmProfileToggle').getAttribute('aria-checked');
     if (filmEnabled !== String(test.params.profile_enabled)) await post('/api/ui/command', {command:'filmToggle'});
+    const rendersBefore = await page.evaluate(() => __lightTablePerf.renders.length);
     await post('/api/ui/command', {command:'slider', args:{key:'print_exposure', value:test.params.print_exposure}});
     // Actual slider event takes the normal app UI -> grade -> preview -> save route.
     const before = await page.evaluate(() => processingFrames);
     await post('/api/ui/command', {command:'slider', args:{key:'exposure', value:test.exposure}});
-    await page.waitForFunction(({before, exposure}) => processingFrames > before &&
+    // A grade draw can use the previous film texture while the new base is
+    // still rendering. Require a fresh, fully presented base before readback.
+    await page.waitForFunction(({before, rendersBefore, exposure}) => processingFrames > before &&
       Math.abs(processingFrame.grade.exposure - exposure) < 0.0001 &&
+      __lightTablePerf.renders.length > rendersBefore &&
+      document.querySelector('#zoomwrap').getAttribute('aria-busy') === 'false' &&
       !document.querySelector('#zoomwrap').classList.contains('photo-pending'),
-      {before, exposure:test.exposure}, {timeout:120000});
+      {before, rendersBefore, exposure:test.exposure}, {timeout:120000});
     // Poll authoritative saved state, so the CLI reference uses the accepted recipe.
     let saved;
     for (let attempt = 0; attempt < 120; attempt++) {

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -1906,7 +1906,7 @@
           "paragraphs": [
             "Stock previews include the current photo’s edits. Browsing and closing the preview window do not apply a stock; choosing a preview does.",
             "A film stock describes the physical film process. An editing preset can contain broader saved adjustments, and may also include Film settings. The Output menu inside Film chooses a scan or print recipe; it does not export a file.",
-            "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The steady status badge explains the work still in progress. Wait for it to finish before judging fine detail."
+            "After you turn on Film, a quick preview can appear before accurate RAW detail and the larger preview finish. The status badge shows a slim animated bar while the preview is processing. Wait for it to finish before judging fine detail."
           ],
           "tips": [
             "If a stock is unavailable, it may require the GPU engine. Engine availability is shown in Settings → Performance."
@@ -2591,7 +2591,7 @@
         {
           "title": "Check what has finished rendering",
           "paragraphs": [
-            "A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. The steady status badge shows Applying film…, Refining RAW detail…, or Updating preview detail… as needed, and stays visible until the requested preview is displayed. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.",
+            "A 100% zoom setting does not guarantee that full image detail has arrived. A quick preview may appear first while accurate RAW processing and a larger preview finish. A slim animated bar beneath Applying film…, Refining RAW detail…, or Updating preview detail… stays visible until the requested preview is displayed. The bar indicates ongoing work, not a percentage or time remaining. With reduced motion enabled, the bar stays still. The photo stays visible without dimming. At 1:1, wait for 100% detail ready when assessing fine detail; Preview ready alone refers to the requested preview resolution.",
             "If the status reports a preview pixel size smaller than the source, you are seeing a smaller delivered preview. Auto resolution fits the display and increases its request for zoomed viewing; very large sources can exceed the preview request limit."
           ],
           "steps": [

--- a/web/style.css
+++ b/web/style.css
@@ -1970,9 +1970,22 @@ body { display:flex; flex-direction:column; }
 .preview-detail-status { position:absolute; left:12px; bottom:12px; z-index:15;
   max-width:calc(100% - 24px); padding:5px 8px; border-radius:4px;
   color:#eee; background:rgba(18,18,18,.85); font-size:11px; pointer-events:none; }
-.preview-detail-status.working::before { content:""; display:inline-block;
-  width:6px; height:6px; margin-right:7px; vertical-align:1px;
-  border-radius:50%; background:currentColor; }
+.preview-detail-status.working { width:180px; padding-bottom:14px; }
+.preview-detail-status.working::before,
+.preview-detail-status.working::after { content:""; position:absolute;
+  left:8px; bottom:6px; height:3px; border-radius:2px; background:currentColor; }
+.preview-detail-status.working::before { right:8px; opacity:.18; }
+/* Render stages do not expose a measurable fraction. Sweep within the track
+   while work is active instead of implying a percentage or time remaining. */
+.preview-detail-status.working::after { width:calc((100% - 16px) * .35);
+  animation:preview-progress-sweep 1.4s ease-in-out infinite alternate; }
+@keyframes preview-progress-sweep {
+  from { transform:translateX(0); }
+  to { transform:translateX(185.714%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .preview-detail-status.working::after { animation:none; width:auto; right:8px; opacity:.55; }
+}
 
 .capture-time-status { white-space:pre-wrap; overflow-wrap:anywhere; max-height:220px;
   overflow:auto; font-size:11px; line-height:1.5; color:var(--ink-2); margin:10px 0; }


### PR DESCRIPTION
Replace the dot beside “Applying film…” with a slim animated bar beneath the status label. The bar stays visible through RAW refinement, respects reduced-motion settings, and disappears when the requested preview is displayed. It indicates ongoing work without inventing a completion percentage.

The application pixel gate now waits for a fresh completed film preview before reading pixels; a grade-only draw can still contain the previous film texture. Pixel tolerances are unchanged. The corrected application pixel gate passed all 11 checks locally, including both previously failing film cases.

Validation: 5 preview-progress tests, 10 Help tests, 6 photo-feature contract tests, and Help bundle validation passed. Visually verified both animated and reduced-motion versions during a real RAW film render in an isolated review instance.
