### PR TITLE
Fix fuzzy Original previews in Compare

### DIFF
--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -324,7 +324,8 @@
       {
         "title": "Compare while zoomed in",
         "paragraphs": [
-          "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom."
+          "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom.",
+          "Original uses the same preview resolution as the edited photo, including at 1:1. For RAW photos, Original uses the neutral, unedited conversion; allow it to finish loading before judging detail."
         ],
         "steps": [
           "Turn on Compare, then zoom beyond Fit.",

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -11,7 +11,7 @@
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
@@ -20,7 +20,7 @@
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -43,14 +43,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -64,7 +64,7 @@
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -72,8 +72,8 @@
       "content": "ea587a5f680591f686563eed6326436e6413f5da512086974be55c4603bebe85",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "server.py": "fcb60bc18a874b64f8c3b5623bc175d930d0382b318a8e54ec4d32a93c8191a4",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
@@ -86,7 +86,7 @@
     "editing-curves": {
       "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -95,7 +95,7 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -103,14 +103,14 @@
       "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
@@ -118,7 +118,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -126,21 +126,21 @@
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "7702f31a22aca801cec4d6985a696f77e4d038fb86613ba1953b2590cd855434",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -149,8 +149,8 @@
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
-        "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "server.py": "fcb60bc18a874b64f8c3b5623bc175d930d0382b318a8e54ec4d32a93c8191a4",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -164,28 +164,28 @@
     "editing-remove-heal": {
       "content": "41b396a3d13fa3364bd68d63aec838869e50787b3e2a7ab68a5cf4530af3fbf7",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -193,7 +193,7 @@
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -201,7 +201,7 @@
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -215,22 +215,22 @@
     "export-photos": {
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
-        "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "server.py": "fcb60bc18a874b64f8c3b5623bc175d930d0382b318a8e54ec4d32a93c8191a4",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
@@ -238,7 +238,7 @@
     "film-getting-started": {
       "content": "97535aed48434a85676c329af61e990b7c9f12cdefb2217b027e40859c376def",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
@@ -254,7 +254,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
@@ -262,7 +262,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
@@ -270,14 +270,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -293,7 +293,7 @@
       "content": "431fb5fc10894d56e863219e9661ab2995d81996b9f8816abf7f3c7b9f4485ce",
       "sources": {
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
-        "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
+        "server.py": "fcb60bc18a874b64f8c3b5623bc175d930d0382b318a8e54ec4d32a93c8191a4",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
@@ -302,7 +302,7 @@
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
@@ -310,14 +310,14 @@
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
       "content": "c0aaafaea42d873402c2b4568063738f9af58924482b9aded7e31cf4952392a5",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/preview-progress.js": "617276bc15d8b07945c9b7698f55932f62b77ec41f853c006b1622320814841a",
@@ -329,14 +329,14 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -345,14 +345,14 @@
       "content": "66a50e18b2e2dee4d8a35ea3c59b09e45f609b5dddea804b663e9744a456617d",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
+        "server.py": "fcb60bc18a874b64f8c3b5623bc175d930d0382b318a8e54ec4d32a93c8191a4",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba"
       }
     },
     "search-filter-sort": {
       "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/library-filters.js": "ce5a8b7272b19301b684af76675ec25ea87f53f2e76fdaea17ef1c99f1116825",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
@@ -368,7 +368,7 @@
     "shortcut-schemes": {
       "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
@@ -376,7 +376,7 @@
     "smart-collections": {
       "content": "811716ffcdf02245d65b07cf0f3a60a85ba2fa11c540ce4a9d5993086a311bef",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
@@ -384,14 +384,14 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
       }
     },
@@ -399,14 +399,14 @@
       "content": "85731343eefbc085ca0eff4b39db0d043c537b6cc69f3b77c8722ec01725acb9",
       "sources": {
         "app/main.swift": "88a5ace95307e1633a051291cd00b318323f566e87a35216139c138b8a0fced6",
-        "server.py": "a66d553fa0d22359180cef9363e5ced1146bb712ad6a04d0beea29aa1ab7603b",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618"
+        "server.py": "fcb60bc18a874b64f8c3b5623bc175d930d0382b318a8e54ec4d32a93c8191a4",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3"
       }
     },
     "views-and-selection": {
-      "content": "eec672627d176e832438690d1b6bade7c803c188d150ccb7bb54dd27965f8cd2",
+      "content": "1b320331a9590ff87449bd29ce96c93ec0358af0f3233eeda92382ea966b312e",
       "sources": {
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618",
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "14a75022cb0a5a599f74aa1909d9bfa0fc94d6b0e2e31324541f40a519e15e57"
       }
@@ -415,7 +415,7 @@
       "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
         "library_workflow.py": "9dfeb6839e0970471158d6abab48c867f4ec408748fde056d0fd721ec5e5009a",
-        "web/app.js": "4471bd3da6e88d455e404a4d52553183a5572ecc83d67c64d8b7e8bb43860618"
+        "web/app.js": "74bdb5b1546bb7de4379f3290b4283656d91a73f88ac8272291c56c0cba1ecf3"
       }
     }
   },

--- a/server.py
+++ b/server.py
@@ -2842,10 +2842,19 @@ def rot90k(deg: float) -> int:
     return (-int(round(deg / 90))) % 4
 
 
-def orig_jpeg(name: str, width: int, rotate: float = 0) -> bytes:
+def orig_jpeg(name: str, width: int, rotate: float = 0, *,
+              quality: str = "draft") -> bytes:
     guard_photo(name)
     guard_local_photo(name)
     with SESSION.inflight("decode", library_workflow.source_name(name)):
+        if quality == "full" and is_raw(name):
+            # Compare uses the same neutral conversion as unedited Develop.
+            # The embedded camera JPEG is only a quick opening preview: it can
+            # have different tone/color and cannot resolve full image detail.
+            # Keep this separate from the draft URL's immutable browser cache.
+            import raw_decode_runtime
+            with raw_decode_runtime.cancellation(lambda: False, priority="refine"):
+                return build_neutral_preview(name, width, rotate).read_bytes()
         return _orig_jpeg(name, width, rotate)
 
 
@@ -6186,7 +6195,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_video(q["name"])
             elif u.path == "/api/orig":
                 self._send(200, orig_jpeg(q["name"], int(q.get("w", 1100)),
-                                          float(q.get("rot", 0))),
+                                          float(q.get("rot", 0)),
+                                          quality=q.get("quality", "draft")),
                            "image/jpeg",
                            "public, max-age=31536000, immutable")
             elif u.path == "/api/neutral":

--- a/tests/test_compare_original.py
+++ b/tests/test_compare_original.py
@@ -1,0 +1,115 @@
+"""Compare must use accurate pixels at the edited preview's resolution."""
+import http.client
+import io
+import json
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from PIL import Image
+
+import server
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CompareOriginalTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("node"), "Node.js is unavailable")
+    def test_browser_and_native_original_url_retains_requested_detail(self):
+        javascript = (ROOT / "web/app.js").read_text()
+        start = javascript.index("function originalPreviewURL(")
+        function = javascript[start:javascript.index("\nlet browserOriginal", start)]
+        script = """
+const S = {params: {rotate: 90}};
+const cur = () => ({name: '3:photo & detail.ARW', fileKey: 'changed-source'});
+const INTERACTIVE_PREVIEW_WIDTH = 1100;
+const requestedPreviewWidth = () => 6000;
+""" + function + """
+console.log(JSON.stringify([800, 3000, 6000, undefined].map(width =>
+  Object.fromEntries(new URL(originalPreviewURL(width), 'http://local').searchParams))));
+"""
+        result = subprocess.run(["node", "-e", script], capture_output=True,
+                                text=True, check=True, timeout=10)
+        urls = json.loads(result.stdout)
+        self.assertEqual([int(url["w"]) for url in urls], [800, 3000, 6000, 6000])
+        for url in urls:
+            self.assertEqual(url["quality"], "full")
+            self.assertEqual(url["name"], "3:photo & detail.ARW")
+            self.assertEqual(url["rot"], "90")
+            self.assertEqual(url["key"], "changed-source")
+
+    def test_raw_original_matches_unedited_develop_pixels_and_rotation(self):
+        # A detailed decoded RAW and a deliberately different camera thumbnail
+        # catch both lost resolution and accidentally using the camera look.
+        y, x = np.indices((1280, 1920))
+        pixels = np.stack([(x % 16) / 16, (y % 16) / 16,
+                           ((x + y) % 16) / 16], axis=-1).astype(np.float32)
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(server, "CACHE", Path(directory)),
+            mock.patch.object(server, "file_key", return_value="source"),
+            mock.patch.object(server, "guard_local_photo"),
+            mock.patch.object(server, "src_path", return_value=Path("frame.dng")),
+            mock.patch.object(server.color_pipeline, "decode_raw", return_value=pixels),
+            mock.patch.object(server.color_pipeline, "linear_prophoto_to_display_srgb",
+                              side_effect=lambda image, params: image),
+            mock.patch.object(server, "raw_display", side_effect=AssertionError("camera thumbnail")),
+        ):
+            for rotation, dimensions in ((0, (1920, 1280)), (90, (1280, 1920))):
+                with self.subTest(rotation=rotation):
+                    expected = server.build_neutral_preview(
+                        "frame.dng", 1920, rotation,
+                        server.fp.clean_params({"profile_enabled": False})).read_bytes()
+                    actual = server.orig_jpeg("frame.dng", 1920, rotation, quality="full")
+                    self.assertEqual(actual, expected)
+                    self.assertEqual(Image.open(io.BytesIO(actual)).size, dimensions)
+
+    def test_quick_raw_opening_preview_remains_a_draft(self):
+        with mock.patch.object(server, "guard_local_photo"), \
+                mock.patch.object(server, "_orig_jpeg", return_value=b"draft") as draft, \
+                mock.patch.object(server, "build_neutral_preview") as accurate:
+            self.assertEqual(server.orig_jpeg("frame.dng", 1100), b"draft")
+            draft.assert_called_once_with("frame.dng", 1100, 0)
+            accurate.assert_not_called()
+
+    def test_processed_original_reuses_exact_unedited_pixels(self):
+        with mock.patch.object(server, "guard_local_photo"), \
+                mock.patch.object(server, "_orig_jpeg", return_value=b"source") as original, \
+                mock.patch.object(server, "build_neutral_preview") as raw:
+            self.assertEqual(server.orig_jpeg("frame.jpg", 4000, 90, quality="full"), b"source")
+            original.assert_called_once_with("frame.jpg", 4000, 90)
+            raw.assert_not_called()
+
+    def test_original_http_route_passes_quality_without_changing_draft_requests(self):
+        class Handler(server.Handler):
+            def log_message(self, *_args):
+                pass
+
+        httpd = server.LightTableServer(("127.0.0.1", 0), Handler)
+        worker = threading.Thread(target=httpd.serve_forever, daemon=True)
+        worker.start()
+        connection = http.client.HTTPConnection(*httpd.server_address, timeout=3)
+        try:
+            with mock.patch.object(server, "orig_jpeg", return_value=b"pixels") as original:
+                for suffix, quality in (("&quality=full", "full"), ("", "draft")):
+                    connection.request("GET", "/api/orig?name=frame.dng&w=3000&rot=90" + suffix)
+                    response = connection.getresponse()
+                    self.assertEqual(response.status, 200)
+                    self.assertEqual(response.getheader("Content-Type"), "image/jpeg")
+                    self.assertEqual(response.read(), b"pixels")
+                    original.assert_called_with("frame.dng", 3000, 90.0, quality=quality)
+        finally:
+            connection.close()
+            httpd.shutdown()
+            httpd.server_close()
+            worker.join(2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/app.js
+++ b/web/app.js
@@ -3711,9 +3711,10 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
 function originalPreviewURL(requestedWidth = requestedPreviewWidth()) {
   const im = cur();
   if (!im) return '';
-  const width = Math.min(requestedWidth, INTERACTIVE_PREVIEW_WIDTH);
+  // Compare must resolve the same detail as the edited preview, including 1:1.
+  const width = requestedWidth;
   return `/api/orig?name=${encodeURIComponent(im.name)}` +
-    `&w=${width}&rot=${S.params.rotate || 0}` +
+    `&w=${width}&rot=${S.params.rotate || 0}&quality=full` +
     `&key=${encodeURIComponent(im.fileKey || im.mtime || '')}`;
 }
 

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -215,7 +215,8 @@
         {
           "title": "Compare while zoomed in",
           "paragraphs": [
-            "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom."
+            "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom.",
+            "Original uses the same preview resolution as the edited photo, including at 1:1. For RAW photos, Original uses the neutral, unedited conversion; allow it to finish loading before judging detail."
           ],
           "steps": [
             "Turn on Compare, then zoom beyond Fit.",


### PR DESCRIPTION
Compare made an unedited photo look softer on the Original side because that preview was capped at 1,100 pixels. RAW originals also kept the camera's small embedded JPEG after the edited preview had refined.

Request the edited preview's resolution for Original, including at 1:1, and use the same neutral RAW conversion as unedited Develop. Keep quick opening previews on the existing draft path and give accurate comparison URLs a separate cache identity. Update the in-app help.

Validation: 112 focused tests ran (111 passed, one skipped), including resolution, rotation, RAW pixel equality, processed-image reuse, draft preservation, and HTTP routing. Help validation and diff checks pass. On the Sony outdoor-bar RAW sample, Original increased from 1,100 × 734 to 3,000 × 2,001 and matched the unedited Develop JPEG byte for byte. Native visual verification was unavailable because the local test reported no Metal device. The installed app has not been rebuilt.
