### PR TITLE
Correct Original preview color and preserve edits across Before

### DIFF
--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -325,7 +325,8 @@
         "title": "Compare while zoomed in",
         "paragraphs": [
           "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom.",
-          "Original uses the same preview resolution as the edited photo, including at 1:1. For RAW photos, Original uses the neutral, unedited conversion; allow it to finish loading before judging detail."
+          "Original uses the same preview resolution as the edited photo, including at 1:1. For RAW photos, Original uses the neutral, unedited conversion; allow it to finish loading before judging detail.",
+          "Hold B to view the original without Film, local masks, or finishing adjustments. Release B to restore the edited view."
         ],
         "steps": [
           "Turn on Compare, then zoom beyond Fit.",
@@ -522,7 +523,7 @@
         ],
         "tips": [
           "Both schemes use G for Photo Grid, Shift+G for Culling Grid, N for Survey, P/X/U for flags, and 0–5 for stars.",
-          "Hold B to show the original while inspecting an edit. Slash (/) focuses photo search.",
+          "Hold B to show the original without Film, local masks, or finishing adjustments; release B to restore the edit. Slash (/) focuses photo search.",
           "Photo shortcuts are ignored while typing in text, number, or selection fields. Leave the field before using a photo command."
         ]
       }

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -241,7 +241,7 @@
         "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
-        "web/style.css": "a0388361871a669100767c3486fe880e50e2d16666ea58e5e8c3bcd33885be44"
+        "web/style.css": "d424fd1d1ee31646dc5ea06e713e7b092e5897070962e0672bb3e6efcf91a133"
       }
     },
     "film-grain-and-format": {
@@ -324,7 +324,7 @@
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "f379882d2234db258fa8f3491c5f0829913083012874dd417bb8bea8264dd4bd",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb",
-        "web/style.css": "a0388361871a669100767c3486fe880e50e2d16666ea58e5e8c3bcd33885be44",
+        "web/style.css": "d424fd1d1ee31646dc5ea06e713e7b092e5897070962e0672bb3e6efcf91a133",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
       }
     },

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -11,7 +11,7 @@
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
@@ -20,7 +20,7 @@
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -43,14 +43,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -64,7 +64,7 @@
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -72,8 +72,8 @@
       "content": "ea587a5f680591f686563eed6326436e6413f5da512086974be55c4603bebe85",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "server.py": "753763e4ea86a41367a2d14c1fc27f60f3f6b638142f3b2440db3fb8a7a3f8b9",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
@@ -86,7 +86,7 @@
     "editing-curves": {
       "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -95,7 +95,7 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -103,14 +103,14 @@
       "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
@@ -118,7 +118,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -126,21 +126,21 @@
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "61e5a03da9c860f6c1bf1b049bce67710b34e74f551eabe3131705ee10ee69ce",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -149,8 +149,8 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
-        "server.py": "753763e4ea86a41367a2d14c1fc27f60f3f6b638142f3b2440db3fb8a7a3f8b9",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -164,28 +164,28 @@
     "editing-remove-heal": {
       "content": "a21bed5c2d859545a1ab2ee26ff88c7d8463e4bb0ee96390cbda6c404cf6539e",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -193,7 +193,7 @@
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -201,7 +201,7 @@
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -215,22 +215,22 @@
     "export-photos": {
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
-        "server.py": "753763e4ea86a41367a2d14c1fc27f60f3f6b638142f3b2440db3fb8a7a3f8b9",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
@@ -238,7 +238,7 @@
     "film-getting-started": {
       "content": "41af570de7f96eec29c31312925173b0dd477bbb37a1e0c2cedb1363533d2f4b",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/style.css": "a0388361871a669100767c3486fe880e50e2d16666ea58e5e8c3bcd33885be44"
@@ -255,7 +255,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
@@ -263,7 +263,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
@@ -271,14 +271,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -294,7 +294,7 @@
       "content": "431fb5fc10894d56e863219e9661ab2995d81996b9f8816abf7f3c7b9f4485ce",
       "sources": {
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
-        "server.py": "753763e4ea86a41367a2d14c1fc27f60f3f6b638142f3b2440db3fb8a7a3f8b9",
+        "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
@@ -303,7 +303,7 @@
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
@@ -311,14 +311,14 @@
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
       "content": "91f27aaf6e367408f0d1572495a6edc96f3534285b26144b02b496901edcc673",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
@@ -332,14 +332,14 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -348,14 +348,14 @@
       "content": "66a50e18b2e2dee4d8a35ea3c59b09e45f609b5dddea804b663e9744a456617d",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "server.py": "753763e4ea86a41367a2d14c1fc27f60f3f6b638142f3b2440db3fb8a7a3f8b9",
+        "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba"
       }
     },
     "search-filter-sort": {
       "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/library-filters.js": "ce5a8b7272b19301b684af76675ec25ea87f53f2e76fdaea17ef1c99f1116825",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
@@ -369,9 +369,9 @@
       }
     },
     "shortcut-schemes": {
-      "content": "54062344e16beb673cb11f5d0b3f9ad94cf76483696bf41a4118d474e254c33d",
+      "content": "9117f2d6a953f9a3f836b91420b22d75cc570201d2d5cc822f2adf7e64f9d224",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
@@ -379,7 +379,7 @@
     "smart-collections": {
       "content": "811716ffcdf02245d65b07cf0f3a60a85ba2fa11c540ce4a9d5993086a311bef",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
@@ -387,29 +387,29 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
-        "web/survey.js": "91596e45087e93927c8748f73c0eaf8002c647833fd3a4284ba6df8c96b7aa45"
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
+        "web/survey.js": "848f431664f546fdc3c24a8aed10f65edc87afa3879816dc004a875eb1506365"
       }
     },
     "trash-rejected": {
       "content": "85731343eefbc085ca0eff4b39db0d043c537b6cc69f3b77c8722ec01725acb9",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "server.py": "753763e4ea86a41367a2d14c1fc27f60f3f6b638142f3b2440db3fb8a7a3f8b9",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87"
+        "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987"
       }
     },
     "views-and-selection": {
-      "content": "1b320331a9590ff87449bd29ce96c93ec0358af0f3233eeda92382ea966b312e",
+      "content": "c7fe327084f2f9da186fc1f38af80e1d14fa9c2e03c20d98d1fe452047869ce5",
       "sources": {
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87",
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "b9f72a0baa25880fbebe27450e19a713afb2349c0838a95b7c39c6cd5f919532"
       }
@@ -418,7 +418,7 @@
       "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
         "library_workflow.py": "9dfeb6839e0970471158d6abab48c867f4ec408748fde056d0fd721ec5e5009a",
-        "web/app.js": "31b450495142be606ac1a1d48ff8cc8cc9b4def25c28b9a5068514089b9fbb87"
+        "web/app.js": "255e83744365b9686159de33c5e57a644f72478bb8f2115c01c0136e0f635987"
       }
     }
   },

--- a/server.py
+++ b/server.py
@@ -2849,6 +2849,9 @@ def rot90k(deg: float) -> int:
     return (-int(round(deg / 90))) % 4
 
 
+ORIGINAL_PREVIEW_CACHE_VERSION = 2  # display sRGB, not film-input ProPhoto
+
+
 def orig_jpeg(name: str, width: int, rotate: float = 0, *,
               quality: str = "draft") -> bytes:
     guard_photo(name)
@@ -2867,15 +2870,16 @@ def orig_jpeg(name: str, width: int, rotate: float = 0, *,
 
 def _orig_jpeg(name: str, width: int, rotate: float = 0) -> bytes:
     k = rot90k(rotate)
+    prefix = f"v{ORIGINAL_PREVIEW_CACHE_VERSION}_{file_key(name)}_{width}"
     if k:
-        rotated = CACHE / "orig" / f"{file_key(name)}_{width}_{k}.jpg"
+        rotated = CACHE / "orig" / f"{prefix}_{k}.jpg"
         if not valid_jpeg_cache(rotated):
             base = Image.open(io.BytesIO(_orig_jpeg(name, width, 0))).convert("RGB")
             arr = np.rot90(np.asarray(base), k)
             durable_io.cache_write_bytes(
                 rotated, jpeg_bytes(np.ascontiguousarray(arr)))
         return rotated.read_bytes()
-    p = CACHE / "orig" / f"{file_key(name)}_{width}.jpg"
+    p = CACHE / "orig" / f"{prefix}.jpg"
     if not valid_jpeg_cache(p):
         if is_raw(name):
             im = Image.open(raw_display(name))
@@ -2887,7 +2891,8 @@ def _orig_jpeg(name: str, width: int, rotate: float = 0) -> bytes:
             im.save(buffer, "JPEG", quality=88, subsampling=1)
             durable_io.cache_write_bytes(p, buffer.getvalue())
         else:
-            arr = linear_for(name, width)
+            arr = platform_image.processed_preview(
+                src_path(name), width, app_root=APP, output_space="srgb")
             durable_io.cache_write_bytes(
                 p, jpeg_bytes((arr * 255 + 0.5).astype(np.uint8)))
         prune_cache_throttled(p.parent, "*.jpg", _ORIGINAL_CACHE_MAX_BYTES)
@@ -2933,7 +2938,7 @@ RUST_AVAILABLE = bool((RUST_WORKER_BIN or RUST_BIN.exists())
                       and RUST_DATA.is_dir())
 RENDER_CACHE_VERSION = 8  # sixteen-mask atlas, range masks, and uniformity
 EDIT_PREVIEW_CACHE_VERSION = 1
-EDITED_THUMB_CACHE_VERSION = 1
+EDITED_THUMB_CACHE_VERSION = 2  # processed source previews now use display sRGB
 EDITED_THUMB_RENDER_EDGE = 512
 EDITED_THUMB_OUTPUT_EDGE = 320
 EDITED_THUMB_LOCK = threading.Lock()
@@ -3639,7 +3644,8 @@ def _render_preview(name: str, params: dict, width: int,
         if refining:
             preview_image = orig_jpeg(name, width, cp["rotate"])
             image_url = (f"/api/orig?name={quote(name, safe='')}&w={width}"
-                         f"&rot={cp['rotate']}&key={file_key(name)}")
+                         f"&rot={cp['rotate']}&key={file_key(name)}"
+                         f"&v={ORIGINAL_PREVIEW_CACHE_VERSION}")
         elif is_raw(name):
             preview_image = accurate
             image_url = (f"/api/neutral?name={quote(name, safe='')}&w={width}"
@@ -3649,9 +3655,10 @@ def _render_preview(name: str, params: dict, width: int,
         else:
             preview_image = orig_jpeg(name, width, cp["rotate"])
             image_url = (f"/api/orig?name={quote(name, safe='')}&w={width}"
-                         f"&rot={cp['rotate']}&key={file_key(name)}")
+                         f"&rot={cp['rotate']}&key={file_key(name)}"
+                         f"&v={ORIGINAL_PREVIEW_CACHE_VERSION}")
         source_key = hashlib.md5(json.dumps([
-            "source-preview-v1", file_key(name), cp, int(width),
+            "source-preview-v2", file_key(name), cp, int(width), image_url,
         ], sort_keys=True, separators=(",", ":")).encode()).hexdigest()
         response = {
             "ms": int((time.time() - t0) * 1000), "match": 1.0,
@@ -5743,10 +5750,24 @@ def program_render_image(body: dict, *, priority: str = "background") -> Image.I
     params = fp.clean_params(state.get("params") or {})
     if body.get("before"):
         return Image.open(io.BytesIO(orig_jpeg(
-            name, width, params.get("rotate", 0)))).convert("RGB")
+            name, width, params.get("rotate", 0), quality="full"))).convert("RGB")
     result = render_preview(
         name, params, width, str(body.get("engine", "rs")),
         str(body.get("client", "cli"))[:80], None, False, priority)
+    if result.get("refining"):
+        # File/analysis requests have no browser refinement loop. Finish the
+        # RAW source before encoding their one authoritative result.
+        import raw_decode_runtime
+        with raw_decode_runtime.cancellation(None, priority=priority):
+            if params["profile_enabled"]:
+                build_raw_preview(name, width, "full", params)
+            else:
+                build_neutral_preview(name, width, params.get("rotate", 0), params)
+        result = render_preview(
+            name, params, width, str(body.get("engine", "rs")),
+            str(body.get("client", "cli"))[:80], None, False, priority)
+        if result.get("refining"):
+            raise RuntimeError("Accurate RAW preview is unavailable")
     if result.get("cancelled"):
         raise RuntimeError(result.get("reason") or "render cancelled")
     base = Image.open(io.BytesIO(_preview_source_bytes(

--- a/tests/before-preview.test.mjs
+++ b/tests/before-preview.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import {test} from 'node:test';
+import {gradeBakeRequest, gradeBakeKey} from '../web/preview-processing.js';
+
+const source = fs.readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+const between = (start, end) => source.slice(source.indexOf(start), source.indexOf(end, source.indexOf(start)));
+
+for (const native of [false, true]) for (const baked of [false, true]) test(`Before selects original pixels and restores edits (${native ? 'Metal' : 'WebGL'}, baked=${baked})`, () => {
+  const noop = () => {}, calls = [];
+  const S = {holdBefore:false, compareActive:false, comparePosition:0.4, params:{profile_enabled:true},
+    renderState:'ready', grade:{exposure:0.5}, masks:[{id:'mask', grade:{texture:baked ? 0.3 : 0}}], softProof:{active:true},
+    gradeEditsBaked:baked,
+    maskTextureDirty:false, gl:{draw:(grade,masks) => calls.push({grade,masks}),
+      drawCompare:position => {calls.push({position}); return true;}}};
+  S.presentedGradeKey = gradeBakeKey(gradeBakeRequest(S.grade, S.masks));
+  const node = {classList:{toggle:noop}, removeAttribute:noop, style:{setProperty:noop}};
+  const context = {S, $:() => node, performance, GRADE_DEFAULTS:{exposure:0},
+    gradeBakeRequest, gradeBakeKey,
+    renderPhysicalPreview:() => assert.fail('Holding Before must not rebuild the edited surface'),
+    scheduleViewportRegionRender:noop, syncPreviewBackend:noop, packedMaskData:{},
+    nativePreviewActive:() => native, scheduleHistogram:noop, GRADE_PERF:{take:() => null},
+    nativeGradePayload:grade => ({grade}), postNative:(action,detail) => calls.push({action,...detail}),
+    previewSourceX:position => position, syncCompareView:noop, syncCompareControl:noop,
+    setCompareActive:on => {S.compareActive=on;}};
+  const code = between('function drawGradeNow(', 'function drawGrade()') +
+    between('function renderedComparePosition()', 'function compareEditingBlocked()') +
+    between('function renderCompare()', 'function setCompareActive(') +
+    between('function setBefore(', "$('beforeBtn').addEventListener") +
+    '\nfunction drawGrade(){drawGradeNow();} globalThis.before=setBefore;';
+  vm.runInNewContext(code, context);
+  context.before(true);
+  assert.equal(calls.findLast(c => 'position' in c)?.position, 1, 'Before must select the original texture');
+  assert.equal(calls.findLast(c => c.grade)?.grade, baked ? context.GRADE_DEFAULTS : S.grade, 'Keep finishing adjustments ready for release without applying baked grade twice');
+  if (!native) assert.deepEqual(Array.from(calls.findLast(c => c.masks)?.masks), baked ? [] : S.masks, 'Keep the edited mask uniforms while holding Before');
+  context.before(false);
+  assert.equal(calls.findLast(c => 'position' in c)?.position, 0);
+  assert.equal(S.params.profile_enabled, true, 'Before must not change saved Film settings');
+});

--- a/tests/processing_app.mjs
+++ b/tests/processing_app.mjs
@@ -87,6 +87,7 @@ try {
     GradeRenderer.prototype.draw = function(...args) {
       draw.apply(this, args);
       if (this.canvas.id !== 'cv' || !this.ready) return;
+      window.processingRenderer = this;
       const gl = this.gl;
       if (gl.getParameter(gl.FRAMEBUFFER_BINDING) !== null) return;
       const pixels = new Uint8Array(this.canvas.width * this.canvas.height * 4);
@@ -120,6 +121,23 @@ try {
     await page.waitForFunction(({source, grade}) => processingFrame.sourceURL === source &&
       Object.entries(grade).every(([key, value]) =>
         Math.abs(processingFrame.grade[key] - value) < 0.0001), {source, grade}, {timeout:120000});
+  };
+  const captureBefore = async (test, frame, name) => {
+    await page.waitForFunction(() => processingRenderer.originalReady, null, {timeout:30000});
+    await page.evaluate(() => document.activeElement?.blur());
+    const beforeHold = await page.evaluate(() => processingFrames);
+    await page.keyboard.down('b');
+    await page.waitForFunction(before => processingFrames > before, beforeHold);
+    const held = await page.evaluate(() => processingFrame);
+    fs.writeFileSync(test.beforeRaw, Buffer.from(held.pixels));
+    const original = await page.request.post(config.baseUrl + '/api/render/file',
+      {data:{name, w:frame.width, format:'png', before:true, state:{params:test.params}}, timeout:120000});
+    if (!original.ok()) throw Error(`Original reference: ${await original.text()}`);
+    fs.writeFileSync(test.beforeReference, await original.body());
+    const beforeRelease = await page.evaluate(() => processingFrames);
+    await page.keyboard.up('b');
+    await page.waitForFunction(before => processingFrames > before, beforeRelease);
+    fs.writeFileSync(test.releasedRaw, Buffer.from(await page.evaluate(() => processingFrame.pixels)));
   };
   for (const [index, test] of config.cases.entries()) {
     process.stdout.write(JSON.stringify({event:'case', name:test.name}) + '\n');
@@ -171,6 +189,7 @@ try {
       if (!reference.ok()) throw Error(await reference.text());
       fs.writeFileSync(test.reference, await reference.body());
       const bounds = await captureDisplay(test, frame);
+      await captureBefore(test, frame, name);
       results.push({name:test.name, photo:name, bounds, ...frame});
       continue;
     }
@@ -227,6 +246,7 @@ try {
     if (!reference.ok()) throw Error(`CLI reference: ${await reference.text()}`);
     fs.writeFileSync(test.reference, await reference.body());
     const bounds = await captureDisplay(test, frame);
+    await captureBefore(test, frame, name);
     results.push({name:test.name, photo:name, bounds, ...frame});
   }
   if (!delayedFilmResponses) throw Error('Slow physical-render regression was not exercised');

--- a/tests/processing_app.py
+++ b/tests/processing_app.py
@@ -63,7 +63,10 @@ def run(output_dir):
                     reference=str(output / f"{case['name']}-cli.png"),
                     display=str(output / f"{case['name']}-display.png"),
                     displayReference=str(output / f"{case['name']}-display-reference.png"),
-                    screenshot=str(output / f"{case['name']}-app.png"))
+                    screenshot=str(output / f"{case['name']}-app.png"),
+                    beforeRaw=str(output / f"{case['name']}-before.rgba"),
+                    beforeReference=str(output / f"{case['name']}-original.png"),
+                    releasedRaw=str(output / f"{case['name']}-released.rgba"))
     module = find_playwright_module()
     if not module or not shutil.which('node'):
         raise RuntimeError('Application gate requires Node and Playwright')
@@ -122,6 +125,13 @@ def run(output_dir):
         record.update(photo=frame['photo'], reference='Actual /api/render/file CLI route (Python CPU grade)',
                       screenshot=case['screenshot'], grade=frame['grade'])
         records.append(record)
+        before_reference = np.asarray(Image.open(case['beforeReference']).convert('RGB')).astype(float) / 255
+        before = np.fromfile(case['beforeRaw'], dtype=np.uint8).reshape(frame['height'], frame['width'], 4)
+        records.append(compare_images(case['name'] + '-hold-before', before_reference,
+                                      before[::-1, :, :3] / 255, output / 'before'))
+        released = np.fromfile(case['releasedRaw'], dtype=np.uint8).reshape(frame['height'], frame['width'], 4)
+        records.append(compare_images(case['name'] + '-release-before', actual[::-1, :, :3] / 255,
+                                      released[::-1, :, :3] / 255, output / 'before'))
         display = np.asarray(Image.open(case['display']).convert('RGB')).astype(float) / 255
         # The reference page displays the readback bytes at exactly the app's
         # DOM bounds, including fractional boundary coverage. No image fitting,

--- a/tests/test_before_preview.py
+++ b/tests/test_before_preview.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(shutil.which("node"), "Node.js is unavailable")
+class BeforePreviewTests(unittest.TestCase):
+    def test_before_texture_selection(self):
+        result = subprocess.run(["node", "--test", str(ROOT / "tests/before-preview.test.mjs")],
+                                capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/test_compare_original.py
+++ b/tests/test_compare_original.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageCms
 
 import server
 
@@ -20,6 +20,96 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class CompareOriginalTests(unittest.TestCase):
+    def test_processed_preview_preserves_srgb_and_invalidates_old_pixels(self):
+        profile = ImageCms.ImageCmsProfile(ImageCms.createProfile("sRGB")).tobytes()
+        for old_cache in (False, True):
+            with self.subTest(old_cache=old_cache), tempfile.TemporaryDirectory() as directory:
+                folder = Path(directory)
+                source = Image.new("RGB", (64, 64))
+                colors = [(200, 40, 20), (30, 180, 60), (40, 80, 220), (128, 128, 128)]
+                for index, color in enumerate(colors):
+                    source.paste(color, (index * 16, 0, (index + 1) * 16, 64))
+                source.save(folder / "photo.jpg", icc_profile=profile, quality=100, subsampling=0)
+                decoded = Image.open(folder / "photo.jpg")
+                cache = folder / "cache"
+                (cache / "orig").mkdir(parents=True)
+                if old_cache:
+                    Image.new("RGB", (64, 64), "black").save(cache / "orig/source_64.jpg")
+                with mock.patch.object(server, "FOLDER", folder), \
+                        mock.patch.object(server, "CACHE", cache), \
+                        mock.patch.object(server, "file_key", return_value="source"), \
+                        mock.patch.object(server, "guard_local_photo"):
+                    image = Image.open(io.BytesIO(server.orig_jpeg("photo.jpg", 64)))
+                for x in (8, 24, 40, 56):
+                    np.testing.assert_allclose(image.getpixel((x, 32)),
+                                               decoded.getpixel((x, 32)), atol=1)
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is unavailable")
+    def test_finished_raw_replaces_draft_in_both_display_paths(self):
+        accurate = mock.Mock()
+        accurate.exists.side_effect = [False, True]
+        with mock.patch.object(server, "neutral_preview_path", return_value=accurate), \
+                mock.patch.object(server, "orig_jpeg", return_value=b"draft"), \
+                mock.patch.object(server, "guard_local_photo"), \
+                mock.patch.object(server, "file_key", return_value="source"):
+            responses = [server.render_preview("photo.dng", {"profile_enabled": False}, 1100)
+                         for _ in range(2)]
+        javascript = (ROOT / "web/app.js").read_text()
+        source = javascript[javascript.index("function rememberPresentedRender("):
+                            javascript.index("function setWebGLBaseImage(")]
+        script = """
+const assert = require('node:assert/strict'), vm = require('node:vm');
+const responses = RESPONSE;
+(async () => { for (const native of [true, false]) {
+  const uploads = [], S = {seq:1, renderState:'pending'};
+  const context = {S, performance, nativePreviewActive:() => native, drawGrade:() => {},
+    setNativeBaseImage:async render => {uploads.push(render.img); return {};},
+    setWebGLBaseImage:async url => {uploads.push(url); return {};}};
+  vm.runInNewContext(SOURCE + '\\nglobalThis.load=setBaseImage;', context);
+  await context.load(responses[0], 1);
+  S.renderState='ready'; S.seq=2;
+  await context.load(responses[1], 2);
+  assert.equal(uploads.length, 2, native ? 'Metal kept draft' : 'WebGL kept draft');
+  assert.match(uploads[1], /api\\/neutral/);
+}})().catch(e => {console.error(e); process.exitCode=1;});
+""".replace("RESPONSE", json.dumps(responses)).replace("SOURCE", json.dumps(source))
+        result = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_cli_before_uses_accurate_raw_at_requested_resolution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            folder = Path(directory)
+            full, draft = folder / "full.jpg", folder / "draft.jpg"
+            Image.new("RGB", (3000, 2000), (60, 90, 120)).save(full)
+            Image.new("RGB", (1600, 1067), (30, 40, 50)).save(draft)
+            with mock.patch.object(server, "CACHE", folder), \
+                    mock.patch.object(server, "file_key", return_value="source"), \
+                    mock.patch.object(server, "guard_local_photo"), \
+                    mock.patch.object(server, "catalog_entry_for", return_value={}), \
+                    mock.patch.object(server, "build_neutral_preview", return_value=full), \
+                    mock.patch.object(server, "raw_display", return_value=draft):
+                result = server.program_render_image({"name": "photo.dng", "w": 3000, "before": True})
+            self.assertEqual(result.size, (3000, 2000))
+            np.testing.assert_array_equal(result, Image.open(full))
+
+    def test_cli_after_waits_for_accurate_raw_on_a_cold_cache(self):
+        for film in (False, True):
+            with self.subTest(film=film), tempfile.TemporaryDirectory() as directory:
+                image = Path(directory) / "accurate.jpg"
+                Image.new("RGB", (90, 60), (60, 90, 120)).save(image)
+                with mock.patch.object(server, "catalog_entry_for", return_value={}), \
+                        mock.patch.object(server, "render_preview", side_effect=[
+                            {"refining": True}, {"refining": False}]) as render, \
+                        mock.patch.object(server, "build_neutral_preview") as neutral, \
+                        mock.patch.object(server, "build_raw_preview") as raw, \
+                        mock.patch.object(server, "_preview_source_bytes", return_value=image.read_bytes()), \
+                        mock.patch.object(server, "exif_for", return_value={}):
+                    server.program_render_image({"name": "photo.dng", "w": 90,
+                        "state": {"params": {"profile_enabled": film}}})
+                self.assertEqual(render.call_count, 2, "CLI returned the draft without finishing RAW")
+                self.assertEqual(raw.call_count, int(film))
+                self.assertEqual(neutral.call_count, int(not film))
+
     @unittest.skipUnless(shutil.which("node"), "Node.js is unavailable")
     def test_browser_and_native_original_url_retains_requested_detail(self):
         javascript = (ROOT / "web/app.js").read_text()
@@ -40,6 +130,7 @@ console.log(JSON.stringify([800, 3000, 6000, undefined].map(width =>
         self.assertEqual([int(url["w"]) for url in urls], [800, 3000, 6000, 6000])
         for url in urls:
             self.assertEqual(url["quality"], "full")
+            self.assertEqual(url["v"], str(server.ORIGINAL_PREVIEW_CACHE_VERSION))
             self.assertEqual(url["name"], "3:photo & detail.ARW")
             self.assertEqual(url["rot"], "90")
             self.assertEqual(url["key"], "changed-source")

--- a/tests/test_performance_contracts.py
+++ b/tests/test_performance_contracts.py
@@ -522,7 +522,7 @@ class NativePreviewContractTests(unittest.TestCase):
         javascript = (ROOT / "web" / "app.js").read_text()
         swift = (ROOT / "app" / "NativePreview.swift").read_text()
         metal = (ROOT / "app" / "NativePreview.metal").read_text()
-        self.assertIn("softProof: S.holdBefore ? null : S.softProof", javascript)
+        self.assertIn("softProof: S.softProof", javascript)
         self.assertNotIn("&& !advancedColorActive()", javascript)
         self.assertIn("var point0", swift)
         self.assertIn("var colorGrade0", swift)

--- a/web/app.js
+++ b/web/app.js
@@ -1732,19 +1732,19 @@ function nativeGradePayload(grade) {
   const values = { ...grade };
   if (!curvesChanged) CURVE_KEYS.forEach((key) => delete values[key]);
   return { grade: values, curvesChanged, interaction: GRADE_PERF.take(),
-    softProof: S.holdBefore ? null : S.softProof };
+    softProof: S.softProof };
 }
 
 function drawGradeNow(forceWebGL = false, refreshScope = true) {
   scheduleViewportRegionRender();
   if (S.renderState === 'pending' && S.presentedPhotoName && S.presentedPhotoName !== cur()?.name) return;
   if (S.previewLoadGeneration != null) return;
-  const requestedGradeKey = gradeBakeKey(gradeBakeRequest(S.grade, S.masks, S.holdBefore));
+  const requestedGradeKey = gradeBakeKey(gradeBakeRequest(S.grade, S.masks));
   if (requestedGradeKey !== (S.presentedGradeKey ?? null)) {
     renderPhysicalPreview();
     return;
   }
-  const activeGrade = S.holdBefore || S.gradeEditsBaked ? GRADE_DEFAULTS : S.grade;
+  const activeGrade = S.gradeEditsBaked ? GRADE_DEFAULTS : S.grade;
   syncPreviewBackend();
   let upload;
   let channelUpload;
@@ -1771,8 +1771,8 @@ function drawGradeNow(forceWebGL = false, refreshScope = true) {
   // continuous draws, but allow an explicit one-shot refresh before sampling
   // or after a new helper texture arrives.
   if (S.gl && (!native || forceWebGL) && !interactiveMask) {
-    S.gl.draw(activeGrade, S.holdBefore || S.gradeEditsBaked ? [] : S.masks, upload,
-      S.holdBefore ? null : S.softProof);
+    S.gl.draw(activeGrade, S.gradeEditsBaked ? [] : S.masks, upload,
+      S.softProof);
     if (refreshScope) scheduleHistogram();
     if (!native) {
       const input = GRADE_PERF.take();
@@ -1795,7 +1795,7 @@ function refreshWebGLSamplingSurface() {
 }
 
 function nativeMaskPayload(imageData) {
-  const masks = (S.holdBefore || S.gradeEditsBaked ? [] : S.masks).slice(0, MAX_MASKS).map((mask) => ({
+  const masks = (S.gradeEditsBaked ? [] : S.masks).slice(0, MAX_MASKS).map((mask) => ({
     enabled: mask.enabled !== false,
     opacity: +mask.opacity || 0,
     lumaLow: +mask.lumaLow || 0,
@@ -3374,7 +3374,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
     const request = {
       name: im.name, params: S.params, w, engine: $('engine').value,
       optics: S.optics, heals: S.heals,
-      ...gradeBakeRequest(S.grade, S.masks, S.holdBefore),
+      ...gradeBakeRequest(S.grade, S.masks),
       client: CLIENT_ID, generation: my, priority: 'interactive',
       native: nativePreviewActive(),
       ...(viewport ? { viewport } : {}),
@@ -3401,7 +3401,7 @@ async function doRender(scheduledAt = performance.now(), options = {}) {
       });
     }
     if (my !== S.seq) return;
-    if (requestedGradeKey !== gradeBakeKey(gradeBakeRequest(S.grade, S.masks, S.holdBefore))) {
+    if (requestedGradeKey !== gradeBakeKey(gradeBakeRequest(S.grade, S.masks))) {
       renderPhysicalPreview();
       return;
     }
@@ -3736,7 +3736,7 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
       });
     }
     postNative('nativePreview', {
-      generation, surface, grade: S.holdBefore || render.gradeEditsBaked ? GRADE_DEFAULTS : S.grade,
+      generation, surface, grade: render.gradeEditsBaked ? GRADE_DEFAULTS : S.grade,
       masks: nativeMaskPayload(packedMaskData),
       ...nativeEditsPayload(Boolean(render.baseEditsBaked)),
       original: {
@@ -3754,7 +3754,7 @@ function originalPreviewURL(requestedWidth = requestedPreviewWidth()) {
   // Compare must resolve the same detail as the edited preview, including 1:1.
   const width = requestedWidth;
   return `/api/orig?name=${encodeURIComponent(im.name)}` +
-    `&w=${width}&rot=${S.params.rotate || 0}&quality=full` +
+    `&w=${width}&rot=${S.params.rotate || 0}&quality=full&v=2` +
     `&key=${encodeURIComponent(im.fileKey || im.mtime || '')}`;
 }
 
@@ -6319,7 +6319,7 @@ function broadcastToLoupe(photo) {
     type: 'sync',
     name: photo.name,
     metadata: metaParts,
-    url: `/api/orig?name=${encodeURIComponent(photo.name)}&w=${sourceLongEdge(photo)}`,
+    url: `/api/orig?name=${encodeURIComponent(photo.name)}&w=${sourceLongEdge(photo)}&v=2`,
   });
 }
 
@@ -7552,6 +7552,8 @@ $('rotL').onclick = () => rotate(-90);
 $('rotR').onclick = () => rotate(90);
 
 function renderedComparePosition() {
+  // The original texture bypasses Film, geometry, masks, grade, and proofing.
+  if (S.holdBefore) return 1;
   return S.compareActive ? S.comparePosition : 0;
 }
 
@@ -7679,6 +7681,7 @@ function setBefore(on) {
   if (on && S.compareActive) setCompareActive(false);
   S.holdBefore = on;
   $('beforeBtn').classList.toggle('on', on);
+  renderCompare();
   drawGrade();
 }
 $('beforeBtn').addEventListener('pointerdown', () => setBefore(true));

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -125,7 +125,7 @@
           ],
           "tips": [
             "Both schemes use G for Photo Grid, Shift+G for Culling Grid, N for Survey, P/X/U for flags, and 0–5 for stars.",
-            "Hold B to show the original while inspecting an edit. Slash (/) focuses photo search.",
+            "Hold B to show the original without Film, local masks, or finishing adjustments; release B to restore the edit. Slash (/) focuses photo search.",
             "Photo shortcuts are ignored while typing in text, number, or selection fields. Leave the field before using a photo command."
           ]
         }
@@ -216,7 +216,8 @@
           "title": "Compare while zoomed in",
           "paragraphs": [
             "Click Compare in Detail to split the original and edited photo. Drag the divider to move the split; drag elsewhere on a zoomed photo to pan. The divider and its handle stay the same size as you zoom.",
-            "Original uses the same preview resolution as the edited photo, including at 1:1. For RAW photos, Original uses the neutral, unedited conversion; allow it to finish loading before judging detail."
+            "Original uses the same preview resolution as the edited photo, including at 1:1. For RAW photos, Original uses the neutral, unedited conversion; allow it to finish loading before judging detail.",
+            "Hold B to view the original without Film, local masks, or finishing adjustments. Release B to restore the edited view."
           ],
           "steps": [
             "Turn on Compare, then zoom beyond Fit.",

--- a/web/loupe.js
+++ b/web/loupe.js
@@ -168,7 +168,7 @@ function loadPhoto(data) {
   emptyState.hidden = true;
   stage.hidden = false;
 
-  const url = data.url || `/api/orig?name=${encodeURIComponent(data.name)}&w=3840`;
+  const url = data.url || `/api/orig?name=${encodeURIComponent(data.name)}&w=3840&v=2`;
   const isNew = loupeImg.src !== url;
 
   loupeImg.onload = () => {

--- a/web/survey.js
+++ b/web/survey.js
@@ -30,7 +30,7 @@ export function createSurvey(ctx) {
   }
 
   function imageURL(image) {
-    return `/api/orig?name=${encodeURIComponent(image.name)}&w=800&key=${encodeURIComponent(image.fileKey || image.mtime || '')}`;
+    return `/api/orig?name=${encodeURIComponent(image.name)}&w=800&v=2&key=${encodeURIComponent(image.fileKey || image.mtime || '')}`;
   }
 
   function syncSurveyCell(cell, image, isActive) {


### PR DESCRIPTION
Original previews now use display sRGB, replace cold RAW drafts with the accurate render, and wait for accurate RAW pixels in file/analysis requests. Holding B selects the original texture and releasing it restores the edited view, including Film and baked local adjustments, without triggering a redundant render or applying the finishing grade twice.

Integrates the preview-fidelity changes with the current measured-progress, automatic-preview, and local-processing behavior. The application pixel journey now checks Original press/release alongside existing delayed-render, mask, and navigation cases. Bundled Help and cache versions are updated.

Validation: 1,147 unit tests passed (4 skipped); 114 WebGL pixel checks and 101 full application pixel checks passed; Help validation and git diff --check passed. Native package signatures and Python import checks passed. The native photo journey is NOT DONE because the Mac session is locked; desktop installation and visible native proof are separate from these browser pixel checks.
