### PR TITLE
Add missing tooltips to photo controls

### DIFF
--- a/docs/help/editing.json
+++ b/docs/help/editing.json
@@ -127,7 +127,7 @@
     ],
     "related": ["editing-tone", "editing-color-grading", "editing-presets"],
     "sources": [
-      {"path": "web/index.html", "anchor": "<button class=\"curveCh on\" data-ch=\"L\">RGB</button>"},
+      {"path": "web/index.html", "anchor": "<button class=\"curveCh on\" data-ch=\"L\""},
       {"path": "web/app.js", "anchor": "(function curveEvents()"},
       {"path": "web/app.js", "anchor": "if (i > 0 && i < pts.length - 1)"},
       {"path": "web/app.js", "anchor": "handles for editing while drawing the exact table until the first edit."}
@@ -241,7 +241,7 @@
     ],
     "related": ["editing-detail-effects-enhance", "editing-lens-corrections", "editing-masks-brush-gradients", "editing-tone"],
     "sources": [
-      {"path": "web/index.html", "anchor": "<summary><span>Effects</span><a class=\"reset\" href=\"#\" data-reset=\"effects\">Reset</a></summary>"},
+      {"path": "web/index.html", "anchor": "<summary><span>Effects</span><a class=\"reset\" href=\"#\" data-reset=\"effects\""},
       {"path": "grade.py", "anchor": "\"texture\": 0.0,      # -1..1, one-pixel local detail"},
       {"path": "grade.py", "anchor": "\"clarity\": 0.0,      # -1..1, midtone-weighted local contrast"},
       {"path": "grade.py", "anchor": "haze = g[\"dehaze\"] * 0.12"},

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -5,14 +5,14 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
     },
@@ -21,21 +21,21 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "capture-time": {
       "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
       "sources": {
         "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "catalog-health-recovery": {
       "content": "41e3f81ef36412cf1ec4ce0f431988f484834120a750a45d31a1fef66365c718",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb"
       }
@@ -44,7 +44,7 @@
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "colour-labels": {
@@ -58,14 +58,14 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-copy-paste-match-exposure": {
@@ -80,14 +80,14 @@
     "editing-crop-geometry": {
       "content": "847f666d8a355cae0104998f95f855baf7de6490a8445d2603e67e681623393c",
       "sources": {
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-curves": {
-      "content": "6649b78fb8f7539558a27bd62d46769edd6bde6e5235aaa604f7bcfc74a24c73",
+      "content": "498bf3ffd912c4de38f040a476a0a4d47236f02de2389e7f2faa2764fd231199",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-detail-effects-enhance": {
@@ -96,15 +96,15 @@
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-effects": {
-      "content": "0ece10b9b54782683aeebcf9f9a667e148d8731e5c85158bd85927bea2c0f6e4",
+      "content": "60f9069c39ff5b1be4b09e99328bf0c4c301f6601e8a3353b060434c3be35e9b",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-history-snapshots": {
@@ -112,14 +112,14 @@
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-masks-ai": {
@@ -127,21 +127,21 @@
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "61e5a03da9c860f6c1bf1b049bce67710b34e74f551eabe3131705ee10ee69ce",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-photo-merge": {
@@ -151,21 +151,21 @@
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-presets": {
       "content": "53107c055d29749d94f8708d4e18b5e246db2eb67b1b68948659c3f46fc65026",
       "sources": {
         "preset_io.py": "16aafa7edd016912ba7538ae223b1b532c3214b507763c22575ba2d0da25c2ea",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-remove-heal": {
       "content": "a21bed5c2d859545a1ab2ee26ff88c7d8463e4bb0ee96390cbda6c404cf6539e",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-save-recovery": {
@@ -179,14 +179,14 @@
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "export-filenames-and-folders": {
@@ -194,7 +194,7 @@
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "export-format-color-space": {
@@ -202,14 +202,14 @@
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "export-metadata-sidecars": {
       "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "export-photos": {
@@ -217,14 +217,14 @@
       "sources": {
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "film-exposure-and-processing": {
@@ -232,7 +232,7 @@
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "film-getting-started": {
@@ -240,7 +240,7 @@
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/style.css": "0d166b919591dd5b6df99053b7eee60ec1c583e21f9bb1c0aa01c648d019dd3f"
       }
     },
@@ -248,7 +248,7 @@
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "film-halation-diffusion-scan": {
@@ -256,7 +256,7 @@
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "film-negative-paper-and-slides": {
@@ -265,14 +265,14 @@
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "flags-and-ratings": {
@@ -287,7 +287,7 @@
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "import-lightroom-catalog": {
@@ -296,7 +296,7 @@
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
         "web/catalog-ui.js": "275b4256f0b650c4dac4109cebaabce2b324b0e59b75a62739534bdacb13f1ba",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "keyboard-midi": {
@@ -304,7 +304,7 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
     },
@@ -319,7 +319,7 @@
       "content": "91f27aaf6e367408f0d1572495a6edc96f3534285b26144b02b496901edcc673",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "f379882d2234db258fa8f3491c5f0829913083012874dd417bb8bea8264dd4bd",
@@ -333,14 +333,14 @@
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -356,15 +356,15 @@
       "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
-        "web/library-filters.js": "ce5a8b7272b19301b684af76675ec25ea87f53f2e76fdaea17ef1c99f1116825",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
+        "web/library-filters.js": "d7067be899aa094b59d3f2bee6d6ffc246dcf782465c2c5e4a37c9f6dd90e658",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
     "settings-and-defaults": {
       "content": "c924f166996e97b4da2d038d431ef735d757dc5cc12fba6e959f5fc39450f006",
       "sources": {
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb"
       }
     },
@@ -372,7 +372,7 @@
       "content": "9117f2d6a953f9a3f836b91420b22d75cc570201d2d5cc822f2adf7e64f9d224",
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9",
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -388,7 +388,7 @@
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "survey-photos": {
@@ -411,7 +411,7 @@
       "sources": {
         "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
-        "web/index.html": "1bc7806e9bb3aa78d4c795ff2dac8db6ff68d12a155612f962c234c64fee8dc9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "virtual-copies-and-stacks": {

--- a/web/index.html
+++ b/web/index.html
@@ -135,7 +135,7 @@
   </aside>
 
   <div id="libraryFilterPanel" class="library-filter-panel" role="dialog" aria-labelledby="libraryFilterTitle" hidden>
-    <div class="library-filter-heading"><strong id="libraryFilterTitle">Filter photos</strong><button id="closeLibraryFilters" class="quiet icon-btn" type="button" aria-label="Close filters">×</button></div>
+    <div class="library-filter-heading"><strong id="libraryFilterTitle">Filter photos</strong><button id="closeLibraryFilters" class="quiet icon-btn" type="button" aria-label="Close filters" title="Close filters">×</button></div>
     <fieldset class="file-type-filters"><legend>File type</legend>
       <label><input type="checkbox" data-file-type="raw">RAW</label>
       <label><input type="checkbox" data-file-type="jpeg">JPEG</label>
@@ -242,7 +242,7 @@
           <button class="quiet icon-btn" id="zoomOut" title="Zoom out" aria-label="Zoom out">&minus;</button>
           <span class="zoom-value" id="zoomVal">100%</span>
           <button class="quiet icon-btn" id="zoomIn" title="Zoom in" aria-label="Zoom in">+</button>
-          <button class="quiet compact on" id="zoomFit" aria-pressed="true">Fit</button>
+          <button class="quiet compact on" id="zoomFit" aria-pressed="true" title="Fit the whole photo to the available space">Fit</button>
           <button class="quiet compact" id="zoom1" aria-pressed="false">1:1</button>
         </div>
         <div class="under-group marking-tools">
@@ -281,7 +281,7 @@
 
     <div class="panel" id="panel">
       <section class="panel-pane on" id="editPane">
-        <div class="panel-title panel-title-compact"><strong>Edit</strong><button class="quiet compact" id="resetEdit">Reset</button></div>
+        <div class="panel-title panel-title-compact"><strong>Edit</strong><button class="quiet compact" id="resetEdit" title="Reset global tone, color, curves, sharpening, noise reduction, and effects">Reset</button></div>
         <div class="histogram-wrap">
           <canvas id="hist" width="300" height="110"></canvas>
           <span class="hist-label hist-black" id="scopeLowLabel">0</span><span class="hist-label hist-white" id="scopeHighLabel">255</span>
@@ -296,7 +296,7 @@
         </div>
 
         <details class="sec" id="lightSection" open>
-          <summary><span>Light</span><span class="summary-actions"><button class="quiet compact section-action" id="autoBtn" type="button" title="Automatically set tone">Auto</button><a class="reset" href="#" data-reset="tone">Reset</a></span></summary>
+          <summary><span>Light</span><span class="summary-actions"><button class="quiet compact section-action" id="autoBtn" type="button" title="Automatically set tone">Auto</button><a class="reset" href="#" data-reset="tone" title="Reset Exposure, Contrast, Highlights, Shadows, Whites, and Blacks">Reset</a></span></summary>
           <div class="secbody">
             <div class="row"><span class="name">Exposure</span><input type="range" data-g="exposure" min="-3" max="3" step="0.01" value="0"><span class="val" data-gv="exposure">0.00</span></div>
             <div class="row"><span class="name">Contrast</span><input type="range" data-g="contrast" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="contrast">0.00</span></div>
@@ -308,18 +308,18 @@
         </details>
 
         <details class="sec">
-          <summary><span>Color</span><a class="reset" href="#" data-reset="colour">Reset</a></summary>
+          <summary><span>Color</span><a class="reset" href="#" data-reset="colour" title="Reset white balance, Vibrance, Saturation, Color Mixer, Point Color, and Color Grading">Reset</a></summary>
           <div class="secbody">
             <div class="row row-with-action"><span class="name">Temp</span><input type="range" data-g="temp" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="temp">0.00</span><button class="quiet icon-btn row-action" id="wbBtn" type="button" title="Click a neutral area to set white balance" aria-label="White balance eyedropper"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 15 8-8M11 5l4 4M4 16l3-.5-2.5-2.5z"/></svg></button></div>
             <div class="row"><span class="name">Tint</span><input type="range" data-g="tint" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="tint">0.00</span></div>
             <div class="row"><span class="name">Vibrance</span><input type="range" data-g="vibrance" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="vibrance">0.00</span></div>
             <div class="row"><span class="name">Saturation</span><input type="range" data-g="saturation" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="saturation">0.00</span></div>
-            <div class="curve-head"><span>Color Mixer</span><a class="reset" href="#" data-reset="hsl">Reset</a></div>
+            <div class="curve-head"><span>Color Mixer</span><a class="reset" href="#" data-reset="hsl" title="Reset all Color Mixer channels">Reset</a></div>
             <div class="hsl-dots" id="hslBands"></div>
             <div class="row"><span class="name">Hue</span><input type="range" data-hsl="h" min="-1" max="1" step="0.01" value="0"><span class="val" data-hslv="h">0.00</span></div>
             <div class="row"><span class="name">Saturation</span><input type="range" data-hsl="s" min="-1" max="1" step="0.01" value="0"><span class="val" data-hslv="s">0.00</span></div>
             <div class="row"><span class="name">Luminance</span><input type="range" data-hsl="l" min="-1" max="1" step="0.01" value="0"><span class="val" data-hslv="l">0.00</span></div>
-            <div class="curve-head advanced-color-head"><span>Point Color</span><a class="reset" href="#" data-reset="pointColor">Reset</a></div>
+            <div class="curve-head advanced-color-head"><span>Point Color</span><a class="reset" href="#" data-reset="pointColor" title="Remove all sampled Point Color adjustments">Reset</a></div>
             <div class="btnrow"><button class="quiet" id="pointColorSample">Sample color</button><button class="quiet" id="pointColorDelete">Delete point</button></div>
             <select id="pointColorSelect" class="stack-gap" aria-label="Selected point color"><option value="">No sampled colors</option></select>
             <div class="row"><span class="name">Range</span><input type="range" data-point-color="range" min="2" max="90" step="1" value="30"><span class="val" data-point-color-value="range">30°</span></div>
@@ -334,15 +334,15 @@
         </details>
 
         <details class="sec">
-          <summary><span>Curve</span><a class="reset" href="#" data-reset="curve">Reset</a></summary>
+          <summary><span>Curve</span><a class="reset" href="#" data-reset="curve" title="Reset the combined RGB and individual channel curves">Reset</a></summary>
           <div class="secbody">
-            <div class="segmented curve-segments"><button class="curveCh on" data-ch="L">RGB</button><button class="curveCh" data-ch="R">R</button><button class="curveCh" data-ch="G">G</button><button class="curveCh" data-ch="B">B</button></div>
+            <div class="segmented curve-segments"><button class="curveCh on" data-ch="L" title="Edit the combined RGB tone curve">RGB</button><button class="curveCh" data-ch="R" title="Edit the red channel curve">R</button><button class="curveCh" data-ch="G" title="Edit the green channel curve">G</button><button class="curveCh" data-ch="B" title="Edit the blue channel curve">B</button></div>
             <canvas id="curve" width="300" height="220"></canvas>
           </div>
         </details>
 
         <details class="sec">
-          <summary><span>Color Grading</span><a class="reset" href="#" data-reset="colorGrading">Reset</a></summary>
+          <summary><span>Color Grading</span><a class="reset" href="#" data-reset="colorGrading" title="Reset Shadows, Midtones, Highlights, and Global color grading">Reset</a></summary>
           <div class="secbody">
             <div class="grading-wheels" id="gradingWheels">
               <button class="grading-wheel on" data-cg-tone="shadows" type="button"><i></i><span>Shadows</span></button>
@@ -359,7 +359,7 @@
         </details>
 
         <details class="sec">
-          <summary><span>Effects</span><a class="reset" href="#" data-reset="effects">Reset</a></summary>
+          <summary><span>Effects</span><a class="reset" href="#" data-reset="effects" title="Reset Texture, Clarity, Dehaze, and Vignette">Reset</a></summary>
           <div class="secbody">
             <div class="row"><span class="name">Texture</span><input type="range" data-g="texture" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="texture">0.00</span></div>
             <div class="row"><span class="name">Clarity</span><input type="range" data-g="clarity" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="clarity">0.00</span></div>
@@ -369,7 +369,7 @@
         </details>
 
         <details class="sec" id="detailSection">
-          <summary><span>Detail</span><a class="reset" href="#" data-reset="detail">Reset</a></summary>
+          <summary><span>Detail</span><a class="reset" href="#" data-reset="detail" title="Reset sharpening and noise reduction adjustments">Reset</a></summary>
           <div class="secbody">
             <div class="row"><span class="name">Sharpening</span><input type="range" data-g="sharpness" min="0" max="1" step="0.01" value="0"><span class="val" data-gv="sharpness">0.00</span></div>
             <div class="row"><span class="name">Radius</span><input type="range" data-g="sharpenRadius" min="0.5" max="3" step="0.05" value="1"><span class="val" data-gv="sharpenRadius">1.00</span></div>
@@ -390,7 +390,7 @@
         </details>
 
         <details class="sec" id="lensPane">
-          <summary><span>Lens corrections</span><button class="quiet compact section-reset-button" id="lensReset" type="button">Reset</button></summary>
+          <summary><span>Lens corrections</span><button class="quiet compact section-reset-button" id="lensReset" type="button" title="Reset lens profile, distortion, vignetting, and chromatic aberration corrections">Reset</button></summary>
           <div class="secbody">
             <div class="lens-profile-card" id="lensProfileCard"><span class="status-dot"></span><div><strong id="lensProfileName">Checking photo metadata…</strong><span id="lensProfileDetail">Automatic correction uses the bundled camera and lens database.</span></div></div>
             <label class="field-label" for="lensProfileOverride">Lens profile</label>
@@ -409,7 +409,7 @@
         </details>
 
         <details class="sec" id="rawDevelopSection" hidden>
-          <summary><span>Profile</span><a class="reset" href="#" data-reset="raw">Reset</a></summary>
+          <summary><span>Profile</span><a class="reset" href="#" data-reset="raw" title="Reset the RAW profile and capture-stage processing settings">Reset</a></summary>
           <div class="secbody">
             <label class="field-label" for="raw_profile">Camera profile</label>
             <select id="raw_profile"><option value="camera">Camera color</option><option value="detail">Fine detail</option><option value="smooth">Smooth color</option></select>
@@ -425,7 +425,7 @@
       </section>
 
       <section class="panel-pane" id="maskPane">
-        <div class="panel-title"><div><strong>Masking</strong><span>Create and refine local adjustments</span></div><button class="quiet compact" id="maskReset">Clear All</button></div>
+        <div class="panel-title"><div><strong>Masking</strong><span>Create and refine local adjustments</span></div><button class="quiet compact" id="maskReset" title="Delete all masks and their local adjustments from this photo">Clear All</button></div>
         <div class="pane-content local-pane-content">
           <button class="quiet compact tool-back" type="button" data-exit-tool>Back to Edit</button>
           <button class="mask-create-toggle" id="maskCreateToggle" type="button" aria-expanded="true">
@@ -434,19 +434,19 @@
           <div class="mask-create-menu" id="maskCreateMenu">
             <span class="tool-section-label">Choose a tool</span>
             <div class="mask-tool-grid" role="group" aria-label="Create mask">
-            <button id="maskAddBrush"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m4 15 9-9 2 2-9 9H4zM12 7l2-2 2 2-2 2M4 17c2 0 3-1 3-3"/></svg><span>Brush</span></button>
-            <button id="maskAddLinear"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4h12M6 8h8M8 12h4M9.5 16h1"/></svg><span>Linear</span></button>
-            <button id="maskAddRadial"><svg viewBox="0 0 20 20" aria-hidden="true"><ellipse cx="10" cy="10" rx="7" ry="4.5"/><ellipse cx="10" cy="10" rx="3.5" ry="2"/></svg><span>Radial</span></button>
-            <button id="maskAddSubject"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="7" r="3"/><path d="M4.5 17c.6-4 2.4-6 5.5-6s4.9 2 5.5 6"/></svg><span>Subject</span></button>
-            <button id="maskAddSky"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M3 13h14M5 13a5 5 0 0 1 9-3 3 3 0 0 1 3 3M10 3v3M4.5 5.5l2 2M15.5 5.5l-2 2"/></svg><span>Sky</span></button>
-            <button id="maskAddObject"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 7V4h3M13 4h3v3M16 13v3h-3M7 16H4v-3"/><circle cx="10" cy="10" r="2.5"/></svg><span>Object</span></button>
-            <button id="maskAddDepth"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M3 6h9M5 10h10M8 14h9"/><circle cx="14" cy="6" r="2"/><circle cx="4" cy="14" r="2"/></svg><span>Depth</span></button>
-            <button id="maskAddPeople"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="7" cy="7" r="2.5"/><circle cx="14" cy="8" r="2"/><path d="M2.5 17c.5-3.8 2-5.7 4.5-5.7s4 1.9 4.5 5.7M11 17c.3-2.8 1.3-4.2 3-4.2s2.7 1.4 3 4.2"/></svg><span>People</span></button>
+            <button id="maskAddBrush" title="Paint a mask directly on the photo"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m4 15 9-9 2 2-9 9H4zM12 7l2-2 2 2-2 2M4 17c2 0 3-1 3-3"/></svg><span>Brush</span></button>
+            <button id="maskAddLinear" title="Create a mask with a gradual transition along a line"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 4h12M6 8h8M8 12h4M9.5 16h1"/></svg><span>Linear</span></button>
+            <button id="maskAddRadial" title="Create a mask with a soft circular transition"><svg viewBox="0 0 20 20" aria-hidden="true"><ellipse cx="10" cy="10" rx="7" ry="4.5"/><ellipse cx="10" cy="10" rx="3.5" ry="2"/></svg><span>Radial</span></button>
+            <button id="maskAddSubject" title="Automatically select the main subject for local adjustments"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="7" r="3"/><path d="M4.5 17c.6-4 2.4-6 5.5-6s4.9 2 5.5 6"/></svg><span>Subject</span></button>
+            <button id="maskAddSky" title="Automatically select the sky for local adjustments"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M3 13h14M5 13a5 5 0 0 1 9-3 3 3 0 0 1 3 3M10 3v3M4.5 5.5l2 2M15.5 5.5l-2 2"/></svg><span>Sky</span></button>
+            <button id="maskAddObject" title="Click an object in the photo to select it for local adjustments"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 7V4h3M13 4h3v3M16 13v3h-3M7 16H4v-3"/><circle cx="10" cy="10" r="2.5"/></svg><span>Object</span></button>
+            <button id="maskAddDepth" title="Select a range of distances from the camera; refine the far and near limits"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M3 6h9M5 10h10M8 14h9"/><circle cx="14" cy="6" r="2"/><circle cx="4" cy="14" r="2"/></svg><span>Depth</span></button>
+            <button id="maskAddPeople" title="Show masks for people, facial features, skin, and hair"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="7" cy="7" r="2.5"/><circle cx="14" cy="8" r="2"/><path d="M2.5 17c.5-3.8 2-5.7 4.5-5.7s4 1.9 4.5 5.7M11 17c.3-2.8 1.3-4.2 3-4.2s2.7 1.4 3 4.2"/></svg><span>People</span></button>
             </div>
             <div class="people-mask-menu" id="peopleMaskMenu" hidden>
               <div class="people-mask-head"><span>People masks</span><small id="peopleFaceCount">Choose a part</small></div>
               <div class="people-mask-grid">
-                <button data-person-part="person">Person</button><button data-person-part="face-skin">Face skin</button><button data-person-part="eyes">Eyes</button><button data-person-part="eyebrows">Eyebrows</button><button data-person-part="lips">Lips</button><button data-person-part="teeth">Teeth</button><button data-person-part="hair">Hair</button><button class="people-preset" id="maskSoftenSkin">Soften skin</button>
+                <button data-person-part="person" title="Select people for local adjustments">Person</button><button data-person-part="face-skin" title="Select estimated face skin for local adjustments">Face skin</button><button data-person-part="eyes" title="Select eyes for local adjustments">Eyes</button><button data-person-part="eyebrows" title="Select eyebrows for local adjustments">Eyebrows</button><button data-person-part="lips" title="Select lips for local adjustments">Lips</button><button data-person-part="teeth" title="Select teeth for local adjustments">Teeth</button><button data-person-part="hair" title="Select estimated hair regions for local adjustments">Hair</button><button class="people-preset" id="maskSoftenSkin" title="Select face skin and reduce Texture and Clarity">Soften skin</button>
               </div>
               <p class="hint">Runs privately with Apple Vision. Face skin and hair are estimated; no identity is inferred.</p>
             </div>
@@ -462,10 +462,10 @@
               <button class="quiet icon-btn" id="maskRename" type="button" title="Rename mask" aria-label="Rename mask">•••</button>
             </div>
             <div class="mask-refine-bar" role="group" aria-label="Refine selected mask">
-              <button id="maskRefineAdd" type="button" aria-pressed="false"><span aria-hidden="true">+</span>Add</button>
-              <button id="maskRefineSubtract" type="button" aria-pressed="false"><span aria-hidden="true">−</span>Subtract</button>
-              <button id="maskRefineIntersect" type="button" aria-pressed="false"><span aria-hidden="true">∩</span>Intersect</button>
-              <button id="maskEditShape" type="button" aria-pressed="false"><span aria-hidden="true">⌖</span>Edit Shape</button>
+              <button id="maskRefineAdd" type="button" aria-pressed="false" title="Paint areas to add to the selected mask"><span aria-hidden="true">+</span>Add</button>
+              <button id="maskRefineSubtract" type="button" aria-pressed="false" title="Paint areas to subtract from the selected mask"><span aria-hidden="true">−</span>Subtract</button>
+              <button id="maskRefineIntersect" type="button" aria-pressed="false" title="Paint the only area the selected mask should retain"><span aria-hidden="true">∩</span>Intersect</button>
+              <button id="maskEditShape" type="button" aria-pressed="false" title="Drag on the photo to change the selected gradient’s shape or position"><span aria-hidden="true">⌖</span>Edit Shape</button>
             </div>
             <p class="hint tool-instruction" id="maskInstruction">Draw directly on the photo.</p>
             <div class="mask-quick-actions">
@@ -508,7 +508,7 @@
                 <div class="row"><span class="name">Luminance Low</span><input type="range" id="maskLumaLow" min="0" max="1" step="0.01"><span class="val" id="maskLumaLowV">0%</span></div>
                 <div class="row"><span class="name">Luminance High</span><input type="range" id="maskLumaHigh" min="0" max="1" step="0.01"><span class="val" id="maskLumaHighV">100%</span></div>
                 <label class="check-row"><input type="checkbox" id="maskColorEnabled"><span>Colour range</span></label>
-                <button class="quiet full" id="maskColorSample" type="button">Sample colour</button>
+                <button class="quiet full" id="maskColorSample" type="button" title="Click a color, or Shift-drag to average an area, to refine the mask’s color range">Sample colour</button>
                 <div class="row"><span class="name">Hue</span><input type="range" id="maskColorHue" min="0" max="360" step="1"><span class="val" id="maskColorHueV">—</span></div>
                 <div class="row"><span class="name">Range</span><input type="range" id="maskColorRange" min="2" max="90" step="1"><span class="val" id="maskColorRangeV">30°</span></div>
                 <div class="row"><span class="name">Colour amount</span><input type="range" id="maskColorAmount" min="0" max="1" step="0.01"><span class="val" id="maskColorAmountV">100%</span></div>
@@ -521,13 +521,13 @@
       </section>
 
       <section class="panel-pane" id="healPane">
-        <div class="panel-title"><div><strong>Remove</strong><span>Clean up spots and distractions</span></div><button class="quiet compact" id="healReset">Clear All</button></div>
+        <div class="panel-title"><div><strong>Remove</strong><span>Clean up spots and distractions</span></div><button class="quiet compact" id="healReset" title="Delete all Remove, Heal, and Clone corrections from this photo">Clear All</button></div>
         <div class="pane-content local-pane-content">
           <button class="quiet compact tool-back" type="button" data-exit-tool>Back to Edit</button>
           <div class="heal-mode-grid" role="group" aria-label="Removal mode">
-            <button id="healToolRemove" type="button" aria-pressed="true"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m6 14 8-8M5 7l8 8M4 11a6 6 0 1 0 5-7"/></svg><span>Remove</span></button>
-            <button id="healToolHeal" type="button" aria-pressed="false"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 14 9-9a2.1 2.1 0 0 1 3 3l-9 9a2.1 2.1 0 0 1-3-3zM10 9l3 3"/></svg><span>Heal</span></button>
-            <button id="healToolClone" type="button" aria-pressed="false"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="7" cy="11" r="4"/><circle cx="13" cy="7" r="4"/></svg><span>Clone</span></button>
+            <button id="healToolRemove" type="button" aria-pressed="true" title="Fill a distraction using surrounding image detail"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m6 14 8-8M5 7l8 8M4 11a6 6 0 1 0 5-7"/></svg><span>Remove</span></button>
+            <button id="healToolHeal" type="button" aria-pressed="false" title="Blend detail from a source area with the target’s color and brightness"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 14 9-9a2.1 2.1 0 0 1 3 3l-9 9a2.1 2.1 0 0 1-3-3zM10 9l3 3"/></svg><span>Heal</span></button>
+            <button id="healToolClone" type="button" aria-pressed="false" title="Copy detail from a source area onto the target"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="7" cy="11" r="4"/><circle cx="13" cy="7" r="4"/></svg><span>Clone</span></button>
           </div>
           <p class="hint tool-instruction" id="healInstruction">Click or drag over a distraction. Heal and Clone choose a source automatically.</p>
           <div class="spot-visualize-control">
@@ -544,7 +544,7 @@
               <div><span>Selected</span><strong id="healSelectedName">Correction</strong></div>
             </div>
             <label class="check-row"><input type="checkbox" id="healVisible" checked><span>Enable this correction</span></label>
-            <div class="btnrow correction-actions"><button class="primary-btn" id="healReposition">Move Target</button><button class="primary-btn" id="healRefresh">Refresh Source</button></div>
+            <div class="btnrow correction-actions"><button class="primary-btn" id="healReposition" title="Click a new position in the photo for the selected correction’s target">Move Target</button><button class="primary-btn" id="healRefresh" title="Try a different source position for the selected Heal or Clone correction">Refresh Source</button></div>
             <p class="hint source-hint" id="healSourceHint">Drag either on-image circle to refine the target or source.</p>
             <button class="text-btn negative local-delete" id="healDelete">Delete Correction</button>
           </div>
@@ -552,10 +552,10 @@
       </section>
 
       <section class="panel-pane" id="filmPane">
-        <div class="panel-title panel-title-compact"><strong>Realistic Film Simulation</strong><button class="quiet compact" id="resetFilm">Reset</button></div>
+        <div class="panel-title panel-title-compact"><strong>Realistic Film Simulation</strong><button class="quiet compact" id="resetFilm" title="Reset the film profile and physical film stages for this photo">Reset</button></div>
 
         <details class="sec" id="filmProfileSection" open>
-          <summary><span>Film profile</span><a class="reset" href="#" data-reset="film">Reset</a><button type="button" class="section-switch" id="filmProfileToggle" role="switch" aria-checked="false" aria-label="Film profile off" title="Turn film profile on"><span class="switch-label" id="filmProfileState">Off</span><span class="switch-track" aria-hidden="true"><span></span></span></button></summary>
+          <summary><span>Film profile</span><a class="reset" href="#" data-reset="film" title="Reset the film profile, stock, output, and capture settings">Reset</a><button type="button" class="section-switch" id="filmProfileToggle" role="switch" aria-checked="false" aria-label="Film profile off" title="Turn film profile on"><span class="switch-label" id="filmProfileState">Off</span><span class="switch-track" aria-hidden="true"><span></span></span></button></summary>
           <div class="secbody">
             <div class="film-stock-choice">
               <label class="field-label" for="stock">Stock</label><select id="stock"></select>
@@ -589,7 +589,7 @@
         </details>
 
         <details class="sec" id="filmStagesSection" open>
-          <summary><span>Physical film stages</span><a class="reset" href="#" data-reset="stages">Reset</a></summary>
+          <summary><span>Physical film stages</span><a class="reset" href="#" data-reset="stages" title="Reset the physical film stage controls to their defaults">Reset</a></summary>
           <div class="secbody">
             <div class="row toggle-slider"><input type="checkbox" id="couplers_on" checked><span class="name">Couplers</span><input type="range" id="couplers_amount" min="0" max="2" step="0.05" value="1"><span class="val" id="couplers_amountV">1.00</span></div>
             <div class="row toggle-slider"><input type="checkbox" id="halation_on" checked><span class="name">Halation</span><input type="range" id="halation_amount" min="0" max="3" step="0.1" value="1"><span class="val" id="halation_amountV">1.0</span></div>
@@ -682,7 +682,7 @@
       </section>
 
       <section class="panel-pane" id="historyPane">
-        <div class="panel-title"><div><strong>History</strong><span>Every step, kept with the photo</span></div><button class="quiet compact" id="historyClear">Clear</button></div>
+        <div class="panel-title"><div><strong>History</strong><span>Every step, kept with the photo</span></div><button class="quiet compact" id="historyClear" title="Clear this photo’s stored history steps; keep its current edits">Clear</button></div>
         <div class="pane-content">
           <div class="history-list" id="historyList">Select a photo.</div>
           <p class="pane-note">History is stored in the catalog, so it survives quitting. Undo and redo follow each photo during this session.</p>
@@ -1311,7 +1311,7 @@
     <div class="help-layout">
       <aside class="help-browser" aria-label="Find help">
         <label class="help-search-label" for="helpSearch">Search help</label>
-        <div class="help-search-box"><input id="helpSearch" type="search" placeholder="Try crop, masks, or export…" autocomplete="off" spellcheck="false" aria-controls="helpResults"><button class="quiet icon-btn" id="helpClear" aria-label="Clear help search" hidden>×</button></div>
+        <div class="help-search-box"><input id="helpSearch" type="search" placeholder="Try crop, masks, or export…" autocomplete="off" spellcheck="false" aria-controls="helpResults"><button class="quiet icon-btn" id="helpClear" aria-label="Clear help search" hidden title="Clear help search">×</button></div>
         <div class="help-filter no-dd"><select id="helpCategory" aria-label="Help topic"><option value="">All topics</option></select><output id="helpResultCount" role="status" aria-live="polite"></output></div>
         <nav class="help-results" id="helpResults" aria-label="Help articles"></nav>
       </aside>

--- a/web/library-filters.js
+++ b/web/library-filters.js
@@ -71,6 +71,7 @@ export function installLibraryFilters({ el, onChange, closeDropdown }) {
       button.type = 'button'; button.className = 'filter-chip';
       button.dataset.filterChip = chip.id;
       button.setAttribute('aria-label', `Remove ${chip.label} filter`);
+      button.title = `Remove ${chip.label} filter`;
       button.textContent = `${chip.label} ×`;
       button.onclick = () => {
         const index = [...chipsHost.children].indexOf(button);


### PR DESCRIPTION
Several photo controls lacked hover explanations, including icon-only close buttons, curve channels, mask tools, removal modes, and reset actions. Add native hover tooltips to 50 controls and generated filter chips, with descriptions of tool behavior and reset scope.

Labels, layout, and click behavior stay unchanged. Refresh the reviewed help source fingerprints and two anchors affected by the added attributes; the bundled help text remains unchanged.

Validation: existing filter tests (6 passed), help tests (10 passed), help-content check (54 articles current), JavaScript syntax check, and a markup comparison confirming that only tooltip attributes changed. The desktop app has not been rebuilt or installed for this change.
