### PR TITLE
Fix Presets Manage button toggle behavior

### DIFF
--- a/docs/help/editing.json
+++ b/docs/help/editing.json
@@ -519,19 +519,20 @@
     "sections": [
       {
         "title": "Apply an existing recipe",
-        "paragraphs": ["Open Presets in the editing toolbar. Manage presets provides the selected preset’s source and conversion coverage, along with explicit application controls."],
+        "paragraphs": ["Open Presets in the editing toolbar. Click Manage… to open or close Manage presets; the button is highlighted while the section is open. Manage presets provides the selected preset’s source and conversion coverage, along with explicit application controls."],
         "steps": ["Choose a preset and review its summary, especially if it came from another editor.", "Use Apply mapped adjustments to apply the settings the preset supplies.", "Use Replace adjustment settings only when you want to reset adjustments, masks, Remove corrections, and geometry before applying the preset.", "Inspect the photo and use Undo if you want to restore the previous edit."],
         "tips": ["Replace keeps your crop. It keeps Film unless the preset includes Film settings or you enable Turn Film off for the actions below.", "Presets from other editors are converted approximately because their processing differs. Read skipped settings and conversion notes; matching controls do not promise identical pixels."]
       },
       {
         "title": "Save or import a preset",
-        "paragraphs": ["Manage presets can save the current look or import LightTable recipes, Lightroom/Camera Raw presets, and Capture One styles."],
+        "paragraphs": ["Manage presets can save the current look or import LightTable recipes, Lightroom/Camera Raw presets, and Capture One styles. Manage… is available even when there are no presets, so you can import or save your first one."],
         "steps": ["To save, select All adjustment settings or Changed settings only under Save current look, choose whether to include Film settings, and click Save new….", "To import, click Import… and choose the preset files. The Mac app also supports choosing a whole preset folder.", "Review the import result and the new preset’s conversion coverage before applying it.", "To share a selected preset, choose an Export format and click Export…."],
         "tips": ["LightTable export is lossless for its preset format. Lightroom XMP and Capture One style exports are approximate.", "Supported file choices include .ltpreset, .xmp, .lrtemplate, .costyle, .costylepack, .zip, and .json. An accepted extension does not guarantee that every setting inside can be converted."]
       }
     ],
     "related": ["editing-history-snapshots", "editing-copy-paste-match-exposure", "editing-curves"],
     "sources": [
+      {"path": "web/preset-browser.js", "anchor": "managementSection.open = !managementSection.open;"},
       {"path": "web/index.html", "anchor": "Replacing resets adjustments, masks, Remove corrections, and geometry before applying this preset."},
       {"path": "web/index.html", "anchor": "Your crop is kept. Film is kept unless the preset includes it or you turn it off above."},
       {"path": "web/index.html", "anchor": "accept=\".ltpreset,.xmp,.lrtemplate,.costyle,.costylepack,.zip,.json\""},

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -11,7 +11,7 @@
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
@@ -20,7 +20,7 @@
       "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -43,14 +43,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -64,7 +64,7 @@
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -73,7 +73,7 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
@@ -86,7 +86,7 @@
     "editing-curves": {
       "content": "498bf3ffd912c4de38f040a476a0a4d47236f02de2389e7f2faa2764fd231199",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -95,7 +95,7 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -103,14 +103,14 @@
       "content": "60f9069c39ff5b1be4b09e99328bf0c4c301f6601e8a3353b060434c3be35e9b",
       "sources": {
         "grade.py": "738e09884d38dbaafc758e680966b76f8c87318b69da2b598e732a753ecd57ec",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-history-snapshots": {
       "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
@@ -118,7 +118,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -126,21 +126,21 @@
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "61e5a03da9c860f6c1bf1b049bce67710b34e74f551eabe3131705ee10ee69ce",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -150,42 +150,43 @@
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "merge_workflow.py": "42aaacd9addb07d1257dec2c2da9e299903f1b68aa213082cff0b2747ccc9e68",
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-presets": {
-      "content": "53107c055d29749d94f8708d4e18b5e246db2eb67b1b68948659c3f46fc65026",
+      "content": "886f274ee923929d189f0b5c630b01ecac064d85a5d48d09b6a18727d8afd4fa",
       "sources": {
         "preset_io.py": "16aafa7edd016912ba7538ae223b1b532c3214b507763c22575ba2d0da25c2ea",
-        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
+        "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
+        "web/preset-browser.js": "1e25275e561f55e18270dfa8515b40d894a625f8d28f07eac27db61694a1d2c4"
       }
     },
     "editing-remove-heal": {
       "content": "a21bed5c2d859545a1ab2ee26ff88c7d8463e4bb0ee96390cbda6c404cf6539e",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-save-recovery": {
       "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -193,7 +194,7 @@
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -201,7 +202,7 @@
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -216,21 +217,21 @@
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
@@ -238,7 +239,7 @@
     "film-getting-started": {
       "content": "41af570de7f96eec29c31312925173b0dd477bbb37a1e0c2cedb1363533d2f4b",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/style.css": "0d166b919591dd5b6df99053b7eee60ec1c583e21f9bb1c0aa01c648d019dd3f"
@@ -255,7 +256,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
@@ -263,7 +264,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
@@ -271,14 +272,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -303,7 +304,7 @@
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
@@ -311,14 +312,14 @@
     "metadata-and-keywords": {
       "content": "2979a125df41a87f964cb871021d9d64d2475671170764dd7f692a4707f86677",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
       }
     },
     "performance-previews": {
       "content": "91f27aaf6e367408f0d1572495a6edc96f3534285b26144b02b496901edcc673",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/preview-detail.js": "2755c53ad030b4d3588d218f967b3094b5b268cd3d08e756c0a2deab784f1d98",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
@@ -332,14 +333,14 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -355,7 +356,7 @@
     "search-filter-sort": {
       "content": "2e3a01b337fd7d0e0206507c3f3356dc89de8d28dbc3c3f6edcce7f36962df9b",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/library-filters.js": "d7067be899aa094b59d3f2bee6d6ffc246dcf782465c2c5e4a37c9f6dd90e658",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
@@ -371,7 +372,7 @@
     "shortcut-schemes": {
       "content": "9117f2d6a953f9a3f836b91420b22d75cc570201d2d5cc822f2adf7e64f9d224",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
@@ -379,7 +380,7 @@
     "smart-collections": {
       "content": "811716ffcdf02245d65b07cf0f3a60a85ba2fa11c540ce4a9d5993086a311bef",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/library.js": "e0fd82e840280b83030d990c87838d270d04840ec9d874996efba7a917003709"
       }
     },
@@ -387,14 +388,14 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/survey.js": "848f431664f546fdc3c24a8aed10f65edc87afa3879816dc004a875eb1506365"
       }
     },
@@ -403,13 +404,13 @@
       "sources": {
         "app/main.swift": "3a2d8f7ecf3ea0cef582e1ecfdbe7f6519832d3e95fba3900d77d2e357e6015d",
         "server.py": "104c9c8c6ac583c5dd5e4d8467f2a62ed1832dc367dd9f580451bbf62a3fb901",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931"
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a"
       }
     },
     "views-and-selection": {
       "content": "c7fe327084f2f9da186fc1f38af80e1d14fa9c2e03c20d98d1fe452047869ce5",
       "sources": {
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931",
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "e7b75ecbec1ccefecfca8e5d854a839eab3df5892d63ba7754eb5aef33bddec9"
       }
@@ -418,7 +419,7 @@
       "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
         "library_workflow.py": "9dfeb6839e0970471158d6abab48c867f4ec408748fde056d0fd721ec5e5009a",
-        "web/app.js": "2c2dca3737dd0542af00bdc3a9182fa912a667dc982b33e8d7eced90fe0d8931"
+        "web/app.js": "bb6fcabb7e1e1b6bbcd09126f3669fb7436b45c8157b84ef11d4c32350ae6c5a"
       }
     }
   },

--- a/web/app.js
+++ b/web/app.js
@@ -9497,11 +9497,7 @@ PRESET_BROWSER = createPresetBrowser({
   onFavoritesChange(names) { APP_PREFS.presetFavorites = names; savePrefs(); },
   onSelect(preset) { $('presetList').value = preset.name; renderPresetSummary(true); },
   onApply: (preset, photo) => applyPreset(preset, photo),
-  onManage() {
-    $('presetManage').open = true;
-    $('presetManage').scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    $('presetManage').querySelector('summary').focus();
-  },
+  managementSection: $('presetManage'),
   async getPreview(preset, photo, { signal }) {
     const response = await fetch('/api/render/file', {
       method: 'POST', headers: { 'Content-Type': 'application/json' }, signal,

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -977,7 +977,7 @@
         {
           "title": "Apply an existing recipe",
           "paragraphs": [
-            "Open Presets in the editing toolbar. Manage presets provides the selected preset’s source and conversion coverage, along with explicit application controls."
+            "Open Presets in the editing toolbar. Click Manage… to open or close Manage presets; the button is highlighted while the section is open. Manage presets provides the selected preset’s source and conversion coverage, along with explicit application controls."
           ],
           "steps": [
             "Choose a preset and review its summary, especially if it came from another editor.",
@@ -993,7 +993,7 @@
         {
           "title": "Save or import a preset",
           "paragraphs": [
-            "Manage presets can save the current look or import LightTable recipes, Lightroom/Camera Raw presets, and Capture One styles."
+            "Manage presets can save the current look or import LightTable recipes, Lightroom/Camera Raw presets, and Capture One styles. Manage… is available even when there are no presets, so you can import or save your first one."
           ],
           "steps": [
             "To save, select All adjustment settings or Changed settings only under Save current look, choose whether to include Film settings, and click Save new….",

--- a/web/preset-browser.css
+++ b/web/preset-browser.css
@@ -3,7 +3,7 @@
 .preset-browser-toolbar { display:flex; align-items:center; justify-content:space-between; gap:8px; }
 .preset-browser-filters { display:flex; gap:4px; }
 .preset-browser-filters button, .preset-browser-manage { min-height:26px; padding:3px 9px; font-size:11px; }
-.preset-browser-filters button[aria-pressed="true"] { border-color:var(--slider-accent); background:var(--on-soft); color:var(--on-ink); }
+.preset-browser-filters button[aria-pressed="true"], .preset-browser-manage[aria-expanded="true"] { border-color:var(--slider-accent); background:var(--on-soft); color:var(--on-ink); }
 .preset-browser-hint, .preset-browser-status { margin:0; color:var(--muted); font-size:11px; line-height:1.5; }
 .preset-browser-status { color:var(--ink-2); }
 .preset-browser-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; }

--- a/web/preset-browser.js
+++ b/web/preset-browser.js
@@ -61,7 +61,7 @@ export function createPresetBrowser({
   container, getPresets, getPhoto, getSelectedName = () => '',
   onSelect = () => {}, onApply, canApply = () => true,
   getFavorites = () => [], onFavoritesChange = () => {},
-  getPreview, onManage,
+  getPreview, managementSection,
 }) {
   let active = false, destroyed = false, loading = false, page = 0, favoritesOnly = false;
   let snapshot, searchTimer;
@@ -82,11 +82,22 @@ export function createPresetBrowser({
   const previous = root.querySelector('[data-page="previous"]');
   const next = root.querySelector('[data-page="next"]');
   const filterButtons = [...root.querySelectorAll('[data-filter]')];
-  if (onManage) {
+  let syncManagement;
+  if (managementSection) {
     const manage = document.createElement('button');
     manage.type = 'button'; manage.className = 'preset-browser-manage';
     manage.textContent = 'Manage…'; manage.setAttribute('aria-label', 'Manage presets');
-    manage.onclick = onManage;
+    manage.setAttribute('aria-controls', managementSection.id);
+    syncManagement = () => manage.setAttribute('aria-expanded', String(managementSection.open));
+    syncManagement();
+    managementSection.addEventListener('toggle', syncManagement);
+    manage.onclick = () => {
+      managementSection.open = !managementSection.open;
+      syncManagement();
+      if (managementSection.open) {
+        managementSection.querySelector('summary').scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    };
     root.querySelector('.preset-browser-toolbar').append(manage);
   }
 
@@ -202,6 +213,10 @@ export function createPresetBrowser({
     refresh(options = {}) { loading = options.loading ?? loading; render(); },
     setActive(value) { active = !!value; if (active) render(); else cancel(); },
     select,
-    destroy() { destroyed = true; cancel(); root.remove(); },
+    destroy() {
+      destroyed = true; cancel();
+      if (syncManagement) managementSection.removeEventListener('toggle', syncManagement);
+      root.remove();
+    },
   };
 }


### PR DESCRIPTION
Clicking Manage in Presets previously appeared to do nothing when the management section was already open. Make the button open and close that section, highlight it while expanded, and keep its accessibility state synchronized when the section's own disclosure is used.

Manage remains available with an empty preset library because it contains Import and Save new. Update the in-app Help to explain this behavior.

Validation: 9 preset browser tests, 10 Help content tests, 8 Help search tests, Help source/bundle checks, JavaScript syntax checks, and git diff checks passed. The prepared fix was also exercised with mouse and keyboard in an isolated running UI, including an empty preset library. Rebased onto current main and reconciled existing Help review fingerprints without adding review acknowledgements. The separate control-audit findings are outside this change.
