### PR TITLE
Fix inactive controls and import selection across photo workflows

### DIFF
--- a/app/main.swift
+++ b/app/main.swift
@@ -857,6 +857,37 @@ private final class PhotosLibraryImporter {
     }
 }
 
+// MARK: - Native web UI
+
+private func isLocalEditorPage(_ url: URL?, port: Int) -> Bool {
+    guard let url, port > 0 else { return false }
+    return url.scheme == "http" && url.host == "127.0.0.1" && url.port == port
+        && url.user == nil && url.password == nil
+}
+
+private func externalWebURL(_ url: URL?) -> URL? {
+    guard let url, ["http", "https"].contains(url.scheme?.lowercased() ?? ""),
+          let host = url.host, !host.isEmpty,
+          url.user == nil, url.password == nil else { return nil }
+    return url
+}
+
+/// Closing a sheet and navigating can both finish the same WebKit request.
+/// Release the callback before invoking it so even reentrant cancellation is safe.
+private final class NativeJavaScriptReply {
+    private var completion: ((Bool) -> Void)?
+
+    init(_ completion: @escaping (Bool) -> Void) { self.completion = completion }
+
+    func resolve(_ accepted: Bool) {
+        let callback = completion
+        completion = nil
+        callback?(accepted)
+    }
+
+    deinit { resolve(false) }
+}
+
 // MARK: - Preset links
 
 /// A link names a reviewed catalog entry; it is never a file or fetch URL.
@@ -904,7 +935,7 @@ func presetExportData(content: String, encoding: String = "utf8") throws -> Data
 
 // MARK: - App
 
-final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
+final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDelegate,
                          WKScriptMessageHandler, NSMenuItemValidation,
                          NSWindowDelegate,
                          PHPickerViewControllerDelegate {
@@ -917,6 +948,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
     private var closeApproved = false
     var window: NSWindow!
     var webView: WKWebView!
+    private var javaScriptConfirmation: (alert: NSAlert, reply: NativeJavaScriptReply)?
     private var secondaryLoupeWindow: NSWindow?
     var nativePreview: NativePreviewRenderer?
     let nativePerfLogQueue = DispatchQueue(label: "lighttable.native-perf-log")
@@ -1007,6 +1039,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
     }
 
     func applicationWillTerminate(_ note: Notification) {
+        cancelJavaScriptConfirmation()
         photosLibraryImporter?.shutdown()
         server.stop()
     }
@@ -1028,6 +1061,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
     private func prepareToClose(completion: @escaping (Bool) -> Void) {
         guard !closePending else { completion(false); return }
         closePending = true
+        cancelJavaScriptConfirmation()
         window.contentView?.isHidden = false
         var finished = false
         let finish: (Bool) -> Void = { [weak self] saved in
@@ -1154,6 +1188,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
             forMainFrameOnly: true))
         webView = LightTableWebView(frame: .zero, configuration: cfg)
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         webView.setValue(false, forKey: "drawsBackground")
         // The page handles pinch itself; don't let WebKit scale the whole UI.
         webView.allowsMagnification = false
@@ -1224,6 +1259,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
 
     func windowWillClose(_ notification: Notification) {
         if notification.object as? NSWindow === window {
+            cancelJavaScriptConfirmation()
             secondaryLoupeWindow?.close()
         } else if notification.object as? NSWindow === secondaryLoupeWindow {
             secondaryLoupeWindow = nil
@@ -1886,9 +1922,71 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate,
         (webView as? LightTableWebView)?.resetWindowChromeLayout()
         // A server restart or library switch may change the editor's origin.
         if webView === self.webView {
+            cancelJavaScriptConfirmation()
             presetLinksReady = false
             secondaryLoupeWindow?.close()
         }
+    }
+
+    private func isTrustedEditorFrame(_ frame: WKFrameInfo, in webView: WKWebView) -> Bool {
+        let origin = frame.securityOrigin
+        return webView === self.webView && frame.isMainFrame
+            && isLocalEditorPage(webView.url, port: server.port)
+            && origin.protocol == "http" && origin.host == "127.0.0.1"
+            && origin.port == server.port
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        if webView === self.webView { cancelJavaScriptConfirmation() }
+    }
+
+    func webView(_ webView: WKWebView,
+                 runJavaScriptConfirmPanelWithMessage message: String,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping (Bool) -> Void) {
+        guard isTrustedEditorFrame(frame, in: webView),
+              let parent = webView.window, parent.isVisible,
+              !closePending, !closeApproved,
+              javaScriptConfirmation == nil, parent.attachedSheet == nil else {
+            completionHandler(false)
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = "LightTable"
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        let reply = NativeJavaScriptReply(completionHandler)
+        javaScriptConfirmation = (alert, reply)
+        alert.beginSheetModal(for: parent) { [weak self] response in
+            if self?.javaScriptConfirmation?.reply === reply {
+                self?.javaScriptConfirmation = nil
+            }
+            reply.resolve(response == .alertFirstButtonReturn)
+        }
+    }
+
+    private func cancelJavaScriptConfirmation() {
+        guard let pending = javaScriptConfirmation else { return }
+        javaScriptConfirmation = nil
+        pending.reply.resolve(false)
+        if let parent = pending.alert.window.sheetParent {
+            parent.endSheet(pending.alert.window, returnCode: .cancel)
+            pending.alert.window.orderOut(nil)
+        }
+    }
+
+    func webView(_ webView: WKWebView,
+                 createWebViewWith configuration: WKWebViewConfiguration,
+                 for navigationAction: WKNavigationAction,
+                 windowFeatures: WKWindowFeatures) -> WKWebView? {
+        guard navigationAction.targetFrame == nil,
+              isTrustedEditorFrame(navigationAction.sourceFrame, in: webView),
+              let url = externalWebURL(navigationAction.request.url) else { return nil }
+        if !NSWorkspace.shared.open(url) {
+            sendEvent(["type": "error", "message": "Could not open the link in your browser."])
+        }
+        return nil
     }
 
     /// A catalog file from another editor, opened read-only by the server.

--- a/docs/help/editing.json
+++ b/docs/help/editing.json
@@ -8,7 +8,7 @@
     "sections": [
       {
         "title": "Check that your work is saved",
-        "paragraphs": ["Adjustments are stored as edit settings for the photo. The editor saves changes automatically as you finish interactions; you do not need a separate Save command for each adjustment."],
+        "paragraphs": ["Editing controls are unavailable until a photo is loaded. Adjustments are stored as edit settings for the photo. The editor saves changes automatically as you finish interactions; you do not need a separate Save command for each adjustment."],
         "steps": ["Make your adjustment, then check the save status in the app.", "Wait for Saving… to change to Saved. Saving also includes pending edit-history writes.", "If the status says Edits not saved, use Retry save. Keep the window open while a save is failing."],
         "tips": ["Saved · recovery needs attention means the save completed but the local recovery system reported a problem. Use the available retry control and read the status message."]
       },
@@ -43,7 +43,7 @@
       },
       {
         "title": "Keep a named look",
-        "paragraphs": ["A snapshot stores the photo’s current adjustment settings, crop, masks, Remove corrections, and optics. It is a saved editing state for this photo."],
+        "paragraphs": ["A snapshot stores the photo’s current adjustment settings, crop, masks, Remove corrections, and optics. It is a saved editing state for this photo. Create snapshot is unavailable until a photo is loaded."],
         "steps": ["Open History, expand Snapshots, and click Create snapshot.", "Enter a useful name, such as Soft portrait or Before retouching.", "Click the snapshot’s name to apply it later. Use Undo if you want to return to the state you just replaced."],
         "tips": ["The photo keeps up to 50 snapshots; creating another beyond that limit drops the oldest snapshot from the list.", "The × beside a snapshot deletes that named snapshot, not the original photo."]
       }
@@ -205,7 +205,7 @@
         "title": "Create an enhanced derivative in the Mac app",
         "paragraphs": ["Photo → Enhance Photo… offers Denoise and Super resolution and writes a new 16-bit master when the selected operation succeeds. The original remains untouched."],
         "steps": ["Select the photo, choose Photo → Enhance Photo…, and read the availability message.", "Choose the enhancement and click Enhance if available.", "After completion, find the new result in the refreshed library and inspect it."],
-        "tips": ["Super resolution has no bundled model and requires a compatible local model. A listed option alone does not mean that operation is available.", "Enhancement can generate detail; evaluate the output before treating it as a faithful record of fine texture."]
+        "tips": ["Unavailable enhancements are disabled. Super resolution has no bundled model and requires a compatible model installed locally.", "Enhancement can generate detail; evaluate the output before treating it as a faithful record of fine texture."]
       }
     ],
     "related": ["editing-tone", "editing-effects", "editing-history-snapshots"],
@@ -213,7 +213,7 @@
       {"path": "web/index.html", "anchor": "Judge sharpening and noise reduction at 1:1. These controls work in both Film and Develop modes."},
       {"path": "web/index.html", "anchor": "<b>Space</b><span>Toggle Fit / 1:1</span>"},
       {"path": "web/app.js", "anchor": "Runs locally when Apply is pressed; the slider is not live."},
-      {"path": "web/app.js", "anchor": "Writes a new 16-bit master; the original is untouched."},
+      {"path": "web/enhance-panel.js", "anchor": "Writes a new 16-bit master; the original is untouched."},
       {"path": "enhance_workflow.py", "anchor": "Super-resolution has no bundled model."},
       {"path": "enhance_workflow.py", "anchor": "Enhance output is model-generated detail, not measured detail."},
       {"path": "app/main.swift", "anchor": "addEditorItem(photoMenu, title: \"Enhance Photo…\","}
@@ -400,9 +400,9 @@
     "sections": [
       {
         "title": "Create a manual mask",
-        "paragraphs": ["Open Mask in the editing toolbar and choose a tool under Create New Mask. Each mask has its own Light and Color adjustments.", "Texture and Clarity use the image after global adjustments and earlier masks. These controls require a preview update; wait for it to finish before judging the result."],
+        "paragraphs": ["Open Mask in the editing toolbar and choose a tool under Create New Mask. Click Create New Mask to show or hide the tools. Each mask has its own Light and Color adjustments.", "Texture and Clarity use the image after global adjustments and earlier masks. These controls require a preview update; wait for it to finish before judging the result."],
         "steps": ["Choose Brush to paint, Linear for a graduated adjustment, or Radial for a round adjustment.", "For Brush, choose Size, Feather, and Flow, then paint over the photo. For Linear or Radial, drag on the photo to set the shape.", "Keep Show Overlay enabled while checking the selected area, then turn it off to judge the photo.", "Adjust the selected mask’s Light or Color sliders. Use Amount in Range to reduce its overall strength.", "Rename the mask using its ••• button so its purpose is easy to recognize later."],
-        "tips": ["Add, Subtract, and Intersect put you in painting refinement modes. For a Linear or Radial mask, choose Edit Shape to return to manipulating its shape.", "Enable temporarily switches a mask’s effect off or on. Invert reverses its selection.", "The editor allows up to sixteen local masks. Delete Mask removes the selected mask; Clear All removes the photo’s masks.", "Mask pins and brush outlines stay sharp and the same thickness as you zoom. The outline grows with the area it covers in the photo."]
+        "tips": ["Add, Subtract, and Intersect put you in painting refinement modes. For a Linear or Radial mask, choose Edit Shape to return to manipulating its shape.", "Enable temporarily switches a mask’s effect off or on. Invert reverses its selection.", "The editor allows up to sixteen local masks. Delete Mask removes the selected mask; Clear All removes the photo’s masks and is unavailable when there are none.", "Mask pins and brush outlines stay sharp and the same thickness as you zoom. The outline grows with the area it covers in the photo."]
       }
     ],
     "related": ["editing-masks-ai", "editing-masks-ranges-refinements", "editing-history-snapshots"],
@@ -498,7 +498,7 @@
         "title": "Refine an existing correction",
         "paragraphs": ["Select a correction in the list to show its controls. The on-image circles indicate the editable target and, for Heal and Clone, the source.", "Zoom in for precise placement. Circle outlines and pins stay sharp at every zoom level; the circles continue to show the same area of the photo."],
         "steps": ["Drag the target circle to reposition the correction, or choose Move Target and click its new position.", "For Heal or Clone, drag the source circle to a better area. Refresh Source tries a different source position.", "Adjust Feather or Opacity if the correction’s edge or strength needs refinement.", "Toggle Enable this correction to compare, or use Delete correction to remove it."],
-        "tips": ["Remove does not expose a source circle or Refresh Source. Those source controls apply to Heal and Clone.", "Clear All removes the photo’s Remove, Heal, and Clone corrections. Use Undo to reverse an accidental editing change."]
+        "tips": ["Remove does not expose a source circle or Refresh Source. Those source controls apply to Heal and Clone.", "Clear All removes the photo’s Remove, Heal, and Clone corrections and is unavailable when there are none. Use Undo to reverse an accidental editing change."]
       }
     ],
     "related": ["editing-detail-effects-enhance", "editing-history-snapshots", "editing-copy-paste-match-exposure"],

--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -371,7 +371,7 @@
       {
         "title": "Back up and inspect",
         "paragraphs": [
-          "Settings → Catalog shows the catalog location and backup preferences. Backups include catalog organization, edits, stored masks, history, and variants. Back up original photos, external presets and profiles, and preferences separately."
+          "Settings → Catalog shows the catalog location and backup preferences. Backups include catalog organization, edits, stored masks, history, and variants. Back up original photos, external presets and profiles, and preferences separately. Local ••• → Back up catalog… also creates a backup and shows its saved path or error in a results dialog. Find duplicates in the same menu shows matching files, or reports that none were found."
         ],
         "steps": [
           "Choose an Automatic backup interval and Backup location.",
@@ -431,6 +431,14 @@
       {
         "path": "app/main.swift",
         "anchor": "diagnosticsMenu, title: \"Restart Rendering Service\","
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "showCatalogResult('Back up catalog'"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "showCatalogResult('Find duplicates'"
       }
     ]
   }

--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -103,19 +103,19 @@
           "Open Local ••• → Import from card….",
           "Choose the Source and Destination. Set Folder template and Rename to before scanning. The defaults keep filenames and organize copies as year/year-month-day.",
           "Choose verification: Full hash, Size only, or None. Set Duplicates to Skip or Copy anyway, and optionally choose Second copy to.",
-          "Click Scan. Review the destination preview and the checked files, then click Import.",
-          "Wait for the copied count and check whether any files failed."
+          "Click Scan. Use Previous and Next to review every page, and check the selected count and destination preview before clicking Import. Import is unavailable when no photos are selected.",
+          "Wait for the copied count and check whether any files failed. Cancel stops after the current file finishes copying and verification; completed copies are kept and card originals stay untouched."
         ],
         "tips": [
           "Template tokens include {filename}, {sequence}, {custom}, {camera}, {yyyy}, {mm}, and {dd}. Start at controls the four-digit sequence.",
-          "The selection list currently shows up to 200 files per scan. Only checked entries in that list are submitted. Check the completed count when working with a larger card.",
+          "Previews show 200 files per page. Selection carries across pages; Select all and Select none apply to the whole scan, including pages you have not opened.",
           "If files are reported as cloud-only, download them locally and scan again."
         ]
       },
       {
         "title": "Refresh the plan when settings change",
         "paragraphs": [
-          "Scan again after changing the destination or naming templates so you can review the updated paths before importing."
+          "Changing the source, destination, naming, or verification settings clears the reviewed plan. Scan again to review the new files and paths before importing."
         ]
       }
     ],
@@ -130,11 +130,11 @@
       },
       {
         "path": "web/catalog-ui.js",
-        "anchor": "(ingestPlan.items || []).slice(0, 200)"
+        "anchor": "items().slice(page * pageSize, (page + 1) * pageSize)"
       },
       {
         "path": "web/catalog-ui.js",
-        "anchor": "items: ingestPlan.items.filter((item) => checked.has(item.source))"
+        "anchor": "const chosen = () => items().filter(item => selected.has(item.source));"
       },
       {
         "path": "web/catalog-ui.js",
@@ -143,6 +143,10 @@
       {
         "path": "ingest_workflow.py",
         "anchor": "TOKENS = {\"filename\", \"camera\", \"sequence\", \"custom\", *DATE_TOKENS}"
+      },
+      {
+        "path": "server.py",
+        "anchor": "def cancel_ingest_job() -> bool:"
       }
     ]
   },
@@ -158,7 +162,10 @@
       "sidebar",
       "missing photos",
       "rescan",
-      "synchronize"
+      "synchronize",
+      "watch folder",
+      "watched folders",
+      "tethering"
     ],
     "sections": [
       {
@@ -178,6 +185,14 @@
         "paragraphs": [
           "A folder’s ••• menu includes Show in Finder on Mac or Show in File Explorer on Windows. For the current folder, Synchronize Folder refreshes the view. Local ••• → Rescan folders scans the catalog sources.",
           "Remove from LightTable removes an added root from the app’s source list; it does not move the original files to the Trash. The action is offered when more than one source is available."
+        ]
+      },
+      {
+        "title": "Manage watched folders",
+        "paragraphs": [
+          "Open Local ••• → Watch folder… to add a watched folder. Choose how arriving photos should be handled. Save is unavailable until a folder is specified; copying into the library also requires a destination.",
+          "To edit an existing watch, choose it in Watched folders. Every saved watch appears in this list. Choose New watched folder for another folder, or use Delete watch to stop watching the selected folder. This does not delete its photos.",
+          "The Watching shortcut opens the first active watch. Save errors stay in the dialog so you can correct the settings."
         ]
       }
     ],
@@ -202,6 +217,14 @@
       {
         "path": "app/main.swift",
         "anchor": "sources.removeAll { $0.path == clean }"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "el('watchExisting')?.addEventListener('change'"
+      },
+      {
+        "path": "web/catalog-ui.js",
+        "anchor": "Choose a watched folder and library destination first."
       }
     ]
   },
@@ -1082,7 +1105,7 @@
       {
         "title": "Describe the photo",
         "paragraphs": [
-          "In Info, expand Description for title, caption, and headline; Rights for creator, copyright, and credit; or Place for location and coordinates. Changes save to the catalog as you type.",
+          "In Info, expand Description for title, caption, and headline; Rights for creator, copyright, and credit; or Place for location and coordinates. Changes save to the catalog as you type. Open in Maps is available after this photo’s metadata loads and both latitude and longitude are valid. It opens the location in your browser.",
           "Apply to selection copies the current metadata form to selected photos, including its blank fields. Review the whole form first. Metadata is included in exports according to the export recipe; editing these fields does not rewrite the original image file."
         ]
       }
@@ -1129,6 +1152,10 @@
       {
         "path": "keyword_workflow.py",
         "anchor": "MAX_BATCH = 5000"
+      },
+      {
+        "path": "app/main.swift",
+        "anchor": "createWebViewWith configuration:"
       }
     ]
   },
@@ -1232,7 +1259,7 @@
         "title": "Review translated edits",
         "paragraphs": [
           "Develop settings are approximate and cannot promise Lightroom’s rendered appearance. Unsupported local masks, camera profiles, .lrcat-data AI masks or LUT payloads, and unsupported smart-collection rules are reported as skipped. Imported develop settings turn Film off.",
-          "Local ••• → Import sidecars… is a separate action for reading supported metadata from adjacent sidecars. That action does not apply develop settings or crop."
+          "Local ••• → Import sidecars… is a separate action for reading supported metadata from adjacent sidecars. That action does not apply develop settings or crop. Its results dialog shows progress, applied counts, skipped settings, and errors."
         ]
       }
     ],

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -3,39 +3,41 @@
     "add-photos": {
       "content": "78282b14cc31bbf1590b392567e0fe5837406ff0cc71045134480816ea9f491e",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
         "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
     },
     "browse-folders": {
-      "content": "2032c026c01d58b37a5f11a324369edc495d99848efdc4e7b2177266d03c03e1",
+      "content": "2d1e827ab09443dd4cdf72f487c00e04b622cb325d624ba6825a827a7e82851e",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "capture-time": {
       "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
       "sources": {
         "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "catalog-health-recovery": {
-      "content": "41e3f81ef36412cf1ec4ce0f431988f484834120a750a45d31a1fef66365c718",
+      "content": "cc43a7d2d0f37307bba27168f31b351257def6934dfa1d84528b4fdae30aed22",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb"
       }
@@ -43,14 +45,14 @@
     "collections": {
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -58,273 +60,276 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-copy-paste-match-exposure": {
       "content": "ea587a5f680591f686563eed6326436e6413f5da512086974be55c4603bebe85",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
       }
     },
     "editing-crop-geometry": {
       "content": "847f666d8a355cae0104998f95f855baf7de6490a8445d2603e67e681623393c",
       "sources": {
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-curves": {
       "content": "498bf3ffd912c4de38f040a476a0a4d47236f02de2389e7f2faa2764fd231199",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-detail-effects-enhance": {
-      "content": "eceac49eddd311832852e28fbff3fab0be536cabf1220d3fc81c5087bb62c0ed",
+      "content": "f84a04de3fa2ccdcd9de2e81e51b6e7b7143c76507424fc852e15d5d4f969ccb",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/enhance-panel.js": "7d711f35ab34b4a87868123fb12456b8efa436fc611c4f2c0fa4109daca8b4db",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-effects": {
       "content": "60f9069c39ff5b1be4b09e99328bf0c4c301f6601e8a3353b060434c3be35e9b",
       "sources": {
         "grade.py": "fb353c05fa51927d0b12cc60c3d4b216db35199ddc5c409d85b94e8ffc682575",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-history-snapshots": {
-      "content": "6f936976f8f8cdf840ad7ec9c962a8842d589de6e723fe92913419f08cee781f",
+      "content": "9701be6c95f540dd34e06d1d3352128854e51addaae98f082cedd479b07ed428",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-masks-ai": {
       "content": "896a488aeeae69c324acd2afbb8f6cc1d97d7b92e270423cece1162b2e1ddf30",
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-masks-brush-gradients": {
-      "content": "283185725633efc67f5650a6135ca43e1b5264cc99469221a8c5e4aca57383ef",
+      "content": "b8985b49d09c388575e45f806d333ccad8d2df4f28ec3a5bb941c166f2277d4d",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
     },
     "editing-masks-ranges-refinements": {
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-photo-merge": {
       "content": "79288ea8afc3621d945d5e55ca0716c8b4f4ae064c4d9007b7d686d6b9553895",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
         "merge_workflow.py": "af4489a9b4bdeb2374640e59d09a65b567a65da6b04ad7519b6d390eabee8e91",
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-presets": {
       "content": "b408454541155b51882efc3dd3822b7e51aea09adca52799fe3b585615bb6b3e",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
         "preset_io.py": "ef53c6ad973ce5ab42c7c328fdd3e88ac002f913cad158bf20446e6219a94c8c",
         "preset_library.py": "98efb1e5151d8406e158681cde6da78003e2fe8c4bea911ee645fe78a644d14d",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/preset-browser.css": "b83edbc52e4a3f4fa24161fa9501b39bb73582eaefa72551f412a03e11c5d246",
         "web/preset-browser.js": "ba0eaa2c1617814d25da6d2fd92e24961f2de4a4012acf6ba38773cb002bf465",
         "web/presets.js": "1ce2d7d1772bf0e46dc46c54f90ba7b2701a8c1eff0232a22bace13e62ae665f"
       }
     },
     "editing-remove-heal": {
-      "content": "6a0e41eb99b3db975e6818c4c431006fcd7a0e20abc452baef943c1b89037dc2",
+      "content": "430f3a6c8cf70a80ac1734ece3d17532ced4716d367cf3a889045770a5024cd8",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
     },
     "editing-save-recovery": {
-      "content": "07e7a40c17c1c46fb63ffe875cb92bf97a8a846e98d91afe0015e05a24e2f4df",
+      "content": "ae8a8b2b9fb30794abc5d2e0173120d54f6de276e2269e773dcc9817a6680405",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/edit-save-queue.js": "89912c589158fa6ef921ab045488cccae9ea6c4bd916bc3ad82642764acb8e1d"
       }
     },
     "editing-tone": {
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "export-filenames-and-folders": {
       "content": "1552993eec7ab45f052272d2f40d8d4a7bbecd798a0d7a3a293bbf9c6f6bc8f0",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "export-format-color-space": {
       "content": "60a0df55b58ddb767af2cd0ed2caa75fa2fffc5b4ea987b5546be381c4a94b84",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "export-metadata-sidecars": {
       "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "export-photos": {
       "content": "4d390512f607806ae441447fd841b11e98359bbb324fb6750416268864a4f62a",
       "sources": {
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "film-getting-started": {
       "content": "41af570de7f96eec29c31312925173b0dd477bbb37a1e0c2cedb1363533d2f4b",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
-        "web/style.css": "e284c41a3600e070bbb841dff1c7879b63ef3a83f685dce612359ad58ca63be8"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
+        "web/style.css": "7aa0b6a0a4f91400ec63896f2ac9ebaab559a9a0e9717d78c1f255302d760344"
       }
     },
     "film-grain-and-format": {
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "film-halation-diffusion-scan": {
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "film-negative-paper-and-slides": {
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
     "import-from-card": {
-      "content": "5a0553049a8b55ee9243df162f16abbc78e3e1cd05ae464a8404b19e2c00f680",
+      "content": "16ea57872d954a2daca935ae8d8dd185b2b86cfcc9224855017ad4d0938152b4",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "web/catalog-ui.js": "5ae50a657708474c7569913eb50905acf2a96730683f49592093246353af36bd",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "import-lightroom-catalog": {
-      "content": "d4b33b201ef79c1d9e9a2dcce86c68406c516f8a01b1b10e5ec14fee9ed6985e",
+      "content": "91ea014d65c4fe0f0b89087aad31b260332d0f198e76b3b318791a5b32aaeb90",
       "sources": {
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/catalog-ui.js": "5ae50a657708474c7569913eb50905acf2a96730683f49592093246353af36bd",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "keyboard-midi": {
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
     },
     "metadata-and-keywords": {
-      "content": "5ea9582931d3c5edad41cb761c5e4ff44f88e3a987246c839fd11bbf16f8189b",
+      "content": "60f57dc6250304224728edaf38fc85642ca17a02969a90e0af070bc756938465",
       "sources": {
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
         "keyword_workflow.py": "7be02bdb2980cb048b4a7c42393e542947f8b2f33ce6902a178af787d71a194b",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/keyword-batch.js": "195652d58c404cf552e254d133b3b7a0b9c61af06c615283e4dcda1ce1eb7adb",
-        "web/metadata-panel.js": "57a865f3c49864fb9198d8ddc27432b0ebfdb4b65907fbd5eeb50030c92daf93"
+        "web/metadata-panel.js": "acb686e499a56546f43a736e3a2ff669cd3dcfd79148b71ebf72dc9251692261"
       }
     },
     "performance-previews": {
@@ -333,13 +338,13 @@
         "gpu_compute.py": "6aaf344c93689e2673c957fdad76c1aed4c81cc144d9d64e3b91cc3a44859ba4",
         "grade.py": "fb353c05fa51927d0b12cc60c3d4b216db35199ddc5c409d85b94e8ffc682575",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/preview-detail.js": "9fd803f1c070fba51f7466e03ca45c1c7b802765d48f943b2d510a23f368b595",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "4f9101296cb8bf1c269b20afe60ef13d3cb2903733c74fcd733e97db7cb61947",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb",
-        "web/style.css": "e284c41a3600e070bbb841dff1c7879b63ef3a83f685dce612359ad58ca63be8",
+        "web/style.css": "7aa0b6a0a4f91400ec63896f2ac9ebaab559a9a0e9717d78c1f255302d760344",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
       }
     },
@@ -347,15 +352,15 @@
       "content": "4b126846f459b5e30610108e553a3a9f0b6fb4f3563a87a9f2db6f6db9eac5ba",
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -363,8 +368,8 @@
       "content": "66a50e18b2e2dee4d8a35ea3c59b09e45f609b5dddea804b663e9744a456617d",
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/catalog-ui.js": "5ae50a657708474c7569913eb50905acf2a96730683f49592093246353af36bd"
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98"
       }
     },
     "search-filter-sort": {
@@ -372,8 +377,8 @@
       "sources": {
         "catalog_scan.py": "1a5179c94b5c0a2e27990765fb1a20978e7de1631b9e07692fcb4acfe7dbeee9",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/library-filters.js": "e7dcf58cdd378a68797023a54052c54e40bd507320fda116e3190abfcd90667c",
         "web/library.js": "28fd7b59813710582e54ea1950c7a9e66223b4f7681657057a018ae5e0b9cd2e"
       }
@@ -381,15 +386,15 @@
     "settings-and-defaults": {
       "content": "1cde6311046ebd3780715b226c84b72c16aef9f5396294f54489936d21b64232",
       "sources": {
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb"
       }
     },
     "shortcut-schemes": {
       "content": "9117f2d6a953f9a3f836b91420b22d75cc570201d2d5cc822f2adf7e64f9d224",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -397,7 +402,7 @@
       "content": "9b7e47fe1ac1a2ae85a54070f12b51d8876a2d4497b5f3dc3c0857cca2e1da6b",
       "sources": {
         "catalog.py": "ed86ff50c6792feacfe21584f8a023426efedd3736248d0e04f9744f517e8956",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/library.js": "28fd7b59813710582e54ea1950c7a9e66223b4f7681657057a018ae5e0b9cd2e"
       }
     },
@@ -405,46 +410,46 @@
       "content": "0fc72df4c888e30d32089e8a919d8f1993f289e7417edef271979d55eafe97de",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
     },
     "survey-photos": {
       "content": "b13b5825be39abb574e64995b612d8af0537c3e61be040cb91710ddbb6e73dc5",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/survey.js": "848f431664f546fdc3c24a8aed10f65edc87afa3879816dc004a875eb1506365"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
+        "web/survey.js": "a18c0fca1a2bb8d288df88082c4c8380c13cbf8d04cc873e08efc19d2de6f7cb"
       }
     },
     "trash-rejected": {
       "content": "85731343eefbc085ca0eff4b39db0d043c537b6cc69f3b77c8722ec01725acb9",
       "sources": {
-        "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab"
+        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725"
       }
     },
     "views-and-selection": {
       "content": "9ebb5b5cdb1366a1d628888627cd133347341b2820fcddae7bcbeae8f129d07f",
       "sources": {
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
-        "web/style.css": "e284c41a3600e070bbb841dff1c7879b63ef3a83f685dce612359ad58ca63be8"
+        "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
+        "web/style.css": "7aa0b6a0a4f91400ec63896f2ac9ebaab559a9a0e9717d78c1f255302d760344"
       }
     },
     "virtual-copies-and-stacks": {
       "content": "218ec1271cafd5ab4b50150de522ed6bbd31c59451ffcdbe70466af76fdbf888",
       "sources": {
         "library_workflow.py": "b07bc79b58666fe92ce189ac4132a6904457e166f73c155f3f636fc683966e3c",
-        "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab"
+        "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725"
       }
     },
     "xmp-interchange": {
       "content": "47a963b65ba3099f4ad70985f488864080b10612b042395cd9322f50e2e78a53",
       "sources": {
-        "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
-        "web/catalog-ui.js": "5ae50a657708474c7569913eb50905acf2a96730683f49592093246353af36bd",
+        "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
+        "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
         "xmp_sidecar.py": "97a5b8277afc91497471f8212a77f429bdecca136e19c4c47f8b0a9d8b23d233"
       }
     }

--- a/server.py
+++ b/server.py
@@ -1230,9 +1230,11 @@ IMPORT_JOB: dict = {"running": False, "stage": "", "done": 0, "total": 0,
                     "result": None, "error": None}
 
 
-def cancel_ingest_job() -> None:
+def cancel_ingest_job() -> bool:
     with INGEST_LOCK:
         INGEST["cancelled"] = True
+    # The worker finishes and verifies its active file before becoming terminal.
+    return False
 
 
 def library_state(st: dict | None = None) -> dict:
@@ -7979,18 +7981,26 @@ def start_ingest(body: dict) -> dict:
     import ingest_workflow
 
     request = ingest_workflow.clean_plan_request(body.get("request"))
-    plan = body.get("plan")
-    if not plan or not plan.get("items"):
-        scanned = scan_ingest_source({"path": body["path"],
-                                      "request": body.get("request")})
-        plan = scanned["plan"]
+    # An explicitly supplied selection must never expand to a fresh scan.
+    # Only legacy callers that omit the plan may request scan-and-import.
+    if "plan" not in body:
+        plan = scan_ingest_source({"path": body["path"],
+                                   "request": body.get("request")})["plan"]
+    else:
+        plan = body["plan"]
+    if not isinstance(plan, dict) or not isinstance(plan.get("items"), list):
+        raise ValueError("scan the source and select photos before importing")
     items = plan["items"]
+    if not items:
+        raise ValueError("select at least one photo to import")
+    if any(not isinstance(item, dict) for item in items):
+        raise ValueError("invalid import selection; scan the source again")
     with INGEST_LOCK:
         if INGEST["running"]:
             return {"error": "an ingest is already running"}
         INGEST.update(running=True, done=0, total=len(items), errors=[],
                       copied=0, bytes=0, cancelled=False)
-        INGEST["jobId"] = JOBS.create(
+        job_id = INGEST["jobId"] = JOBS.create(
             "ingest", total=len(items), state="running",
             cancel=cancel_ingest_job)["id"]
 
@@ -8031,7 +8041,7 @@ def start_ingest(body: dict) -> dict:
                 cat.close()
 
     threading.Thread(target=run, name="lighttable-ingest", daemon=True).start()
-    return {"queued": len(items)}
+    return {"queued": len(items), "jobId": job_id}
 
 
 def rename_photos(body: dict) -> dict:

--- a/tests/catalog-controls.test.mjs
+++ b/tests/catalog-controls.test.mjs
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+const source = readFileSync(new URL('../web/catalog-ui.js', import.meta.url), 'utf8');
+const tick = async () => { for (let i = 0; i < 12; i++) await Promise.resolve(); };
+
+function harness(kind, {post: send, get: fetch} = {}) {
+  const nodes = new Map(), calls = [], timers = new Map();
+  let timer = 0;
+  const document = {body: {dataset: {}}, activeElement: null};
+  class Element {
+    constructor(id) { this.id = id; this.value = ''; this.disabled = false; this.hidden = false;
+      this.textContent = ''; this.handlers = {}; this.attributes = {}; this.inputs = [];
+      const classes = new Set();
+      this.classList = {add: c => classes.add(c), remove: c => classes.delete(c),
+        contains: c => classes.has(c), toggle: (c, value) => value ? classes.add(c) : classes.delete(c)};
+    }
+    set innerHTML(value) {
+      this.html = value;
+      this.inputs = [...value.matchAll(/<input[^>]*data-source="([^"]*)"[^>]*>/g)]
+        .map(match => ({dataset: {source: match[1]}, checked: /\schecked(?:\s|>)/.test(match[0]), disabled: false}));
+    }
+    get innerHTML() { return this.html || ''; }
+    addEventListener(type, handler) { this.handlers[type] = handler; }
+    dispatchEvent(event) { return this.handlers[event.type]?.(event); }
+    setAttribute(key, value) { this.attributes[key] = value; }
+    querySelectorAll() { return this.inputs; }
+    focus() { document.activeElement = this; }
+  }
+  const ids = kind === 'ingest' ? ['ingestDialog', 'ingestOpen', 'ingestStart2', 'ingestCancel',
+    'ingestSource', 'ingestDest', 'ingestFolderTemplate', 'ingestFilenameTemplate', 'ingestCustom',
+    'ingestStart', 'ingestBackup', 'ingestVerify', 'ingestDuplicates', 'ingestChoose', 'ingestChooseDest',
+    'ingestChooseBackup', 'ingestScan', 'ingestSelectAll', 'ingestSelectNone', 'ingestPrevious', 'ingestNext',
+    'ingestGrid', 'ingestStatus', 'ingestSelection', 'ingestPage', 'ingestExample'] : kind === 'watch'
+    ? ['watchDialog', 'watchOpen', 'watchDestRow', 'watchMode', 'watchSave', 'watchPath', 'watchDest',
+      'watchDelete', 'watchPreset', 'watchId', 'watchExisting', 'watchExistingRow', 'watchName',
+      'watchRecursive', 'watchFollow', 'watchStatus', 'watchPill', 'watchCancel', 'watchChoose', 'watchChooseDest']
+    : ['catalogBackup', 'catalogDuplicates', 'importSidecarsBtn', 'catalogResultDialog',
+      'catalogResultTitle', 'catalogResultBody', 'catalogResultClose', 'localLibraryMenuBtn'];
+  for (const id of ids) nodes.set(id, new Element(id));
+  const context = vm.createContext({document, Event: class {constructor(type) { this.type = type; }},
+    setTimeout(fn) { const id = ++timer; timers.set(id, fn); return id; },
+    clearTimeout(id) { timers.delete(id); }, setInterval() {}, clearInterval() {},
+  });
+  vm.runInContext(source.replace('export function', 'function'), context);
+  const ui = context.createCatalogUI({el: id => nodes.get(id), toast() {}, sendNative: () => false,
+    post: async (path, body) => { calls.push({path, body: JSON.parse(JSON.stringify(body))}); return send ? send(path, body) : {ok: true}; },
+    get: async path => fetch ? fetch(path) : path === '/api/presets' ? [] : {watches: []},
+  });
+  const h = {ui, calls, nodes, el: id => nodes.get(id), document,
+    click: id => nodes.get(id).handlers.click?.({}),
+    async timers() { const callbacks = [...timers.values()]; timers.clear(); for (const fn of callbacks) await fn(); },
+  };
+  return h;
+}
+const plan = count => ({items: Array.from({length: count}, (_, i) => ({source: `/card/${i}.jpg`,
+  destination: `/dest/${i}.jpg`, name: `${i}.jpg`, size: 1000})), total: count, bytes: count * 1000});
+const ingestHarness = (count, overrides = {}) => {
+  const h = harness('ingest', {
+    post: async path => path === '/api/ingest/scan' ? {plan: plan(count)} : {jobId: 'import-123'},
+    get: async path => path.startsWith('/api/jobs/') ? {state: 'running', total: count, result: {copied: 0}} : {watches: []},
+    ...overrides,
+  });
+  h.ui.setIngestField('ingestSource', '/card'); h.ui.setIngestField('ingestDest', '/dest');
+  return h;
+};
+
+test('a 201-photo scan submits the full selection, not just the first preview page', async () => {
+  const h = ingestHarness(201); await h.click('ingestScan');
+  assert.equal(h.el('ingestGrid').inputs.length, 200);
+  assert.match(h.el('ingestStatus').textContent, /201 of 201 photos selected/);
+  await h.click('ingestStart2');
+  assert.equal(h.calls.at(-1).body.plan.items.length, 201);
+  assert.equal(h.calls.at(-1).body.plan.total, 201);
+});
+
+test('all pages are reachable and an unchecked photo stays excluded after changing pages', async () => {
+  const h = ingestHarness(201); await h.click('ingestScan'); await h.click('ingestNext');
+  assert.equal(h.el('ingestGrid').inputs.length, 1);
+  const last = h.el('ingestGrid').inputs[0]; last.checked = false;
+  h.el('ingestGrid').handlers.change({target: last});
+  await h.click('ingestPrevious'); await h.click('ingestNext');
+  assert.equal(h.el('ingestGrid').inputs[0].checked, false);
+  await h.click('ingestStart2');
+  assert.equal(h.calls.at(-1).body.plan.items.length, 200);
+  assert.equal(h.calls.at(-1).body.plan.items.some(item => item.source === '/card/200.jpg'), false);
+});
+
+test('clearing every photo disables Import and never posts an empty plan', async () => {
+  const h = ingestHarness(201); await h.click('ingestScan'); await h.click('ingestSelectNone');
+  assert.equal(h.el('ingestStart2').disabled, true);
+  assert.match(h.el('ingestStatus').textContent, /0 of 201 photos selected/);
+  await h.click('ingestStart2'); assert.equal(h.calls.length, 1);
+  await h.click('ingestSelectAll'); assert.equal(h.el('ingestStart2').disabled, false);
+});
+
+test('changing the reviewed destination, including native picker results, requires a new scan', async () => {
+  const h = ingestHarness(3); await h.click('ingestScan');
+  h.ui.setIngestField('ingestDest', '/other-destination');
+  assert.equal(h.el('ingestStart2').disabled, true); await h.click('ingestStart2');
+  assert.equal(h.calls.length, 1); assert.equal(h.el('ingestGrid').inputs.length, 0);
+});
+
+test('failed scans clear stale plans and rejected imports remain visible and retryable', async () => {
+  let reject = false;
+  const h = ingestHarness(3, {post: async path => path === '/api/ingest/scan'
+    ? reject ? {error: 'Card disconnected'} : {plan: plan(3)} : {error: 'Import already running'}});
+  await h.click('ingestScan'); await h.click('ingestStart2');
+  assert.match(h.el('ingestStatus').textContent, /already running/);
+  assert.equal(h.el('ingestStart2').disabled, false);
+  reject = true; await h.click('ingestScan');
+  assert.match(h.el('ingestStatus').textContent, /disconnected/);
+  assert.equal(h.el('ingestStart2').disabled, true);
+});
+
+test('Cancel targets the active job and waits for its final verified-copy count', async () => {
+  let cancelled = false;
+  const h = ingestHarness(3, {get: async path => path.startsWith('/api/jobs/')
+    ? {state: cancelled ? 'cancelled' : 'running', total: 3, result: {copied: cancelled ? 1 : 0}}
+    : {watches: []}});
+  await h.click('ingestOpen'); await h.click('ingestScan'); await h.click('ingestStart2');
+  assert.equal(h.el('ingestScan').disabled, true);
+  await h.click('ingestCancel');
+  assert.equal(h.calls.at(-1).path, '/api/jobs/import-123/cancel');
+  assert.equal(h.el('ingestDialog').classList.contains('on'), true);
+  assert.equal(h.el('ingestCancel').disabled, true);
+  cancelled = true; await h.timers();
+  assert.match(h.el('ingestStatus').textContent, /Import cancelled\. Copied 1\/3/);
+  assert.equal(h.el('ingestCancel').disabled, false);
+  assert.equal(h.el('ingestStart2').disabled, true, 'a completed or cancelled plan must be rescanned');
+});
+
+test('backup, duplicate and sidecar outcomes use a visible dialog and preserve filenames as text', async () => {
+  const h = harness('results', {post: async path => path.endsWith('backup') ? {archive: '/backup.zip'}
+    : {read: 3, applied: 2, missing: 1}, get: async path => path.endsWith('duplicates')
+      ? {groups: [{files: [{relpath: '<img src=x>'}, {relpath: 'copy.jpg'}]}]} : {watches: []}});
+  await h.click('catalogBackup'); assert.match(h.el('catalogResultBody').textContent, /backup.zip/);
+  assert.equal(h.el('catalogResultDialog').attributes['aria-hidden'], 'false');
+  await h.click('catalogDuplicates'); assert.match(h.el('catalogResultBody').textContent, /<img src=x> = copy.jpg/);
+  assert.equal(h.el('catalogResultBody').innerHTML, '');
+  await h.click('importSidecarsBtn'); assert.match(h.el('catalogResultBody').textContent, /Read 3 sidecars, applied 2/);
+  await h.click('catalogResultClose'); assert.equal(h.el('catalogResultDialog').attributes['aria-hidden'], 'true');
+});
+
+test('catalog API errors appear as errors rather than false success or no duplicates', async () => {
+  const h = harness('results', {post: async () => ({error: 'Catalog unavailable'}),
+    get: async path => path.endsWith('duplicates') ? {error: 'Could not search'} : {watches: []}});
+  await h.click('catalogBackup'); assert.equal(h.el('catalogResultBody').textContent, 'Catalog unavailable');
+  await h.click('importSidecarsBtn'); assert.equal(h.el('catalogResultBody').textContent, 'Catalog unavailable');
+  await h.click('catalogDuplicates'); assert.equal(h.el('catalogResultBody').textContent, 'Could not search');
+});
+
+test('blank watched folders and copy destinations cannot be saved; server errors keep the form open', async () => {
+  const h = harness('watch', {post: async () => ({error: 'Folder unavailable'})});
+  await tick(); await h.click('watchOpen');
+  assert.equal(h.el('watchSave').disabled, true); await h.click('watchSave'); assert.equal(h.calls.length, 0);
+  h.ui.setIngestField('watchPath', '/camera');
+  assert.equal(h.el('watchSave').disabled, false);
+  h.el('watchMode').value = 'ingest'; h.el('watchMode').handlers.change();
+  assert.equal(h.el('watchSave').disabled, true);
+  h.ui.setIngestField('watchDest', '/library'); await h.click('watchSave');
+  assert.equal(h.el('watchDialog').classList.contains('on'), true);
+  assert.equal(h.el('watchStatus').textContent, 'Folder unavailable');
+  assert.equal(h.el('watchSave').disabled, false);
+});
+
+test('every watch is reachable and the watching pill edits the enabled watch it names', async () => {
+  const watches = [{id: 'paused', name: 'Paused', path: '/paused', enabled: false},
+    {id: 'second', name: 'Camera', path: '/camera', enabled: true},
+    {id: 'third', name: 'Studio', path: '/studio', enabled: true}];
+  const h = harness('watch', {get: async path => path === '/api/presets' ? [] : {watches, status: []},
+    post: async (_path, body) => ({ok: true, watches: watches.filter(watch => watch.id !== body.id)})});
+  await tick(); await h.click('watchOpen');
+  assert.equal(h.el('watchExistingRow').hidden, false);
+  assert.match(h.el('watchExisting').innerHTML, /value="third"/);
+  h.el('watchExisting').value = 'third'; h.el('watchExisting').handlers.change();
+  assert.equal(h.el('watchPath').value, '/studio');
+  await h.click('watchDelete'); assert.equal(h.calls.at(-1).body.id, 'third');
+  await h.click('watchPill'); assert.equal(h.el('watchId').value, 'second');
+});

--- a/tests/edit-save-integration.test.mjs
+++ b/tests/edit-save-integration.test.mjs
@@ -51,7 +51,7 @@ function harness({manual = false, client = 'test-window'} = {}) {
     SURVEY: {active: 'B.raw', names: ['A.raw', 'B.raw']},
     cullResults: () => S.images, chosenCull: () => ['sharp'], CULL_LABELS: {sharp: 'Sharp'},
     NATIVE_PREVIEW: false, GRADE_DEFAULTS: {},
-    PRESET_BROWSER: null, METADATA: null, CAPTURE_TIME: null,
+    PRESET_BROWSER: null, METADATA: null, CAPTURE_TIME: null, ENHANCE: null,
     HISTORY: {
       record: (name, label, state) => history.push(plain({name, label, state})),
       refresh: noop,
@@ -111,7 +111,8 @@ function harness({manual = false, client = 'test-window'} = {}) {
     ...['snapshot', 'filmRenderFingerprint', 'baseEditsFingerprint', 'updateUndoRedoButtons',
       'pushUndoState', 'pushUndo', 'restore', 'undo', 'redo', 'isStateLoaded',
       'normalizeLibraryImage', 'prefetchState',
-      'showCurrentImage', 'go', 'persistMark', 'saveStateFor', 'enqueuePhotoPatch',
+      'showCurrentImage', 'go', 'photoReadyForEditing', 'syncPhotoActions',
+      'persistMark', 'saveStateFor', 'enqueuePhotoPatch',
       'pasteSettingsTo', 'applyCullFlags', 'keepSurveySelection', 'reconcilePeerSave', 'applyServerStateEvent'].map(appFunction),
     appSource.slice(stateStart, stateEnd),
     'globalThis.app = {saveState, saveStateFor, persistMark, go, showCurrentImage, pushUndo, undo, redo, flushEditSaves, pasteSettingsTo, applyCullFlags, keepSurveySelection, applyServerStateEvent, queue: editSaveQueue, photoUndo};',

--- a/tests/enhance-controls.test.mjs
+++ b/tests/enhance-controls.test.mjs
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createEnhancePanel } from '../web/enhance-panel.js';
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+function fixture({ capabilities, run } = {}) {
+  const handlers = {};
+  const nodes = {
+    enhanceRun: {}, enhanceNote: {},
+    enhanceMode: { value: 'denoise', options: [{ value: 'denoise' }, { value: 'upscale' }],
+      addEventListener: (event, handler) => { handlers[event] = handler; } },
+  };
+  let photo = { name: 'first.jpg' };
+  const calls = [], completed = [];
+  const controller = createEnhancePanel({
+    el: id => nodes[id], getPhoto: () => photo,
+    getCapabilities: capabilities || (async () => ({ available: true, modes: { denoise: true, upscale: false } })),
+    run: async request => { calls.push(request); return run ? run(request) : { ok: true }; },
+    onComplete: result => { completed.push(result); },
+  });
+  return { controller, nodes, handlers, calls, completed, setPhoto: value => { photo = value; controller.sync(); } };
+}
+
+test('pending capabilities and a failed capability check keep Enhance unavailable', async () => {
+  const pending = deferred();
+  const f = fixture({ capabilities: () => pending.promise });
+  const checking = f.controller.refresh();
+  assert.equal(f.nodes.enhanceRun.disabled, true);
+  await f.nodes.enhanceRun.onclick();
+  assert.equal(f.calls.length, 0);
+  pending.reject(new Error('offline'));
+  await checking;
+  assert.equal(f.nodes.enhanceRun.disabled, true);
+  assert.match(f.nodes.enhanceNote.textContent, /Could not check/);
+});
+
+test('mode availability disables Super resolution and rejects an unsupported synthetic click', async () => {
+  const f = fixture();
+  await f.controller.refresh();
+  assert.equal(f.nodes.enhanceMode.options[0].disabled, false);
+  assert.equal(f.nodes.enhanceMode.options[1].disabled, true);
+  assert.equal(f.nodes.enhanceRun.disabled, false);
+  f.nodes.enhanceMode.value = 'upscale';
+  await f.nodes.enhanceRun.onclick();
+  assert.equal(f.calls.length, 0);
+  assert.match(f.nodes.enhanceNote.textContent, /Super resolution needs an installed model/);
+});
+
+test('missing photo disables Enhance and a loaded photo enables it again', async () => {
+  const f = fixture();
+  await f.controller.refresh();
+  f.setPhoto(null);
+  assert.equal(f.nodes.enhanceRun.disabled, true);
+  await f.nodes.enhanceRun.onclick();
+  assert.equal(f.calls.length, 0);
+  f.setPhoto({ name: 'second.jpg' });
+  assert.equal(f.nodes.enhanceRun.disabled, false);
+  await f.nodes.enhanceRun.onclick();
+  assert.deepEqual(f.calls, [{ name: 'second.jpg', mode: 'denoise' }]);
+});
+
+test('an active Enhance request cannot be submitted twice', async () => {
+  const pending = deferred();
+  const f = fixture({ run: () => pending.promise });
+  await f.controller.refresh();
+  const first = f.nodes.enhanceRun.onclick();
+  assert.equal(f.nodes.enhanceRun.disabled, true);
+  await f.nodes.enhanceRun.onclick();
+  assert.equal(f.calls.length, 1);
+  pending.resolve({ ok: true });
+  await first;
+  assert.equal(f.completed.length, 1);
+  assert.equal(f.nodes.enhanceRun.disabled, false);
+});
+
+test('failed requests show their error and allow a retry', async () => {
+  const f = fixture({ run: async () => { throw new Error('Connection lost'); } });
+  await f.controller.refresh();
+  await f.nodes.enhanceRun.onclick();
+  assert.equal(f.nodes.enhanceRun.disabled, false);
+  assert.equal(f.nodes.enhanceNote.textContent, 'Connection lost');
+  assert.equal(f.completed.length, 0);
+});
+
+test('refresh picks a supported mode when the prior mode is unavailable', async () => {
+  const f = fixture({ capabilities: async () => ({ available: true, modes: { denoise: false, upscale: true } }) });
+  await f.controller.refresh();
+  assert.equal(f.nodes.enhanceMode.value, 'upscale');
+  await f.nodes.enhanceRun.onclick();
+  assert.equal(f.calls[0].mode, 'upscale');
+});
+
+test('an older capability response cannot override the latest refresh', async () => {
+  const old = deferred(), current = deferred();
+  let count = 0;
+  const f = fixture({ capabilities: () => (++count === 1 ? old : current).promise });
+  const before = f.controller.refresh(), after = f.controller.refresh();
+  current.resolve({ available: true, modes: { denoise: true, upscale: false } });
+  await after;
+  old.resolve({ available: false, reason: 'stale' });
+  await before;
+  assert.equal(f.nodes.enhanceRun.disabled, false);
+});

--- a/tests/maps-survey-controls.test.mjs
+++ b/tests/maps-survey-controls.test.mjs
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const source = (name) => readFileSync(new URL(`../web/${name}`, import.meta.url), 'utf8');
+
+function metadataHarness(get = async () => ({ iptc: {} })) {
+  const opened = [], notices = [], elements = new Map();
+  let visible = true;
+  for (const id of ['iptcLat', 'iptcLon', 'iptcMapLink']) {
+    elements.set(id, {
+      _value: '', disabled: false,
+      get value() { return this._value; },
+      set value(value) { this._value = String(value); },
+      addEventListener(type, handler) { this[type] = handler; },
+    });
+  }
+  elements.set('infoPane', { classList: { contains: () => visible } });
+  const context = vm.createContext({
+    setTimeout() { return 1; }, clearTimeout() {},
+    window: { open: (...args) => opened.push(args) },
+  });
+  vm.runInContext(source('metadata-panel.js').replace('export function', 'function'), context);
+  const panel = context.createMetadataPanel({
+    el: (id) => elements.get(id), get, post: async () => ({ ok: true }),
+    toast: (message) => notices.push(message),
+  });
+  return {
+    panel, opened, notices, map: elements.get('iptcMapLink'),
+    visible(value) { visible = value; },
+    coordinates(lat, lon) {
+      elements.get('iptcLat').value = lat;
+      elements.get('iptcLon').value = lon;
+      elements.get('iptcLat').input();
+    },
+  };
+}
+
+test('Maps requires a selected photo and loaded metadata, including after hidden-panel navigation', async () => {
+  const h = metadataHarness(async () => ({ iptc: { gps_lat: 40, gps_lon: -70 } }));
+  assert.equal(h.map.disabled, true);
+  h.coordinates('40', '-70');
+  h.map.click();
+  assert.equal(h.opened.length, 0);
+  await h.panel.refresh('first.jpg');
+  assert.equal(h.map.disabled, false);
+  h.visible(false);
+  await h.panel.refresh('second.jpg');
+  assert.equal(h.map.disabled, true, 'coordinates from the previous photo must not be usable');
+  h.map.click();
+  assert.equal(h.opened.length, 0);
+  h.visible(true);
+  await h.panel.refresh('second.jpg');
+  assert.equal(h.map.disabled, false);
+  await h.panel.refresh(null);
+  assert.equal(h.map.disabled, true);
+});
+
+test('Maps rejects blanks, non-finite values, and out-of-range coordinates without opening a window', async () => {
+  const h = metadataHarness();
+  await h.panel.refresh('photo.jpg');
+  for (const [lat, lon] of [
+    ['', ''], [' ', '0'], ['0', ''], ['NaN', '0'], ['Infinity', '0'],
+    ['0', '-Infinity'], ['90.01', '0'], ['-90.01', '0'], ['0', '180.01'], ['0', '-180.01'],
+  ]) {
+    h.coordinates(lat, lon);
+    assert.equal(h.map.disabled, true, `${JSON.stringify([lat, lon])} must be unavailable`);
+    h.map.click();
+  }
+  assert.equal(h.opened.length, 0);
+});
+
+test('Maps accepts zero and coordinate boundaries, and clearing a coordinate disables it immediately', async () => {
+  const h = metadataHarness();
+  await h.panel.refresh('photo.jpg');
+  for (const [lat, lon] of [['0', '0'], ['90', '180'], ['-90', '-180'], [' 40.5 ', ' -73.25 ']]) {
+    h.coordinates(lat, lon);
+    assert.equal(h.map.disabled, false);
+    h.map.click();
+    assert.deepEqual(h.opened.at(-1), [
+      `https://maps.apple.com/?ll=${Number(lat)},${Number(lon)}&q=Photo`, '_blank', 'noopener',
+    ]);
+  }
+  h.coordinates('40.5', '');
+  assert.equal(h.map.disabled, true);
+});
+
+test('Maps stays unavailable while another photo loads and after a failed metadata request', async () => {
+  let rejectRequest;
+  const h = metadataHarness((path) => path.endsWith('first.jpg')
+    ? Promise.resolve({ iptc: { gps_lat: 10, gps_lon: 20 } })
+    : new Promise((resolve, reject) => { rejectRequest = reject; }));
+  await h.panel.refresh('first.jpg');
+  const loading = h.panel.refresh('second.jpg');
+  assert.equal(h.map.disabled, true);
+  await Promise.resolve();
+  rejectRequest(new Error('Metadata unavailable'));
+  await loading;
+  assert.equal(h.map.disabled, true);
+  h.map.click();
+  assert.equal(h.opened.length, 0);
+});
+
+function surveyHarness() {
+  let images = ['A', 'B', 'C'].map((name) => ({ name }));
+  const grid = {
+    children: [], style: { setProperty() {} }, addEventListener() {},
+    get firstElementChild() { return this.children[0] || null; },
+    insertBefore(cell, cursor) {
+      cell.remove();
+      const index = cursor ? this.children.indexOf(cursor) : this.children.length;
+      this.children.splice(index, 0, cell);
+      cell.parent = this;
+    },
+  };
+  const elements = new Map([
+    ['survey', { hidden: true }], ['surveyTitle', {}], ['surveyGrid', grid],
+    ['surveySwap', { hidden: false, disabled: false }],
+  ]);
+  const document = {
+    body: { classList: { add() {}, remove() {} } },
+    createElement() {
+      const children = new Map([
+        ['img', { getAttribute() { return this.src; }, setAttribute(name, value) { this[name] = value; } }],
+        ['.survey-remove', { dataset: {} }], ['.survey-name', {}], ['.survey-marks', {}],
+      ]);
+      return {
+        dataset: {}, parent: null,
+        querySelector: (selector) => children.get(selector),
+        get nextElementSibling() {
+          return this.parent?.children[this.parent.children.indexOf(this) + 1] || null;
+        },
+        remove() {
+          if (this.parent) this.parent.children.splice(this.parent.children.indexOf(this), 1);
+          this.parent = null;
+        },
+      };
+    },
+  };
+  const context = vm.createContext({ document, labelSwatch: () => '' });
+  vm.runInContext(source('survey.js').replace(/^import .*;$/m, '').replace('export function', 'function'), context);
+  const survey = context.createSurvey({ el: (id) => elements.get(id), images: () => images });
+  return {
+    survey, swap: elements.get('surveySwap'),
+    removeImage(name) { images = images.filter((image) => image.name !== name); survey.render(); },
+    order: () => grid.children.map((cell) => decodeURIComponent(cell.dataset.name)),
+  };
+}
+
+test('Swap is hidden and disabled in normal Survey, while Compare swaps the two displayed photos', () => {
+  const h = surveyHarness();
+  h.survey.open(['A', 'B', 'C']);
+  assert.equal(h.swap.hidden, true);
+  assert.equal(h.swap.disabled, true);
+  h.survey.swap();
+  assert.deepEqual(h.order(), ['A', 'B', 'C']);
+  h.survey.open(['A', 'B', 'C'], 'compare');
+  assert.equal(h.swap.hidden, false);
+  assert.equal(h.swap.disabled, false);
+  h.survey.swap();
+  assert.deepEqual(h.order(), ['B', 'A']);
+  h.survey.open(['A', 'B']);
+  assert.equal(h.swap.hidden, true);
+  assert.equal(h.swap.disabled, true);
+});
+
+test('Compare disables Swap when removing a photo or when a photo is no longer available', () => {
+  const h = surveyHarness();
+  h.survey.open(['A', 'B'], 'compare');
+  h.survey.remove('B');
+  assert.equal(h.swap.disabled, true);
+  h.survey.swap();
+  assert.deepEqual(h.order(), ['A']);
+  h.survey.open(['A', 'B'], 'compare');
+  h.removeImage('B');
+  assert.equal(h.swap.disabled, true);
+  h.survey.swap();
+  assert.deepEqual(h.order(), ['A']);
+});

--- a/tests/photo-action-controls.test.mjs
+++ b/tests/photo-action-controls.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+test('photo actions follow empty, loaded, navigating, and emptied library states', () => {
+  const nodes = new Map();
+  const state = { editingName: null, masks: [], heals: [] };
+  let photo = null;
+  const context = vm.createContext({
+    S: state, cur: () => photo, ENHANCE: null,
+    $: id => { if (!nodes.has(id)) nodes.set(id, {}); return nodes.get(id); },
+  });
+  vm.runInContext(source.slice(source.indexOf('function photoReadyForEditing()'),
+    source.indexOf('function updateTransferActions()')), context);
+  const check = (disabled) => {
+    context.syncPhotoActions();
+    for (const id of ['resetEdit', 'autoBtn', 'zoomFit', 'zoom1', 'beforeBtn', 'wbBtn', 'clipBtn', 'versionCreate']) {
+      assert.equal(nodes.get(id).disabled, disabled, id);
+    }
+    for (const id of ['editPane', 'filmPane', 'cropPane', 'maskPane', 'healPane']) {
+      assert.equal(nodes.get(id).inert, disabled, id);
+    }
+  };
+  check(true);
+  photo = { name: 'A' }; state.editingName = 'A';
+  check(false);
+  assert.equal(nodes.get('maskReset').disabled, true);
+  assert.equal(nodes.get('healReset').disabled, true);
+  state.masks = [{}]; state.heals = [{}];
+  check(false);
+  assert.equal(nodes.get('maskReset').disabled, false);
+  assert.equal(nodes.get('healReset').disabled, false);
+  photo = { name: 'B' };
+  check(true);
+  state.editingName = 'B';
+  check(false);
+  photo = null;
+  check(true);
+  assert.equal(nodes.get('maskReset').disabled, true);
+  assert.equal(nodes.get('healReset').disabled, true);
+});
+
+test('a second overflow trigger click closes its menu while a context click can reopen it', () => {
+  const nodes = new Map();
+  const element = id => {
+    if (!nodes.has(id)) {
+      const classes = new Set();
+      nodes.set(id, { attrs: {}, style: {}, offsetWidth: 240, offsetHeight: 180,
+        classList: { contains: name => classes.has(name), add: name => classes.add(name), remove: name => classes.delete(name) },
+        setAttribute(name, value) { this.attrs[name] = value; },
+      });
+    }
+    return nodes.get(id);
+  };
+  const context = vm.createContext({ $: element, closeFolderMenu() {}, updateTransferActions() {}, innerWidth: 1000, innerHeight: 800 });
+  vm.runInContext(source.slice(source.indexOf('function closeActionMenus()'),
+    source.indexOf("$('localLibraryMenuBtn').onclick")), context);
+  const anchor = { getBoundingClientRect: () => ({ right: 500, bottom: 100 }) };
+  context.openActionMenu('localLibraryMenu', anchor);
+  assert.equal(element('localLibraryMenuBtn').attrs['aria-expanded'], 'true');
+  context.openActionMenu('localLibraryMenu', anchor);
+  assert.equal(element('localLibraryMenuBtn').attrs['aria-expanded'], 'false');
+  assert.equal(element('localLibraryMenu').attrs['aria-hidden'], 'true');
+  context.openActionMenu('libraryMenu', null, { clientX: 100, clientY: 200 });
+  context.openActionMenu('libraryMenu', null, { clientX: 150, clientY: 250 });
+  assert.equal(element('libraryMenu').attrs['aria-hidden'], 'false');
+  assert.equal(element('libraryMenu').style.top, '250px');
+});

--- a/tests/test_control_audit.py
+++ b/tests/test_control_audit.py
@@ -1,0 +1,19 @@
+"""Run the control audit behavior regressions in the regular CI suite."""
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+
+@unittest.skipUnless(shutil.which('node'), 'Node required')
+class ControlAuditTests(unittest.TestCase):
+    def test_controls(self):
+        root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(
+            ['node', '--test', 'tests/enhance-controls.test.mjs',
+             'tests/maps-survey-controls.test.mjs',
+             'tests/photo-action-controls.test.mjs',
+             'tests/catalog-controls.test.mjs'], cwd=root,
+            text=True, capture_output=True, timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/test_ingest_selection.py
+++ b/tests/test_ingest_selection.py
@@ -1,0 +1,99 @@
+"""Reviewed ingest selections and cooperative cancellation preserve source files."""
+from contextlib import ExitStack
+from pathlib import Path
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+
+import ingest_workflow
+from jobs import JobRegistry
+import server
+
+
+class IngestSelectionTests(unittest.TestCase):
+    def setUp(self):
+        self.resources = ExitStack()
+        self.addCleanup(self.resources.close)
+        self.root = Path(self.resources.enter_context(tempfile.TemporaryDirectory()))
+        self.source = self.root / 'card'
+        self.source.mkdir()
+        self.destination = self.root / 'library'
+        self.items = []
+        for index in range(3):
+            photo = self.source / f'{index}.jpg'
+            photo.write_bytes(f'disposable source photo {index}'.encode())
+            self.items.append({'source': str(photo), 'destination': str(self.destination / photo.name)})
+        self.registry = JobRegistry()
+        for name, value in [('JOBS', self.registry), ('INGEST', {'running': False}),
+                            ('catalog_handle', lambda: None)]:
+            self.resources.enter_context(mock.patch.object(server, name, value))
+        self.request = {'destination': str(self.destination), 'verify': 'hash'}
+
+    def wait(self, ident):
+        for _ in range(500):
+            record = self.registry.get(ident)
+            if record['state'] in ('done', 'failed', 'cancelled'):
+                return record
+            time.sleep(.01)
+        self.fail('Import did not finish within five seconds')
+
+    def test_explicit_empty_or_malformed_plan_never_scans_or_starts_a_job(self):
+        with mock.patch.object(server, 'scan_ingest_source') as scan:
+            for plan in ({'items': []}, {}, None, {'items': 'all'}, {'items': [None]}):
+                with self.subTest(plan=plan), self.assertRaises(ValueError):
+                    server.start_ingest({'plan': plan, 'path': str(self.source), 'request': self.request})
+            scan.assert_not_called()
+        self.assertEqual(self.registry.list(), [])
+        self.assertFalse(self.destination.exists())
+
+    def test_explicit_subset_copies_only_selected_files_and_preserves_originals(self):
+        originals = {path.name: path.read_bytes() for path in self.source.iterdir()}
+        with mock.patch.object(server, 'scan_ingest_source') as scan:
+            started = server.start_ingest({'plan': {'items': [self.items[2]]}, 'request': self.request})
+            result = self.wait(started['jobId'])
+            scan.assert_not_called()
+        self.assertEqual(result['state'], 'done')
+        self.assertEqual(result['result']['copied'], 1)
+        self.assertEqual([path.name for path in self.destination.iterdir()], ['2.jpg'])
+        self.assertEqual(originals, {path.name: path.read_bytes() for path in self.source.iterdir()})
+
+    def test_omitting_the_plan_preserves_scan_and_import_for_legacy_clients(self):
+        with mock.patch.object(server, 'scan_ingest_source', return_value={'plan': {'items': self.items}}) as scan:
+            started = server.start_ingest({'path': str(self.source), 'request': self.request})
+            self.assertEqual(self.wait(started['jobId'])['result']['copied'], 3)
+            scan.assert_called_once()
+
+    def test_cancel_finishes_current_verified_copy_then_stops_and_keeps_both_sources_and_copies(self):
+        reached = threading.Event()
+        release = threading.Event()
+        copy = ingest_workflow.copy_item
+        def gated(item, **kwargs):
+            if item == self.items[1]:
+                reached.set()
+                if not release.wait(5):
+                    raise TimeoutError('test copy gate')
+            return copy(item, **kwargs)
+        with mock.patch.object(ingest_workflow, 'copy_item', side_effect=gated):
+            started = server.start_ingest({'plan': {'items': self.items}, 'request': self.request})
+            ident = started['jobId']
+            try:
+                self.assertTrue(reached.wait(5))
+                cancelled = self.registry.cancel(ident)
+                self.assertEqual(cancelled['state'], 'running')
+                self.assertTrue(cancelled['cancelRequested'])
+                self.assertIn('already running', server.start_ingest({'plan': {'items': self.items}, 'request': self.request})['error'])
+            finally:
+                release.set()
+            result = self.wait(ident)
+        self.assertEqual(result['state'], 'cancelled')
+        self.assertEqual(result['result']['copied'], 2)
+        self.assertEqual(sorted(path.name for path in self.destination.iterdir()), ['0.jpg', '1.jpg'])
+        for item in self.items[:2]:
+            self.assertEqual(Path(item['source']).read_bytes(), Path(item['destination']).read_bytes())
+        self.assertEqual(len(list(self.source.iterdir())), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_native_web_ui.py
+++ b/tests/test_native_web_ui.py
@@ -1,0 +1,103 @@
+"""Check native web UI trust boundaries and one-shot confirmation replies."""
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(sys.platform == "darwin" and shutil.which("swiftc"),
+                     "requires Swift on macOS")
+class NativeWebUITests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temporary = tempfile.TemporaryDirectory(prefix="lighttable-native-web-ui-")
+        cls.addClassCleanup(cls.temporary.cleanup)
+        directory = Path(cls.temporary.name)
+        source = (ROOT / "app/main.swift").read_text()
+        helpers = source.split("// MARK: - Native web UI", 1)[1].split(
+            "// MARK: - Preset links", 1)[0]
+        main = directory / "main.swift"
+        main.write_text("import Foundation\n" + helpers + r'''
+switch CommandLine.arguments[1] {
+case "origin":
+    precondition(isLocalEditorPage(URL(string: "http://127.0.0.1:8350/"), port: 8350))
+    precondition(isLocalEditorPage(URL(string: "http://127.0.0.1:8350/web/index.html"), port: 8350))
+    for raw in ["https://127.0.0.1:8350/", "http://127.0.0.1:8351/",
+                "http://localhost:8350/", "http://127.0.0.1.evil.example:8350/",
+                "https://example.com/", "file:///tmp/index.html", "about:blank",
+                "http://user:password@127.0.0.1:8350/"] {
+        precondition(!isLocalEditorPage(URL(string: raw), port: 8350), raw)
+    }
+    precondition(!isLocalEditorPage(nil, port: 8350))
+    precondition(!isLocalEditorPage(URL(string: "http://127.0.0.1:0/"), port: 0))
+case "links":
+    for raw in ["https://maps.apple.com/?ll=42,-71&q=Photo", "http://example.com/help"] {
+        let url = URL(string: raw)!
+        precondition(externalWebURL(url) == url)
+    }
+    for raw in ["file:///tmp/photo.jpg", "javascript:alert(1)", "data:text/html,test",
+                "lighttable://preset/test/example", "mailto:user@example.com",
+                "https://user:password@example.com/", "https:/missing-host"] {
+        precondition(externalWebURL(URL(string: raw)) == nil, raw)
+    }
+    precondition(externalWebURL(nil) == nil)
+case "replies":
+    var values: [Bool] = []
+    var reply: NativeJavaScriptReply? = NativeJavaScriptReply { values.append($0) }
+    reply?.resolve(true)
+    reply?.resolve(false) // navigation/close after the user's OK
+    reply = nil
+    precondition(values == [true])
+    values.removeAll()
+    reply = NativeJavaScriptReply { values.append($0) }
+    reply?.resolve(false) // navigation/close before the sheet callback
+    reply?.resolve(true)
+    reply = nil
+    precondition(values == [false])
+    values.removeAll()
+    reply = NativeJavaScriptReply { values.append($0) }
+    reply = nil // an abandoned request always cancels
+    precondition(values == [false])
+    values.removeAll()
+    reply = NativeJavaScriptReply {
+        values.append($0)
+        reply?.resolve(false) // reentrant completion cannot run twice
+    }
+    reply?.resolve(true)
+    reply = nil
+    precondition(values == [true])
+default:
+    fatalError("unknown case")
+}
+print("passed")
+''')
+        cls.binary = directory / "native-web-ui"
+        result = subprocess.run([
+            "swiftc", "-swift-version", "5", "-module-cache-path",
+            str(directory / "modules"), str(main), "-o", str(cls.binary),
+        ], capture_output=True, text=True, timeout=90)
+        if result.returncode:
+            raise AssertionError(result.stdout + result.stderr)
+
+    def run_case(self, case):
+        result = subprocess.run([str(self.binary), case], capture_output=True,
+                                text=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_only_current_local_editor_origin_is_trusted(self):
+        self.run_case("origin")
+
+    def test_external_links_allow_only_http_and_https_without_credentials(self):
+        self.run_case("links")
+
+    def test_confirmation_completes_once_and_defaults_to_cancel(self):
+        self.run_case("replies")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_photo_tool_flow.py
+++ b/tests/test_photo_tool_flow.py
@@ -130,6 +130,7 @@ class PhotoToolFlowTests(unittest.TestCase):
 
         functions = [function(name) for name in (
             'snapshot', 'restore', 'filmRenderFingerprint', 'baseEditsFingerprint',
+            'photoReadyForEditing',
             'exitPhotoTool', 'selectPhotoTool', 'switchPane', 'setCropMode',
             'cropViewState', 'cropViewPrefersImmediate', 'cropViewFrame', 'cropFitScale',
             'cropViewTarget', 'cropViewBackgroundRGB', 'cropViewDimStyle', 'snapCropView',

--- a/web/app.js
+++ b/web/app.js
@@ -39,6 +39,7 @@ import { createSurvey } from '/web/survey.js';
 import { createHistoryPanel } from '/web/history-panel.js';
 import { createMetadataPanel } from '/web/metadata-panel.js';
 import { createCatalogUI } from '/web/catalog-ui.js';
+import { createEnhancePanel } from '/web/enhance-panel.js';
 import { installFirstRunSetup } from '/web/first-run.js';
 import { installRecovery } from '/web/recovery.js';
 import {
@@ -58,6 +59,7 @@ let RECOVERY = null;
 let CAPTURE_TIME = null;
 let UI_BRIDGE = null;
 let PRESET_BROWSER = null;
+let ENHANCE = null;
 let EXTERNAL_EDITORS = [];
 let EXTERNAL_PREFS = {};
 import { afterVisiblePaint, createFrameScheduler, debounce } from '/web/render-scheduler.js';
@@ -288,6 +290,7 @@ function setActionDialog(id, open) {
   dialog.setAttribute('aria-hidden', String(!open));
   if (open) {
     updateTransferActions();
+    if (id === 'enhanceDialog') void ENHANCE?.refresh();
     requestAnimationFrame(() => dialog.querySelector('select, input, button')?.focus());
   }
 }
@@ -1926,7 +1929,8 @@ function renderEditItems(kind) {
 function syncMaskPanel() {
   renderEditItems('mask');
   const mask = selectedMask();
-  const createOpen = !S.masks.length || S.maskCreateOpen;
+  const createOpen = S.maskCreateOpen;
+  $('maskReset').disabled = !photoReadyForEditing() || !S.masks.length;
   $('maskCreateMenu').hidden = !createOpen;
   $('maskCreateToggle').setAttribute('aria-expanded', String(createOpen));
   $('maskSemanticCombineRow').hidden = !mask;
@@ -1996,6 +2000,7 @@ function syncMaskPanel() {
 
 function syncHealPanel() {
   renderEditItems('heal');
+  $('healReset').disabled = !photoReadyForEditing() || !S.heals.length;
   const spot = selectedHeal();
   for (const mode of ['remove', 'heal', 'clone']) {
     $(`healTool${mode[0].toUpperCase()}${mode.slice(1)}`).setAttribute(
@@ -5497,8 +5502,10 @@ function closeActionMenus() {
 }
 
 function openActionMenu(id, anchor = null, event = null) {
+  const wasOpen = $(id).classList.contains('on');
   closeActionMenus();
   closeFolderMenu();
+  if (anchor && wasOpen) return;
   updateTransferActions();
   const menu = $(id);
   menu.classList.add('on');
@@ -6377,6 +6384,7 @@ async function go(i) {
   S.idx = i;
   $('panel').inert = true;
   $('cmp').inert = true;
+  syncPhotoActions();
   const im = cur();
   CAPTURE_TIME?.selectionChanged();
   const generation = ++navigationGeneration;
@@ -7742,7 +7750,25 @@ function transferTargets() {
     .filter(Boolean);
   return selected.length ? selected : (cur() ? [cur()] : []);
 }
+function photoReadyForEditing() {
+  const photo = cur();
+  return !!photo && photo.kind !== 'video' && S.editingName === photo.name;
+}
+function syncPhotoActions() {
+  const ready = photoReadyForEditing();
+  for (const id of ['editPane', 'filmPane', 'cropPane', 'maskPane', 'healPane']) {
+    $(id).inert = !ready;
+  }
+  for (const id of ['resetEdit', 'autoBtn', 'zoomFit', 'zoom1', 'beforeBtn',
+    'wbBtn', 'clipBtn', 'versionCreate']) {
+    $(id).disabled = !ready;
+  }
+  $('maskReset').disabled = !ready || !S.masks.length;
+  $('healReset').disabled = !ready || !S.heals.length;
+  ENHANCE?.sync();
+}
 function updateTransferActions() {
+  syncPhotoActions();
   const targets = transferTargets();
   const primaryKey = window.__LIGHTTABLE_PLATFORM__ === 'windows' ? 'Ctrl' : '⌘';
   $('copyBtn').disabled = !cur();
@@ -10131,6 +10157,7 @@ $('clipBtn').onclick = () => {
 /* ------------------------------------------------------------ auto tone */
 $('autoBtn').onclick = (event) => {
   event.stopPropagation();
+  if (!photoReadyForEditing()) return;
   refreshWebGLSamplingSurface();
   const s = S.gl && S.gl.sample();
   if (!s) {
@@ -10831,29 +10858,16 @@ if ($('learnedDenoiseApply')) {
 }
 
 if ($('enhanceRun')) {
-  getJSON('/api/enhance/capabilities').then((capabilities) => {
-    const note = $('enhanceNote');
-    if (!capabilities.available) {
-      $('enhanceRun').disabled = true;
-      if (note) note.textContent = capabilities.reason || 'Not available.';
-    } else if (note) {
-      note.textContent = 'Writes a new 16-bit master; the original is untouched.';
-    }
-  }).catch(() => {});
-  $('enhanceRun').onclick = async () => {
-    const im = cur();
-    if (!im) return;
-    const mode = $('enhanceMode') ? $('enhanceMode').value : 'denoise';
-    $('enhanceNote').textContent = 'Working…';
-    const result = await api('/api/enhance', { name: im.name, mode });
-    $('enhanceNote').textContent = result.ok
-      ? `Wrote ${String(result.destination).split('/').pop()}`
-      : (result.error || 'Enhance failed');
-    if (result.ok) {
+  ENHANCE = createEnhancePanel({
+    el: $, getPhoto: () => photoReadyForEditing() ? cur() : null,
+    getCapabilities: () => getJSON('/api/enhance/capabilities'),
+    run: (request) => api('/api/enhance', request),
+    onComplete: async () => {
       setActionDialog('enhanceDialog', false);
-      reloadLibrary();
-    }
-  };
+      await reloadLibrary();
+    },
+  });
+  void ENHANCE.refresh();
 }
 
 /* ------------------------------------------------------- native messages */

--- a/web/catalog-ui.js
+++ b/web/catalog-ui.js
@@ -27,6 +27,33 @@ export function createCatalogUI(ctx) {
     }
   };
 
+  let catalogResultVersion = 0;
+  function showCatalogResult(title, message) {
+    const version = ++catalogResultVersion;
+    el('catalogResultTitle').textContent = title;
+    el('catalogResultBody').textContent = message;
+    const dialog = el('catalogResultDialog');
+    dialog.setAttribute('aria-hidden', 'false');
+    dialog.classList.add('on');
+    el('catalogResultClose').focus();
+    return message => {
+      if (version === catalogResultVersion) el('catalogResultBody').textContent = message;
+    };
+  }
+
+  const resultDialog = el('catalogResultDialog');
+  const closeResult = () => {
+    resultDialog?.setAttribute('aria-hidden', 'true');
+    resultDialog?.classList.remove('on');
+    el('localLibraryMenuBtn')?.focus();
+  };
+  el('catalogResultClose')?.addEventListener('click', closeResult);
+  resultDialog?.addEventListener('keydown', event => {
+    event.stopPropagation();
+    if (event.key === 'Escape') { event.preventDefault(); closeResult(); }
+    if (event.key === 'Tab') { event.preventDefault(); el('catalogResultClose').focus(); }
+  });
+
   /* ------------------------------------------------------------- sources */
 
   function renderSources() {
@@ -140,32 +167,32 @@ export function createCatalogUI(ctx) {
     const backup = el('catalogBackup');
     if (backup) {
       backup.addEventListener('click', async () => {
-        const result = await post('/api/catalog/backup', {});
-        const target = el('catalogMaintenance');
-        if (target) {
-          target.textContent = result.archive
-            ? `Backed up to ${result.archive}` : (result.error || 'Failed');
-        }
+        backup.disabled = true;
+        const report = showCatalogResult('Back up catalog', 'Creating backup…');
+        try {
+          const result = await post('/api/catalog/backup', {});
+          if (result.error || !result.archive) throw new Error(result.error || 'Could not create backup');
+          report(`Backed up to ${result.archive}`);
+        } catch (error) { report(String(error.message || error)); }
+        finally { backup.disabled = false; }
       });
     }
 
     const duplicates = el('catalogDuplicates');
     if (duplicates) {
       duplicates.addEventListener('click', async () => {
-        const result = await get('/api/catalog/duplicates');
-        const groups = (result && result.groups) || [];
-        const target = el('catalogMaintenance');
-        if (!target) return;
-        if (!groups.length) {
-          target.textContent = 'No duplicate files found.';
-          return;
-        }
-        const total = groups.reduce((sum, g) => sum + g.files.length, 0);
-        target.innerHTML = `<strong>${groups.length} duplicate `
-          + `group${groups.length === 1 ? '' : 's'}</strong> covering `
-          + `${total} files.<br>`
-          + groups.slice(0, 20).map((group) =>
-            group.files.map((file) => file.relpath).join(' = ')).join('<br>');
+        duplicates.disabled = true;
+        const report = showCatalogResult('Find duplicates', 'Looking for duplicate files…');
+        try {
+          const result = await get('/api/catalog/duplicates');
+          if (result.error) throw new Error(result.error);
+          const groups = result.groups || [];
+          const total = groups.reduce((sum, group) => sum + group.files.length, 0);
+          report(!groups.length ? 'No duplicate files found.'
+            : `${groups.length} duplicate group${groups.length === 1 ? '' : 's'} covering ${total} files.\n\n`
+              + groups.map(group => group.files.map(file => file.relpath).join(' = ')).join('\n'));
+        } catch (error) { report(String(error.message || error)); }
+        finally { duplicates.disabled = false; }
       });
     }
   }
@@ -176,22 +203,21 @@ export function createCatalogUI(ctx) {
     const button = el('importSidecarsBtn');
     if (!button) return;
     button.addEventListener('click', async () => {
-      const report = el('importReport');
-      if (report) report.textContent = 'Reading sidecars…';
+      button.disabled = true;
+      const report = showCatalogResult('Import sidecars', 'Reading sidecars…');
       try {
         const result = await post('/api/import/sidecars', {
           apply: { metadata: true, develop: false, crop: false },
         });
-        if (report) {
-          const ignored = Object.entries(result.ignored || {}).map(([key, count]) => `${key} (${count})`);
-          report.textContent = `Read ${result.read} sidecars, applied ${result.applied}. ${result.missing} photos had none.`
-            + (ignored.length ? ` Skipped: ${ignored.join(', ')}.` : '')
-            + (result.errors?.length ? ` ${result.errors.length} errors: ${result.errors.slice(0, 5).join('; ')}` : '');
-        }
+        if (result.error) throw new Error(result.error);
+        const ignored = Object.entries(result.ignored || {});
+        report(`Read ${result.read} sidecars, applied `
+          + `${result.applied}. ${result.missing} photos had none.`
+          + (ignored.length ? `\nSkipped: ${ignored.map(([key, count]) => `${key} (${count})`).join(', ')}` : '')
+          + (result.errors?.length ? `\nErrors: ${result.errors.map(error => error.error || error).join('; ')}` : ''));
         if (ctx.onLibraryChanged) ctx.onLibraryChanged();
-      } catch (error) {
-        if (report) report.textContent = error.message || 'Sidecars could not be read.';
-      }
+      } catch (error) { report(String(error.message || error)); }
+      finally { button.disabled = false; }
     });
   }
 
@@ -373,118 +399,201 @@ export function createCatalogUI(ctx) {
   }
 
   function bindIngest() {
-    const dialog = el('ingestDialog');
-    const open = el('ingestOpen');
+    const dialog = el('ingestDialog'), open = el('ingestOpen');
     if (!dialog || !open) return;
+    const start = el('ingestStart2'), cancel = el('ingestCancel');
+    const pageSize = 200, selected = new Set();
+    let page = 0, busy = false, scanning = false, jobId = null, cancelling = false;
+    const fields = ['ingestSource', 'ingestDest', 'ingestFolderTemplate',
+      'ingestFilenameTemplate', 'ingestCustom', 'ingestStart', 'ingestBackup',
+      'ingestVerify', 'ingestDuplicates'];
     const show = (visible) => {
       dialog.setAttribute('aria-hidden', visible ? 'false' : 'true');
       dialog.classList.toggle('on', visible);
     };
+    const items = () => ingestPlan?.items || [];
+    const chosen = () => items().filter(item => selected.has(item.source));
+    function controls() {
+      const locked = busy || scanning;
+      for (const id of [...fields, 'ingestChoose', 'ingestChooseDest', 'ingestChooseBackup']) {
+        el(id).disabled = locked;
+      }
+      el('ingestScan').disabled = locked || !el('ingestSource').value.trim()
+        || !el('ingestDest').value.trim();
+      start.disabled = locked || !selected.size || !ingestPlan;
+      cancel.disabled = scanning || (busy && (!jobId || cancelling));
+      el('ingestSelectAll').disabled = locked || selected.size === items().length;
+      el('ingestSelectNone').disabled = locked || !selected.size;
+      el('ingestPrevious').disabled = locked || !page;
+      el('ingestNext').disabled = locked || (page + 1) * pageSize >= items().length;
+      for (const input of el('ingestGrid').querySelectorAll('input')) input.disabled = locked;
+    }
+    function selectionStatus() {
+      const selectedItems = chosen();
+      const bytes = selectedItems.reduce((sum, item) => sum + (Number(item.size) || 0), 0);
+      const cloud = (ingestPlan?.skipped || []).filter(item => item.reason === 'cloud-only').length;
+      el('ingestStatus').textContent = `${selectedItems.length} of ${items().length} photos selected`
+        + `, ${(bytes / 1e9).toFixed(2)} GB`
+        + (ingestPlan?.duplicates ? ` · ${ingestPlan.duplicates} already in the catalog` : '')
+        + (cloud ? `. ${cloud} cloud-only photos skipped; download them in Finder and scan again.` : '');
+      el('ingestExample').textContent = selectedItems[0]
+        ? `First file lands at ${selectedItems[0].destination}` : '';
+      controls();
+    }
+    function renderPage() {
+      el('ingestSelection').hidden = !items().length;
+      el('ingestPage').textContent = items().length
+        ? `Page ${page + 1} of ${Math.ceil(items().length / pageSize)}` : '';
+      el('ingestGrid').innerHTML = items().slice(page * pageSize, (page + 1) * pageSize)
+        .map(item => `<label class="ingest-cell">`
+          + `<input type="checkbox" ${selected.has(item.source) ? 'checked' : ''} data-source="${encodeURIComponent(item.source)}">`
+          + `<span class="ingest-cell-name">${escapeHTML(item.name)}</span>`
+          + `<span class="ingest-cell-dest">${escapeHTML(String(item.destination || '').split('/').slice(-2).join('/'))}</span></label>`).join('');
+      controls();
+    }
+    function invalidate() {
+      if (busy || scanning) return;
+      ingestPlan = null; selected.clear(); page = 0;
+      renderPage();
+      el('ingestExample').textContent = '';
+      el('ingestStatus').textContent = 'Scan the source to review photos and destinations.';
+    }
+    for (const id of fields) {
+      el(id).addEventListener('input', invalidate);
+      el(id).addEventListener('change', invalidate);
+    }
+    el('ingestGrid').addEventListener('change', event => {
+      if (busy || scanning || !event.target.dataset.source) return;
+      const source = decodeURIComponent(event.target.dataset.source);
+      if (event.target.checked) selected.add(source); else selected.delete(source);
+      selectionStatus();
+    });
+    el('ingestSelectAll').addEventListener('click', () => {
+      if (busy || scanning) return;
+      items().forEach(item => selected.add(item.source)); renderPage(); selectionStatus();
+    });
+    el('ingestSelectNone').addEventListener('click', () => {
+      if (busy || scanning) return;
+      selected.clear(); renderPage(); selectionStatus();
+    });
+    for (const [id, step] of [['ingestPrevious', -1], ['ingestNext', 1]]) {
+      el(id).addEventListener('click', () => {
+        if (busy || scanning) return;
+        page = Math.max(0, Math.min(Math.ceil(items().length / pageSize) - 1, page + step));
+        renderPage();
+      });
+    }
     open.addEventListener('click', () => show(true));
-    const cancel = el('ingestCancel');
-    if (cancel) cancel.addEventListener('click', () => { show(false); });
-
-    ['ingestChoose', 'ingestChooseDest', 'ingestChooseBackup'].forEach((id) => {
-      const button = el(id);
-      if (!button) return;
-      button.addEventListener('click', () => {
-        const field = { ingestChoose: 'ingestSource',
-                        ingestChooseDest: 'ingestDest',
-                        ingestChooseBackup: 'ingestBackup' }[id];
+    cancel.addEventListener('click', async () => {
+      if (!busy) { show(false); return; }
+      if (!jobId || cancelling) return;
+      cancelling = true; controls();
+      el('ingestStatus').textContent = 'Stopping after the current file finishes copying and verification…';
+      try {
+        const result = await post(`/api/jobs/${jobId}/cancel`, {});
+        if (result.error) throw new Error(result.error);
+      } catch (error) {
+        cancelling = false; controls();
+        el('ingestStatus').textContent = `Could not cancel import: ${error.message || error}`;
+      }
+    });
+    ['ingestChoose', 'ingestChooseDest', 'ingestChooseBackup'].forEach(id => {
+      el(id).addEventListener('click', () => {
+        const field = { ingestChoose: 'ingestSource', ingestChooseDest: 'ingestDest',
+          ingestChooseBackup: 'ingestBackup' }[id];
         if (!sendNative('chooseIngestFolder', { field })) {
           toast('Choosing a folder needs the desktop app; paste a path instead');
         }
       });
     });
-
-    const scan = el('ingestScan');
-    if (scan) {
-      scan.addEventListener('click', async () => {
-        const path = el('ingestSource').value.trim();
-        if (!path) { toast('Choose a card first'); return; }
-        el('ingestStatus').textContent = 'Scanning…';
-        try {
-          const result = await post('/api/ingest/scan',
-                                    { path, request: ingestRequest() });
-          ingestPlan = result.plan;
-          const grid = el('ingestGrid');
-          grid.innerHTML = (ingestPlan.items || []).slice(0, 200).map((item) => `
-            <label class="ingest-cell">
-              <input type="checkbox" checked data-source="${encodeURIComponent(item.source)}">
-              <span class="ingest-cell-name">${escapeHTML(item.name)}</span>
-              <span class="ingest-cell-dest">${escapeHTML(String(item.destination || '').split('/').slice(-2).join('/'))}</span>
-            </label>`).join('');
-          el('ingestStatus').textContent =
-            `${ingestPlan.total} photos to copy`
-            + (ingestPlan.duplicates
-              ? `, ${ingestPlan.duplicates} already in the catalog` : '')
-            + `, ${(ingestPlan.bytes / 1e9).toFixed(2)} GB`
-            + ((ingestPlan.skipped || []).some((item) => item.reason === 'cloud-only')
-              ? `. ${(ingestPlan.skipped || []).filter((item) => item.reason === 'cloud-only').length} cloud-only photos skipped; download them in Finder and scan again.` : '');
-          el('ingestStart2').disabled = !ingestPlan.total;
-          const first = (ingestPlan.items || [])[0];
-          el('ingestExample').textContent = first
-            ? `First file lands at ${first.destination}` : '';
-        } catch (error) {
-          el('ingestStatus').textContent = String(error.message || error);
+    el('ingestScan').addEventListener('click', async () => {
+      if (busy || scanning) return;
+      const path = el('ingestSource').value.trim();
+      if (!path || !el('ingestDest').value.trim()) {
+        el('ingestStatus').textContent = 'Choose a source and destination first.'; return;
+      }
+      invalidate(); scanning = true; controls();
+      el('ingestStatus').textContent = 'Scanning…';
+      try {
+        const result = await post('/api/ingest/scan', { path, request: ingestRequest() });
+        if (result.error || !Array.isArray(result.plan?.items)) {
+          throw new Error(result.error || 'Could not scan the source');
         }
-      });
-    }
-
-    const start = el('ingestStart2');
-    if (start) {
-      start.addEventListener('click', async () => {
-        if (!ingestPlan) return;
-        const checked = new Set(
-          Array.from(el('ingestGrid').querySelectorAll('input:checked'))
-            .map((input) => decodeURIComponent(input.dataset.source)));
-        const plan = {
-          ...ingestPlan,
-          items: ingestPlan.items.filter((item) => checked.has(item.source)),
-        };
-        start.disabled = true;
-        await post('/api/ingest', { plan, request: ingestRequest(),
-                                    path: el('ingestSource').value.trim() });
-        clearInterval(ingestPoll);
-        ingestPoll = setInterval(async () => {
-          const status = await get('/api/ingest/status');
+        ingestPlan = result.plan;
+        items().forEach(item => selected.add(item.source));
+        renderPage(); selectionStatus();
+      } catch (error) {
+        el('ingestStatus').textContent = String(error.message || error);
+      } finally { scanning = false; controls(); }
+    });
+    start.addEventListener('click', async () => {
+      if (busy || scanning || !ingestPlan || !selected.size) return;
+      const selectedItems = chosen();
+      if (!selectedItems.length) return;
+      const plan = { ...ingestPlan, items: selectedItems, total: selectedItems.length,
+        bytes: selectedItems.reduce((sum, item) => sum + (Number(item.size) || 0), 0) };
+      busy = true; cancelling = false; controls();
+      el('ingestStatus').textContent = 'Starting import…';
+      try {
+        const result = await post('/api/ingest', { plan, request: ingestRequest(),
+          path: el('ingestSource').value.trim() });
+        if (result.error || !result.jobId) throw new Error(result.error || 'Could not start import');
+        jobId = result.jobId; controls();
+      } catch (error) {
+        busy = false; controls();
+        el('ingestStatus').textContent = String(error.message || error); return;
+      }
+      clearTimeout(ingestPoll);
+      let attempts = 0;
+      const poll = async () => {
+        try {
+          const record = await get(`/api/jobs/${jobId}`);
+          if (record.error) throw new Error(record.error);
+          const status = record.result || {};
+          const terminal = ['done', 'failed', 'cancelled'].includes(record.state);
           el('ingestStatus').textContent =
-            `Copied ${status.copied}/${status.total}`
-            + (status.errors && status.errors.length
-              ? ` · ${status.errors.length} failed` : '');
-          if (!status.running) {
-            clearInterval(ingestPoll);
-            start.disabled = false;
+            (record.state === 'cancelled' ? 'Import cancelled. ' : cancelling && !terminal ? 'Stopping after the current file… ' : '')
+            + `Copied ${status.copied || 0}/${record.total}`
+            + (record.errors?.length ? ` · ${record.errors.length} failed` : '');
+          if (terminal) {
+            busy = false; jobId = null; cancelling = false;
+            ingestPlan = null; selected.clear(); page = 0; renderPage();
+            el('ingestExample').textContent = '';
+            if (record.state !== 'done') el('ingestStatus').textContent += ' — the originals on the card were not touched.';
             await refresh();
             if (ctx.onLibraryChanged) ctx.onLibraryChanged();
-            if (status.errors && status.errors.length) {
-              el('ingestStatus').textContent +=
-                ' — the originals on the card were not touched.';
-            }
-            notifyCompletion('Import complete',
+            notifyCompletion(record.state === 'cancelled' ? 'Import cancelled' : record.state === 'failed' ? 'Import finished with errors' : 'Import complete',
               `${status.copied || 0} photo${status.copied === 1 ? '' : 's'} copied`
-              + ((status.errors || []).length ? ` · ${status.errors.length} failed` : ''));
+              + (record.errors?.length ? ` · ${record.errors.length} failed` : ''));
+            return;
           }
-        }, 600);
-      });
-    }
-    return { show };
+        } catch (error) {
+          el('ingestStatus').textContent = `Could not read import progress: ${error.message || error}`;
+        }
+        if (++attempts < 7200) ingestPoll = setTimeout(poll, 1000);
+        else el('ingestStatus').textContent = 'Import is still running. Use Jobs to check its progress or cancel it.';
+      };
+      await poll();
+    });
+    controls();
+    return { show, setField(field, value) {
+      if (busy || scanning) return;
+      if (fields.includes(field)) { el(field).value = value; invalidate(); }
+    } };
   }
 
   /* ------------------------------------------------------------- watches */
 
   function renderWatches(statuses = []) {
     const byId = new Map(statuses.map((status) => [status.id, status]));
-    const list = el('watchList');
-    if (list) {
-      list.innerHTML = watches.map((watch) => {
-        const status = byId.get(watch.id) || {};
-        const detail = status.available === false
-          ? 'Unavailable' : `${status.handled || 0} new`;
-        return `<button class="source-row" data-watch-id="${escapeHTML(watch.id)}">`
-          + `<span class="source-name">${escapeHTML(watch.name)}</span>`
-          + `<span class="source-count">${detail}</span></button>`;
-      }).join('');
+    const existing = el('watchExisting');
+    if (existing) {
+      const selectedId = el('watchId').value;
+      el('watchExistingRow').hidden = !watches.length;
+      const options = '<option value="">New watched folder</option>'
+        + watches.map(watch => `<option value="${escapeHTML(watch.id)}">${escapeHTML(watch.name)}${watch.enabled ? '' : ' · Paused'}</option>`).join('');
+      if (existing.innerHTML !== options) existing.innerHTML = options;
+      if (existing.value !== selectedId) existing.value = selectedId;
     }
     const enabled = watches.filter((watch) => watch.enabled);
     const pill = el('watchPill');
@@ -543,8 +652,16 @@ export function createCatalogUI(ctx) {
       dialog.setAttribute('aria-hidden', visible ? 'false' : 'true');
       dialog.classList.toggle('on', visible);
     };
+    let saving = false;
     const syncMode = () => {
-      el('watchDestRow').hidden = el('watchMode').value !== 'ingest';
+      const needsDestination = el('watchMode').value === 'ingest';
+      el('watchDestRow').hidden = !needsDestination;
+      el('watchSave').disabled = saving || !el('watchPath').value.trim()
+        || (needsDestination && !el('watchDest').value.trim());
+      el('watchDelete').disabled = saving;
+      for (const id of ['watchExisting', 'watchName', 'watchPath', 'watchMode', 'watchDest', 'watchPreset', 'watchRecursive', 'watchFollow', 'watchChoose', 'watchChooseDest', 'watchCancel']) {
+        el(id).disabled = saving;
+      }
     };
     const populatePreset = async (selected = '') => {
       const presets = await get('/api/presets').catch(() => []);
@@ -556,8 +673,10 @@ export function createCatalogUI(ctx) {
       select.dispatchEvent(new Event('change'));
     };
     const edit = (watch = null) => {
+      if (saving) return;
       const current = watch || {};
       el('watchId').value = current.id || '';
+      el('watchExisting').value = current.id || '';
       el('watchName').value = current.name || '';
       el('watchPath').value = current.path || '';
       el('watchMode').value = current.mode || 'catalog';
@@ -572,13 +691,12 @@ export function createCatalogUI(ctx) {
       show(true);
     };
     open.addEventListener('click', () => edit());
-    el('watchPill')?.addEventListener('click', () => edit(watches[0]));
-    el('watchList')?.addEventListener('click', (event) => {
-      const row = event.target.closest('[data-watch-id]');
-      if (row) {
-        edit(watches.find((watch) => watch.id === row.dataset.watchId));
-      }
-    });
+    el('watchPill')?.addEventListener('click', () => edit(watches.find(watch => watch.enabled)));
+    el('watchExisting')?.addEventListener('change', () => edit(watches.find(watch => watch.id === el('watchExisting').value)));
+    for (const id of ['watchPath', 'watchDest']) {
+      el(id).addEventListener('input', syncMode);
+      el(id).addEventListener('change', syncMode);
+    }
     el('watchCancel')?.addEventListener('click', () => show(false));
     el('watchMode')?.addEventListener('change', syncMode);
     [['watchChoose', 'watchPath'], ['watchChooseDest', 'watchDest']]
@@ -588,7 +706,13 @@ export function createCatalogUI(ctx) {
         }
       }));
     el('watchSave')?.addEventListener('click', async () => {
+      if (saving) return;
       const mode = el('watchMode').value;
+      if (!el('watchPath').value.trim() || (mode === 'ingest' && !el('watchDest').value.trim())) {
+        el('watchStatus').textContent = mode === 'ingest'
+          ? 'Choose a watched folder and library destination first.' : 'Choose a folder to watch first.';
+        syncMode(); return;
+      }
       const watch = {
         id: el('watchId').value || undefined,
         name: el('watchName').value.trim(), path: el('watchPath').value.trim(),
@@ -600,24 +724,32 @@ export function createCatalogUI(ctx) {
           filenameTemplate: '{filename}', verify: 'hash', onDuplicate: 'skip',
         } : {},
       };
+      saving = true; syncMode();
       try {
         const result = await post('/api/watch', { action: 'save', watch });
+        if (result.error || !result.ok) throw new Error(result.error || 'Could not save watched folder');
         watches = result.watches || [];
         show(false);
         startWatchPolling();
       } catch (error) {
         el('watchStatus').textContent = String(error.message || error);
-      }
+      } finally { saving = false; syncMode(); }
     });
     el('watchDelete')?.addEventListener('click', async () => {
-      const result = await post('/api/watch', {
-        action: 'delete', id: el('watchId').value,
-      });
-      watches = result.watches || [];
-      show(false);
-      startWatchPolling();
+      if (saving || !el('watchId').value) return;
+      saving = true; syncMode();
+      try {
+        const result = await post('/api/watch', { action: 'delete', id: el('watchId').value });
+        if (result.error || !result.ok) throw new Error(result.error || 'Could not delete watched folder');
+        watches = result.watches || [];
+        show(false); startWatchPolling();
+      } catch (error) { el('watchStatus').textContent = String(error.message || error); }
+      finally { saving = false; syncMode(); }
     });
-    return { edit };
+    return { edit, setField(field, value) {
+      if (saving || !['watchPath', 'watchDest'].includes(field)) return;
+      el(field).value = value; syncMode();
+    } };
   }
 
   /* -------------------------------------------------------------- rename */
@@ -728,7 +860,7 @@ export function createCatalogUI(ctx) {
   bindSidecarImport();
   const importDialog = bindCatalogImport();
   const ingest = bindIngest();
-  bindWatches();
+  const watchDialog = bindWatches();
   const rename = bindRename();
   loadWatches();
 
@@ -738,7 +870,10 @@ export function createCatalogUI(ctx) {
     openIngest: () => ingest && ingest.show(true),
     openRename: () => rename && rename.open(),
     setCatalogPath: (path) => importDialog && importDialog.setPath(path),
-    setIngestField: (field, value) => { if (el(field)) el(field).value = value; },
+    setIngestField: (field, value) => {
+      if (field.startsWith('watch')) watchDialog?.setField(field, value);
+      else ingest?.setField(field, value);
+    },
     get catalog() { return catalog; },
   };
 }

--- a/web/enhance-panel.js
+++ b/web/enhance-panel.js
@@ -1,0 +1,65 @@
+export function createEnhancePanel({ el, getPhoto, getCapabilities, run, onComplete }) {
+  const button = el('enhanceRun');
+  const select = el('enhanceMode');
+  const note = el('enhanceNote');
+  let capabilities = null, busy = false, message = '', generation = 0;
+
+  function sync() {
+    for (const option of select.options) {
+      option.disabled = busy || !capabilities?.available || !capabilities.modes?.[option.value];
+    }
+    if (!busy && !capabilities?.modes?.[select.value]) {
+      const available = [...select.options].find(option => !option.disabled);
+      if (available) select.value = available.value;
+    }
+    select.disabled = ![...select.options].some(option => !option.disabled);
+    button.disabled = busy || !getPhoto() || !capabilities?.available
+      || !capabilities.modes?.[select.value];
+    if (busy) note.textContent = 'Working…';
+    else if (!capabilities) note.textContent = 'Checking available enhancements…';
+    else if (!capabilities.available) note.textContent = capabilities.reason || 'Not available.';
+    else if (!getPhoto()) note.textContent = 'Select a photo first.';
+    else if (message) note.textContent = message;
+    else note.textContent = 'Writes a new 16-bit master; the original is untouched.'
+      + (!capabilities.modes?.upscale ? ' Super resolution needs an installed model.' : '');
+  }
+
+  async function refresh() {
+    if (busy) return;
+    const request = ++generation;
+    capabilities = null;
+    message = '';
+    sync();
+    try {
+      const result = await getCapabilities();
+      if (request !== generation) return;
+      capabilities = result?.error ? { available: false, reason: result.error } : result;
+    } catch (_) {
+      if (request !== generation) return;
+      capabilities = { available: false, reason: 'Could not check available enhancements.' };
+    }
+    sync();
+  }
+
+  select.addEventListener('change', () => { message = ''; sync(); });
+  button.onclick = async () => {
+    const photo = getPhoto();
+    if (busy || !photo || !capabilities?.available || !capabilities.modes?.[select.value]) return;
+    busy = true;
+    message = '';
+    const mode = select.value;
+    sync();
+    try {
+      const result = await run({ name: photo.name, mode });
+      if (result.ok) await onComplete(result);
+      else message = result.error || 'Enhance failed';
+    } catch (error) {
+      message = error.message || 'Enhance failed';
+    } finally {
+      busy = false;
+      sync();
+    }
+  };
+  sync();
+  return { refresh, sync };
+}

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -89,7 +89,7 @@
           "title": "Review translated edits",
           "paragraphs": [
             "Develop settings are approximate and cannot promise Lightroom’s rendered appearance. Unsupported local masks, camera profiles, .lrcat-data AI masks or LUT payloads, and unsupported smart-collection rules are reported as skipped. Imported develop settings turn Film off.",
-            "Local ••• → Import sidecars… is a separate action for reading supported metadata from adjacent sidecars. That action does not apply develop settings or crop."
+            "Local ••• → Import sidecars… is a separate action for reading supported metadata from adjacent sidecars. That action does not apply develop settings or crop. Its results dialog shows progress, applied counts, skipped settings, and errors."
           ]
         }
       ],
@@ -162,19 +162,19 @@
             "Open Local ••• → Import from card….",
             "Choose the Source and Destination. Set Folder template and Rename to before scanning. The defaults keep filenames and organize copies as year/year-month-day.",
             "Choose verification: Full hash, Size only, or None. Set Duplicates to Skip or Copy anyway, and optionally choose Second copy to.",
-            "Click Scan. Review the destination preview and the checked files, then click Import.",
-            "Wait for the copied count and check whether any files failed."
+            "Click Scan. Use Previous and Next to review every page, and check the selected count and destination preview before clicking Import. Import is unavailable when no photos are selected.",
+            "Wait for the copied count and check whether any files failed. Cancel stops after the current file finishes copying and verification; completed copies are kept and card originals stay untouched."
           ],
           "tips": [
             "Template tokens include {filename}, {sequence}, {custom}, {camera}, {yyyy}, {mm}, and {dd}. Start at controls the four-digit sequence.",
-            "The selection list currently shows up to 200 files per scan. Only checked entries in that list are submitted. Check the completed count when working with a larger card.",
+            "Previews show 200 files per page. Selection carries across pages; Select all and Select none apply to the whole scan, including pages you have not opened.",
             "If files are reported as cloud-only, download them locally and scan again."
           ]
         },
         {
           "title": "Refresh the plan when settings change",
           "paragraphs": [
-            "Scan again after changing the destination or naming templates so you can review the updated paths before importing."
+            "Changing the source, destination, naming, or verification settings clears the reviewed plan. Scan again to review the new files and paths before importing."
           ]
         }
       ],
@@ -288,7 +288,7 @@
         {
           "title": "Describe the photo",
           "paragraphs": [
-            "In Info, expand Description for title, caption, and headline; Rights for creator, copyright, and credit; or Place for location and coordinates. Changes save to the catalog as you type.",
+            "In Info, expand Description for title, caption, and headline; Rights for creator, copyright, and credit; or Place for location and coordinates. Changes save to the catalog as you type. Open in Maps is available after this photo’s metadata loads and both latitude and longitude are valid. It opens the location in your browser.",
             "Apply to selection copies the current metadata form to selected photos, including its blank fields. Review the whole form first. Metadata is included in exports according to the export recipe; editing these fields does not rewrite the original image file."
           ]
         }
@@ -312,7 +312,10 @@
         "sidebar",
         "missing photos",
         "rescan",
-        "synchronize"
+        "synchronize",
+        "watch folder",
+        "watched folders",
+        "tethering"
       ],
       "sections": [
         {
@@ -332,6 +335,14 @@
           "paragraphs": [
             "A folder’s ••• menu includes Show in Finder on Mac or Show in File Explorer on Windows. For the current folder, Synchronize Folder refreshes the view. Local ••• → Rescan folders scans the catalog sources.",
             "Remove from LightTable removes an added root from the app’s source list; it does not move the original files to the Trash. The action is offered when more than one source is available."
+          ]
+        },
+        {
+          "title": "Manage watched folders",
+          "paragraphs": [
+            "Open Local ••• → Watch folder… to add a watched folder. Choose how arriving photos should be handled. Save is unavailable until a folder is specified; copying into the library also requires a destination.",
+            "To edit an existing watch, choose it in Watched folders. Every saved watch appears in this list. Choose New watched folder for another folder, or use Delete watch to stop watching the selected folder. This does not delete its photos.",
+            "The Watching shortcut opens the first active watch. Save errors stay in the dialog so you can correct the settings."
           ]
         }
       ],
@@ -1397,7 +1408,7 @@
         {
           "title": "Create a manual mask",
           "paragraphs": [
-            "Open Mask in the editing toolbar and choose a tool under Create New Mask. Each mask has its own Light and Color adjustments.",
+            "Open Mask in the editing toolbar and choose a tool under Create New Mask. Click Create New Mask to show or hide the tools. Each mask has its own Light and Color adjustments.",
             "Texture and Clarity use the image after global adjustments and earlier masks. These controls require a preview update; wait for it to finish before judging the result."
           ],
           "steps": [
@@ -1410,7 +1421,7 @@
           "tips": [
             "Add, Subtract, and Intersect put you in painting refinement modes. For a Linear or Radial mask, choose Edit Shape to return to manipulating its shape.",
             "Enable temporarily switches a mask’s effect off or on. Invert reverses its selection.",
-            "The editor allows up to sixteen local masks. Delete Mask removes the selected mask; Clear All removes the photo’s masks.",
+            "The editor allows up to sixteen local masks. Delete Mask removes the selected mask; Clear All removes the photo’s masks and is unavailable when there are none.",
             "Mask pins and brush outlines stay sharp and the same thickness as you zoom. The outline grows with the area it covers in the photo."
           ]
         }
@@ -1601,7 +1612,7 @@
           ],
           "tips": [
             "Remove does not expose a source circle or Refresh Source. Those source controls apply to Heal and Clone.",
-            "Clear All removes the photo’s Remove, Heal, and Clone corrections. Use Undo to reverse an accidental editing change."
+            "Clear All removes the photo’s Remove, Heal, and Clone corrections and is unavailable when there are none. Use Undo to reverse an accidental editing change."
           ]
         }
       ],
@@ -1631,7 +1642,7 @@
         {
           "title": "Check that your work is saved",
           "paragraphs": [
-            "Adjustments are stored as edit settings for the photo. The editor saves changes automatically as you finish interactions; you do not need a separate Save command for each adjustment."
+            "Editing controls are unavailable until a photo is loaded. Adjustments are stored as edit settings for the photo. The editor saves changes automatically as you finish interactions; you do not need a separate Save command for each adjustment."
           ],
           "steps": [
             "Make your adjustment, then check the save status in the app.",
@@ -1867,7 +1878,7 @@
             "After completion, find the new result in the refreshed library and inspect it."
           ],
           "tips": [
-            "Super resolution has no bundled model and requires a compatible local model. A listed option alone does not mean that operation is available.",
+            "Unavailable enhancements are disabled. Super resolution has no bundled model and requires a compatible model installed locally.",
             "Enhancement can generate detail; evaluate the output before treating it as a faithful record of fine texture."
           ]
         }
@@ -1912,7 +1923,7 @@
         {
           "title": "Keep a named look",
           "paragraphs": [
-            "A snapshot stores the photo’s current adjustment settings, crop, masks, Remove corrections, and optics. It is a saved editing state for this photo."
+            "A snapshot stores the photo’s current adjustment settings, crop, masks, Remove corrections, and optics. It is a saved editing state for this photo. Create snapshot is unavailable until a photo is loaded."
           ],
           "steps": [
             "Open History, expand Snapshots, and click Create snapshot.",
@@ -2688,7 +2699,7 @@
         {
           "title": "Back up and inspect",
           "paragraphs": [
-            "Settings → Catalog shows the catalog location and backup preferences. Backups include catalog organization, edits, stored masks, history, and variants. Back up original photos, external presets and profiles, and preferences separately."
+            "Settings → Catalog shows the catalog location and backup preferences. Backups include catalog organization, edits, stored masks, history, and variants. Back up original photos, external presets and profiles, and preferences separately. Local ••• → Back up catalog… also creates a backup and shows its saved path or error in a results dialog. Find duplicates in the same menu shows matching files, or reports that none were found."
           ],
           "steps": [
             "Choose an Automatic backup interval and Backup location.",

--- a/web/index.html
+++ b/web/index.html
@@ -248,7 +248,7 @@
           <button class="quiet icon-btn" id="filmstripToggle" title="Show or hide filmstrip" aria-label="Show or hide filmstrip">
             <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M2.5 5h15v10h-15zM6 5v10M14 5v10"/></svg>
           </button>
-          <button class="quiet" id="beforeBtn" title="Hold to view unedited (B)">Original</button>
+          <button class="quiet" id="beforeBtn" title="Hold to view unedited (B)" disabled>Original</button>
           <button class="quiet" id="compareBtn" type="button" aria-pressed="false" title="Toggle split before and after view (\)" disabled>Compare</button>
           <button class="quiet compact" id="compareReturn" type="button" hidden>Return to tool</button>
           <button class="quiet compact" id="softProofToolbar" type="button" aria-pressed="false" title="Turn off soft proof" hidden>Soft Proof on</button>
@@ -258,8 +258,8 @@
           <button class="quiet icon-btn" id="zoomOut" title="Zoom out" aria-label="Zoom out">&minus;</button>
           <span class="zoom-value" id="zoomVal">100%</span>
           <button class="quiet icon-btn" id="zoomIn" title="Zoom in" aria-label="Zoom in">+</button>
-          <button class="quiet compact on" id="zoomFit" aria-pressed="true" title="Fit the whole photo to the available space">Fit</button>
-          <button class="quiet compact" id="zoom1" aria-pressed="false">1:1</button>
+          <button class="quiet compact on" id="zoomFit" aria-pressed="true" title="Fit the whole photo to the available space" disabled>Fit</button>
+          <button class="quiet compact" id="zoom1" aria-pressed="false" disabled>1:1</button>
         </div>
         <div class="under-group marking-tools">
           <div class="cullbar-segment cullbar-flags" role="group" aria-label="Flag">
@@ -297,11 +297,11 @@
 
     <div class="panel" id="panel">
       <section class="panel-pane on" id="editPane">
-        <div class="panel-title panel-title-compact"><strong>Edit</strong><button class="quiet compact" id="resetEdit" title="Reset global tone, color, curves, sharpening, noise reduction, and effects">Reset</button></div>
+        <div class="panel-title panel-title-compact"><strong>Edit</strong><button class="quiet compact" id="resetEdit" title="Reset global tone, color, curves, sharpening, noise reduction, and effects" disabled>Reset</button></div>
         <div class="histogram-wrap">
           <canvas id="hist" width="300" height="110"></canvas>
           <span class="hist-label hist-black" id="scopeLowLabel">0</span><span class="hist-label hist-white" id="scopeHighLabel">255</span>
-          <button class="histogram-clip quiet icon-btn" id="clipBtn" title="Clipping warning" aria-label="Clipping warning"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m10 3 7 13H3z"/></svg></button>
+          <button class="histogram-clip quiet icon-btn" id="clipBtn" title="Clipping warning" aria-label="Clipping warning" disabled><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m10 3 7 13H3z"/></svg></button>
           <button class="scope-menu-button quiet compact" id="scopeMenuButton" type="button" aria-expanded="false" aria-controls="scopeMenu"><span id="scopeMenuLabel">Histogram</span><span aria-hidden="true">⌄</span></button>
           <div class="scope-menu context-menu" id="scopeMenu" role="menu" aria-hidden="true">
             <button type="button" data-scope="histogram" aria-pressed="true">Histogram</button>
@@ -312,7 +312,7 @@
         </div>
 
         <details class="sec" id="lightSection" open>
-          <summary><span>Light</span><span class="summary-actions"><button class="quiet compact section-action" id="autoBtn" type="button" title="Automatically set tone">Auto</button><a class="reset" href="#" data-reset="tone" title="Reset Exposure, Contrast, Highlights, Shadows, Whites, and Blacks">Reset</a></span></summary>
+          <summary><span>Light</span><span class="summary-actions"><button class="quiet compact section-action" id="autoBtn" type="button" title="Automatically set tone" disabled>Auto</button><a class="reset" href="#" data-reset="tone" title="Reset Exposure, Contrast, Highlights, Shadows, Whites, and Blacks">Reset</a></span></summary>
           <div class="secbody">
             <div class="row"><span class="name">Exposure</span><input type="range" data-g="exposure" min="-3" max="3" step="0.01" value="0"><span class="val" data-gv="exposure">0.00</span></div>
             <div class="row"><span class="name">Contrast</span><input type="range" data-g="contrast" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="contrast">0.00</span></div>
@@ -326,7 +326,7 @@
         <details class="sec">
           <summary><span>Color</span><a class="reset" href="#" data-reset="colour" title="Reset white balance, Vibrance, Saturation, Color Mixer, Point Color, and Color Grading">Reset</a></summary>
           <div class="secbody">
-            <div class="row row-with-action"><span class="name">Temp</span><input type="range" data-g="temp" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="temp">0.00</span><button class="quiet icon-btn row-action" id="wbBtn" type="button" title="Click a neutral area to set white balance" aria-label="White balance eyedropper"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 15 8-8M11 5l4 4M4 16l3-.5-2.5-2.5z"/></svg></button></div>
+            <div class="row row-with-action"><span class="name">Temp</span><input type="range" data-g="temp" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="temp">0.00</span><button class="quiet icon-btn row-action" id="wbBtn" type="button" title="Click a neutral area to set white balance" aria-label="White balance eyedropper" disabled><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 15 8-8M11 5l4 4M4 16l3-.5-2.5-2.5z"/></svg></button></div>
             <div class="row"><span class="name">Tint</span><input type="range" data-g="tint" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="tint">0.00</span></div>
             <div class="row"><span class="name">Vibrance</span><input type="range" data-g="vibrance" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="vibrance">0.00</span></div>
             <div class="row"><span class="name">Saturation</span><input type="range" data-g="saturation" min="-1" max="1" step="0.01" value="0"><span class="val" data-gv="saturation">0.00</span></div>
@@ -441,7 +441,7 @@
       </section>
 
       <section class="panel-pane" id="maskPane">
-        <div class="panel-title"><div><strong>Masking</strong><span>Create and refine local adjustments</span></div><button class="quiet compact" id="maskReset" title="Delete all masks and their local adjustments from this photo">Clear All</button></div>
+        <div class="panel-title"><div><strong>Masking</strong><span>Create and refine local adjustments</span></div><button class="quiet compact" id="maskReset" title="Delete all masks and their local adjustments from this photo" disabled>Clear All</button></div>
         <div class="pane-content local-pane-content">
           <button class="quiet compact tool-back" type="button" data-exit-tool>Back to Edit</button>
           <button class="mask-create-toggle" id="maskCreateToggle" type="button" aria-expanded="true">
@@ -537,7 +537,7 @@
       </section>
 
       <section class="panel-pane" id="healPane">
-        <div class="panel-title"><div><strong>Remove</strong><span>Clean up spots and distractions</span></div><button class="quiet compact" id="healReset" title="Delete all Remove, Heal, and Clone corrections from this photo">Clear All</button></div>
+        <div class="panel-title"><div><strong>Remove</strong><span>Clean up spots and distractions</span></div><button class="quiet compact" id="healReset" title="Delete all Remove, Heal, and Clone corrections from this photo" disabled>Clear All</button></div>
         <div class="pane-content local-pane-content">
           <button class="quiet compact tool-back" type="button" data-exit-tool>Back to Edit</button>
           <div class="heal-mode-grid" role="group" aria-label="Removal mode">
@@ -709,12 +709,12 @@
           <p class="pane-note">History is stored in the catalog, so it survives quitting. Undo and redo follow each photo during this session.</p>
           <details class="info-section" id="versionsPane">
             <summary>Snapshots</summary>
-            <div class="info-section-body"><button class="primary-btn full" id="versionCreate">Create snapshot</button><div class="version-list" id="versionList"></div></div>
+            <div class="info-section-body"><button class="primary-btn full" id="versionCreate" disabled>Create snapshot</button><div class="version-list" id="versionList"></div></div>
           </details>
         </div>
       </section>
 
-      <section id="catalogSupport" hidden><span id="catalogSummary">—</span><div class="source-list" id="catalogSources">—</div><div id="importReport" class="exif"></div><div id="catalogMaintenance" class="exif"></div><div class="source-list watch-list" id="watchList"></div></section>
+      <section id="catalogSupport" hidden><span id="catalogSummary">—</span><div class="source-list" id="catalogSources">—</div><div id="importReport" class="exif"></div><div id="catalogMaintenance" class="exif"></div></section>
 
       <section class="panel-pane" id="infoPane">
         <div class="panel-title"><div><strong>Info</strong><span>Photo details and metadata</span></div></div><p class="hint pair-note" id="pairedMetadataNote" hidden></p>
@@ -833,7 +833,7 @@
     <p class="hint" id="enhanceNote">Create an enhanced derivative and keep the original untouched.</p>
     <label class="field-label" for="enhanceMode">Enhancement</label>
     <select id="enhanceMode"><option value="denoise">Denoise</option><option value="upscale">Super resolution</option></select>
-    <div class="modal-actions"><button class="quiet" id="enhanceDialogCancel">Cancel</button><button class="primary-btn" id="enhanceRun">Enhance</button></div>
+    <div class="modal-actions"><button class="quiet" id="enhanceDialogCancel">Cancel</button><button class="primary-btn" id="enhanceRun" disabled>Enhance</button></div>
   </div>
 </div>
 
@@ -884,6 +884,14 @@
   </div>
 </div>
 
+<div class="modal-backdrop" id="catalogResultDialog" aria-hidden="true">
+  <div class="modal modal-wide" role="dialog" aria-modal="true" aria-labelledby="catalogResultTitle">
+    <strong id="catalogResultTitle">Catalog</strong>
+    <div id="catalogResultBody" class="catalog-result-body" role="status"></div>
+    <div class="modal-actions"><button id="catalogResultClose" type="button" title="Close the catalog results">Close</button></div>
+  </div>
+</div>
+
 <div class="modal-backdrop" id="ingestDialog" aria-hidden="true">
   <div class="modal modal-wide" role="dialog" aria-modal="true" aria-labelledby="ingestTitle">
     <strong id="ingestTitle">Import from card</strong>
@@ -891,9 +899,17 @@
       <div class="ingest-row">
         <label class="field grow"><span>Source</span><input id="ingestSource" type="text" placeholder="Choose a card or folder"></label>
         <button id="ingestChoose" class="quiet compact">Choose…</button>
-        <button id="ingestScan" class="quiet compact">Scan</button>
+        <button id="ingestScan" class="quiet compact" title="Review photos from the source using the destination and naming settings">Scan</button>
       </div>
-      <div class="ingest-status" id="ingestStatus">Choose a card to begin.</div>
+      <div class="ingest-status" id="ingestStatus" role="status">Choose a source and destination, then scan.</div>
+      <div class="ingest-row" id="ingestSelection" hidden>
+        <button id="ingestSelectAll" class="quiet compact" title="Select every photo across all pages" type="button">Select all</button>
+        <button id="ingestSelectNone" class="quiet compact" title="Clear the selection across all pages" type="button">Select none</button>
+        <span class="grow"></span>
+        <button id="ingestPrevious" class="quiet compact" title="Show the previous page of photos" type="button">Previous</button>
+        <span id="ingestPage" class="ingest-status"></span>
+        <button id="ingestNext" class="quiet compact" title="Show the next page of photos" type="button">Next</button>
+      </div>
       <div class="ingest-grid" id="ingestGrid"></div>
       <div class="ingest-row">
         <label class="field grow"><span>Destination</span><input id="ingestDest" type="text"></label>
@@ -922,6 +938,7 @@
 <div class="modal-backdrop" id="watchDialog" aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" aria-labelledby="watchTitle">
     <strong id="watchTitle">Watch a folder</strong>
+    <label class="field" id="watchExistingRow" hidden><span>Watched folders</span><select id="watchExisting"><option value="">New watched folder</option></select></label>
     <input id="watchId" type="hidden">
     <label class="field"><span>Name</span><input id="watchName" type="text" maxlength="80" placeholder="Capture"></label>
     <div class="ingest-row">
@@ -936,8 +953,8 @@
     <label class="field"><span>Apply preset</span><select id="watchPreset"><option value="">None</option></select></label>
     <label class="check-row"><input type="checkbox" id="watchRecursive"><span>Include subfolders</span></label>
     <label class="check-row"><input type="checkbox" id="watchFollow"><span>Follow the newest arrival when I am not culling</span></label>
-    <p class="hint" id="watchStatus">The watched folder is never changed, moved, or emptied.</p>
-    <div class="modal-actions"><button class="text-btn negative" id="watchDelete" hidden>Delete watch</button><span class="grow"></span><button id="watchCancel">Cancel</button><button class="accent-btn" id="watchSave">Save</button></div>
+    <p class="hint" id="watchStatus" role="status">The watched folder is never changed, moved, or emptied.</p>
+    <div class="modal-actions"><button class="text-btn negative" id="watchDelete" hidden>Delete watch</button><span class="grow"></span><button id="watchCancel">Cancel</button><button class="accent-btn" id="watchSave" disabled>Save</button></div>
   </div>
 </div>
 

--- a/web/metadata-panel.js
+++ b/web/metadata-panel.js
@@ -37,12 +37,35 @@ export function createMetadataPanel(ctx) {
   let pendingSave = null;
   let saveChain = Promise.resolve();
   let refreshSequence = 0;
+  let loadedName = null;
+
+  function coordinates() {
+    const latText = String(el('iptcLat')?.value ?? '').trim();
+    const lonText = String(el('iptcLon')?.value ?? '').trim();
+    if (!latText || !lonText) return null;
+    const lat = Number(latText);
+    const lon = Number(lonText);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)
+        || Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
+    return { lat, lon };
+  }
+
+  function canOpenMap() {
+    return !loading && Boolean(currentName) && loadedName === currentName
+      && Boolean(coordinates());
+  }
+
+  function syncMapAvailability() {
+    const mapLink = el('iptcMapLink');
+    if (mapLink) mapLink.disabled = !canOpenMap();
+  }
 
   function setLoading(value) {
     loading = value;
     for (const id of [...Object.keys(FIELDS), ...Object.keys(GPS_FIELDS)]) {
       if (el(id)) el(id).disabled = value || !currentName;
     }
+    syncMapAvailability();
   }
 
   function flushSave() {
@@ -76,14 +99,13 @@ export function createMetadataPanel(ctx) {
   }
 
   function queueSave() {
+    syncMapAvailability();
     if (loading || !currentName) return;
     // A later navigation must not change either the destination or the values.
     pendingSave = { name: currentName, fields: collect() };
     clearTimeout(saveTimer);
     saveTimer = setTimeout(flushSave, 500);
   }
-
-  let loadedName = null;
 
   async function refresh(name, force = false) {
     const saving = flushSave();
@@ -168,15 +190,15 @@ export function createMetadataPanel(ctx) {
     const mapLink = el('iptcMapLink');
     if (mapLink) {
       mapLink.addEventListener('click', () => {
-        const lat = Number(el('iptcLat') && el('iptcLat').value);
-        const lon = Number(el('iptcLon') && el('iptcLon').value);
-        if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+        if (!canOpenMap()) {
           toast('Add a latitude and longitude first');
           return;
         }
+        const { lat, lon } = coordinates();
         window.open(`https://maps.apple.com/?ll=${lat},${lon}&q=Photo`,
                     '_blank', 'noopener');
       });
+      syncMapAvailability();
     }
 
     const applyAll = el('iptcApplyAll');

--- a/web/style.css
+++ b/web/style.css
@@ -1297,6 +1297,8 @@ a.reset:hover { color:#fff; }
 
 /* -------------------------------------------------------------- video */
 
+.panel-pane[inert] { opacity:.45; }
+
 .video-stage {
   position:absolute; inset:0; z-index:20; display:flex; flex-direction:column;
   align-items:center; justify-content:center; gap:12px; padding:16px;
@@ -1558,6 +1560,7 @@ a.reset:hover { color:#fff; }
   padding-top: 14px;
   border-top: 1px solid var(--line-soft);
 }
+.catalog-result-body { white-space:pre-wrap; overflow:auto; max-height:55vh; margin:12px 0; font-size:12px; line-height:1.6; overflow-wrap:anywhere; }
 .ingest-body { display:flex; flex-direction:column; gap:8px; }
 .ingest-row { display:flex; gap:8px; align-items:flex-end; flex-wrap:wrap; }
 .ingest-row > .field { min-width:120px; flex:1 1 auto; }

--- a/web/survey.js
+++ b/web/survey.js
@@ -24,6 +24,7 @@ export function createSurvey(ctx) {
   const container = el('survey');
   const grid = el('surveyGrid');
   const title = el('surveyTitle');
+  const swapButton = el('surveySwap');
 
   function imageFor(name) {
     return (ctx.images() || []).find((image) => image.name === name) || null;
@@ -86,6 +87,10 @@ export function createSurvey(ctx) {
   function render() {
     if (!container || !grid) return;
     const rows = names.map(imageFor).filter(Boolean);
+    if (swapButton) {
+      swapButton.hidden = mode !== 'compare';
+      swapButton.disabled = mode !== 'compare' || rows.length < 2;
+    }
     if (title) {
       title.textContent = mode === 'compare'
         ? `Compare ${rows.length} photos`
@@ -144,7 +149,7 @@ export function createSurvey(ctx) {
   }
 
   function swap() {
-    if (mode !== 'compare' || names.length < 2) return;
+    if (mode !== 'compare' || names.map(imageFor).filter(Boolean).length < 2) return;
     names = [names[1], names[0]];
     render();
   }


### PR DESCRIPTION
Several controls appeared available but did nothing, and clearing the import selection could import every photo. This fixes the 14 findings from the control audit: empty selections are rejected, import selection covers every page, and Cancel stops the active import after its current copy is verified.

- Show catalog backup, duplicate-search, and sidecar results in a visible dialog, including errors.
- Validate watched folders before saving and make every saved watch reachable for editing or deletion.
- Handle JavaScript confirmations and external HTTP(S) links in the Mac shell; require valid coordinates for Maps.
- Disable unsupported Enhance modes and photo-dependent controls until a photo is loaded; disable Clear All for empty lists.
- Make the mask disclosure and overflow buttons toggle correctly, and hide Swap outside Compare.
- Update in-app Help and add behavior regressions to the regular test suite.

Validation: the full suite on the updated main branch ran 1,268 tests successfully (16 platform/GPU/asset skips), including the new Node regressions. Help validation for all 55 articles, JavaScript syntax checks, and Swift typechecking passed. Actual browser interactions used disposable catalogs: imported all 201 selected photos; clearing all selections disabled Import; cancellation stopped after 38 verified copies while preserving all 201 originals. Also verified visible backup/duplicate/sidecar results, editing the second watched folder, Maps coordinate availability, empty-library controls, mask disclosure, Clear All, Survey, and overflow toggling.

Native confirmation and external-link helpers are tested and the Mac shell typechecks. Native Mac clicks, Windows runtime interaction, and installation are not verified in this change; native computer interaction is unavailable in this session.
