### PR TITLE
Add LightTable contact options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Rust and GPU-driven render core, and physical film simulation built on
 [Screenshots](https://lighttable.app/screenshots.html) ·
 [Features](https://lighttable.app/features.html) ·
 [Get started](#get-started) ·
-[Contribute](#contributing)
+[Contribute](#contributing) ·
+[Contact](#contact)
 
 For searchable guides inside the app, click **Help** in the top bar or press
 **F1** or **?**. Help is bundled for offline use and linked from inspector
@@ -192,6 +193,12 @@ and report what you verified.
 The [processing correctness pipeline](PROCESSING-CORRECTNESS.md) compares film
 stages, exports, and displayed previews with independent numerical references,
 and saves per-case pixel differences and CI reports.
+
+## Contact
+
+- [GitHub Issues](https://github.com/reville/lighttable-digital-darkroom/issues): bug reports and feature requests.
+- [GitHub Discussions](https://github.com/reville/lighttable-digital-darkroom/discussions): general questions and community conversation.
+- [team@lighttable.app](mailto:team@lighttable.app): private questions, collaboration, press, or just getting in touch.
 
 ## Project documentation
 


### PR DESCRIPTION
Adds a Contact section to the README with GitHub Issues for bug reports and feature requests, GitHub Discussions for general questions and community conversation, and team@lighttable.app for private questions, collaboration, press, or just getting in touch.

GitHub Issues and Discussions are enabled. The email forwarding rule is saved in Namecheap, and its mail server accepts the team address.

Validation: git diff --check and all applicable GitHub checks passed. Repository settings and discussion categories were verified through the GitHub API. This change only updates the README.
