### PR TITLE
Use larger icon-only sidebar buttons

### DIFF
--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -336,7 +336,8 @@
       {
         "title": "Move between views",
         "paragraphs": [
-          "Photo Grid presents photos as a visual overview. Culling Grid adds room for selection and rating information. Detail opens the active photo for close inspection."
+          "Photo Grid presents photos as a visual overview. Culling Grid adds room for selection and rating information. Detail opens the active photo for close inspection.",
+          "The right sidebar uses icon buttons for Edit, Film, Crop, Remove, Masking, Info, History, and Presets. Hover over an icon to see its name."
         ],
         "steps": [
           "Use the three Photo view buttons at the top. In the LightTable shortcut scheme, G opens Photo Grid, Shift+G opens Culling Grid, and D opens Detail.",

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -5,14 +5,14 @@
       "sources": {
         "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
         "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "assisted-culling": {
       "content": "9af5dd7b18ed0202de1d8db1948c95b8f5f6a7273e97b3f6c02fb029296a5f60",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/local-ai.js": "7fd3cc2435b3905a0ba3952e9365db5924a3d2230a8f1effdef6eb923287a545"
       }
     },
@@ -21,21 +21,21 @@
       "sources": {
         "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "capture-time": {
       "content": "088465f98807f47c7b775777ca5f782cbfdf239e43af199a5d52c2d8795c1f22",
       "sources": {
         "web/capture-time.js": "53054dc9c78513c2a8d8cee51c91fdc01a4020fe4eeedd0b256a6630b8f57039",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "catalog-health-recovery": {
       "content": "41e3f81ef36412cf1ec4ce0f431988f484834120a750a45d31a1fef66365c718",
       "sources": {
         "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb"
       }
@@ -44,7 +44,7 @@
       "content": "977ba37bd8ff1b6b181aeffccaa24ca482b06d59b3371e7463e1faa96f6191e7",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "colour-labels": {
@@ -58,14 +58,14 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "b0e38986c30ea898f08b9f26c3b362f9501905dfc5b3f744b35dfa93fac5e776",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-copy-paste-match-exposure": {
@@ -80,14 +80,14 @@
     "editing-crop-geometry": {
       "content": "847f666d8a355cae0104998f95f855baf7de6490a8445d2603e67e681623393c",
       "sources": {
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-curves": {
       "content": "498bf3ffd912c4de38f040a476a0a4d47236f02de2389e7f2faa2764fd231199",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-detail-effects-enhance": {
@@ -96,7 +96,7 @@
         "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-effects": {
@@ -104,7 +104,7 @@
       "sources": {
         "grade.py": "fb353c05fa51927d0b12cc60c3d4b216db35199ddc5c409d85b94e8ffc682575",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-history-snapshots": {
@@ -112,14 +112,14 @@
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
         "web/history-panel.js": "cd627083e934d0e3601d0d8a1c1a605c110c1c164bc83c91ab6df65034810db6",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-masks-ai": {
@@ -127,14 +127,14 @@
       "sources": {
         "semantic_masks.py": "1fde2645be458771b694bfb913e6443a5c771968b0b66908bb510db15dc87b48",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "283185725633efc67f5650a6135ca43e1b5264cc99469221a8c5e4aca57383ef",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
     },
@@ -142,7 +142,7 @@
       "content": "30a985ed6dc45dceaf2b898bd62b60452a0df6395d63a0060b93c3c2862fada2",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-photo-merge": {
@@ -152,7 +152,7 @@
         "merge_workflow.py": "af4489a9b4bdeb2374640e59d09a65b567a65da6b04ad7519b6d390eabee8e91",
         "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-presets": {
@@ -164,7 +164,7 @@
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/preset-browser.css": "b83edbc52e4a3f4fa24161fa9501b39bb73582eaefa72551f412a03e11c5d246",
         "web/preset-browser.js": "ba0eaa2c1617814d25da6d2fd92e24961f2de4a4012acf6ba38773cb002bf465",
         "web/presets.js": "1ce2d7d1772bf0e46dc46c54f90ba7b2701a8c1eff0232a22bace13e62ae665f"
@@ -174,7 +174,7 @@
       "content": "6a0e41eb99b3db975e6818c4c431006fcd7a0e20abc452baef943c1b89037dc2",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
     },
@@ -189,14 +189,14 @@
       "content": "7558b9922bbf1501ae4fcaa7ec5a7257078a4bd5f7b02e995b1c2eeac731b9a4",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "editing-white-balance": {
       "content": "ef6c9baa924103c29e019f7d095f6645a7d34b8059cb118b66c749c01480a6d7",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "export-filenames-and-folders": {
@@ -204,7 +204,7 @@
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "export-format-color-space": {
@@ -212,14 +212,14 @@
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "export-metadata-sidecars": {
       "content": "261f370f2dc294998ff6bf5616fae9dfec97fcae48e74c49329fe2a9f756111a",
       "sources": {
         "export_workflow.py": "2df7f8636b686b7fb1675e24876ce828fdcf6879e35f816daff1230810878f01",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "export-photos": {
@@ -227,14 +227,14 @@
       "sources": {
         "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "external-editor": {
       "content": "a3d13d1cb1925ce67e1e93eb91dae2e189e700a3f40d66a11c658fe392a4e306",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "film-exposure-and-processing": {
@@ -242,7 +242,7 @@
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "film-getting-started": {
@@ -250,15 +250,15 @@
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
-        "web/style.css": "e284c41a3600e070bbb841dff1c7879b63ef3a83f685dce612359ad58ca63be8"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
+        "web/style.css": "2d0b9b71bf7a09d6dfde9b8432937447b2618397a82f7bc688d3e6d2a33cf961"
       }
     },
     "film-grain-and-format": {
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "film-halation-diffusion-scan": {
@@ -266,7 +266,7 @@
       "sources": {
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "film-negative-paper-and-slides": {
@@ -275,14 +275,14 @@
         "film_pipeline.py": "0a9da4c2f7098dfa1767917517a8f11bd3af6933b543fa3ee22a815fc17883ab",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
         "web/film-browser.js": "bda9ef862d3cedee30e55328ea02b8048064387d67552eb39d5a8d8b60b42e61",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "flags-and-ratings": {
@@ -297,7 +297,7 @@
       "sources": {
         "ingest_workflow.py": "0443851f307f0a4bef9c724f4e119996e579233a52dbdffdd5cb256b49b3f413",
         "web/catalog-ui.js": "5ae50a657708474c7569913eb50905acf2a96730683f49592093246353af36bd",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "import-lightroom-catalog": {
@@ -306,7 +306,7 @@
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "a9b725213efd2eb42c1798717259d6ef8c70a351146097e34d7797b3c35d8291",
         "web/catalog-ui.js": "5ae50a657708474c7569913eb50905acf2a96730683f49592093246353af36bd",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "keyboard-midi": {
@@ -314,7 +314,7 @@
       "sources": {
         "app/main.swift": "37445f4c3aca195ba1614131a98de89e21391e3ec3aa8bb7c912ec553e325869",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
       }
     },
@@ -334,12 +334,12 @@
         "grade.py": "fb353c05fa51927d0b12cc60c3d4b216db35199ddc5c409d85b94e8ffc682575",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/preview-detail.js": "9fd803f1c070fba51f7466e03ca45c1c7b802765d48f943b2d510a23f368b595",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "4f9101296cb8bf1c269b20afe60ef13d3cb2903733c74fcd733e97db7cb61947",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb",
-        "web/style.css": "e284c41a3600e070bbb841dff1c7879b63ef3a83f685dce612359ad58ca63be8",
+        "web/style.css": "2d0b9b71bf7a09d6dfde9b8432937447b2618397a82f7bc688d3e6d2a33cf961",
         "web/view-performance.js": "8284cb871f75d1774996af75f78a434af92d33a001e647ab64a2fac0fa88fb6c"
       }
     },
@@ -348,14 +348,14 @@
       "sources": {
         "film_lab_ai/providers.py": "ff2e49c21a3ab2285ee1f3a1f438b14868a6e3f5a15c5d04d4cde1131521b7fd",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "raw-jpeg-pairs": {
       "content": "da12918a5daaf43a611386d4a8d7c2d5cc59b9a9cf4d85bb76efa3cb2c543f6e",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -373,7 +373,7 @@
         "catalog_scan.py": "1a5179c94b5c0a2e27990765fb1a20978e7de1631b9e07692fcb4acfe7dbeee9",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/library-filters.js": "e7dcf58cdd378a68797023a54052c54e40bd507320fda116e3190abfcd90667c",
         "web/library.js": "28fd7b59813710582e54ea1950c7a9e66223b4f7681657057a018ae5e0b9cd2e"
       }
@@ -381,7 +381,7 @@
     "settings-and-defaults": {
       "content": "1cde6311046ebd3780715b226c84b72c16aef9f5396294f54489936d21b64232",
       "sources": {
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/settings.js": "f39da91d035f46b693cad463fb31d6c8f65d111f69468f769a1ec8eb8587a6fb"
       }
     },
@@ -389,7 +389,7 @@
       "content": "9117f2d6a953f9a3f836b91420b22d75cc570201d2d5cc822f2adf7e64f9d224",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
         "web/labels.js": "4b56076017a4e70eb5b2f1f2b5d7cbb51f458628e6c3171432d819561aaa418e"
       }
     },
@@ -406,7 +406,7 @@
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56"
       }
     },
     "survey-photos": {
@@ -425,12 +425,12 @@
       }
     },
     "views-and-selection": {
-      "content": "9ebb5b5cdb1366a1d628888627cd133347341b2820fcddae7bcbeae8f129d07f",
+      "content": "3b3c5e71abbe3bb69e1246986ddf4aa7906a266198e1546bec46c23283be4352",
       "sources": {
         "web/app.js": "35f9a62bb30bbaba3160cb521b9f15da6319ba9477837d0eea682f4e87463fab",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
-        "web/index.html": "fb6ef35912f240ad5036e9ceae7b5fb2d2dcc728f20d63340551aac25fa72116",
-        "web/style.css": "e284c41a3600e070bbb841dff1c7879b63ef3a83f685dce612359ad58ca63be8"
+        "web/index.html": "aa6f37b1480ba6bcd8649d7246bd5ce30b291abc80579c194365878725d5be56",
+        "web/style.css": "2d0b9b71bf7a09d6dfde9b8432937447b2618397a82f7bc688d3e6d2a33cf961"
       }
     },
     "virtual-copies-and-stacks": {

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -205,7 +205,8 @@
         {
           "title": "Move between views",
           "paragraphs": [
-            "Photo Grid presents photos as a visual overview. Culling Grid adds room for selection and rating information. Detail opens the active photo for close inspection."
+            "Photo Grid presents photos as a visual overview. Culling Grid adds room for selection and rating information. Detail opens the active photo for close inspection.",
+            "The right sidebar uses icon buttons for Edit, Film, Crop, Remove, Masking, Info, History, and Presets. Hover over an icon to see its name."
           ],
           "steps": [
             "Use the three Photo view buttons at the top. In the LightTable shortcut scheme, G opens Photo Grid, Shift+G opens Culling Grid, and D opens Detail.",

--- a/web/index.html
+++ b/web/index.html
@@ -285,14 +285,14 @@
 
   <aside class="right-shell" id="rightShell">
     <nav class="toolrail" aria-label="Photo tools">
-      <button class="tool-btn on" data-pane="editPane" title="Edit" aria-label="Edit"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 5h12M7 3v4M4 10h12M13 8v4M4 15h12M9 13v4"/></svg><span>Edit</span></button>
-      <button class="tool-btn" data-pane="filmPane" title="Film" aria-label="Film"><svg viewBox="0 0 20 20" aria-hidden="true"><rect x="3" y="4" width="14" height="12" rx="1"/><path d="M7 4v12M13 4v12M3 8h4M13 8h4M3 12h4M13 12h4"/></svg><span>Film</span></button>
-      <button class="tool-btn" data-pane="cropPane" title="Crop and rotate" aria-label="Crop and rotate"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M5 2v11a2 2 0 0 0 2 2h11M2 5h11a2 2 0 0 1 2 2v11"/></svg><span>Crop</span></button>
-      <button class="tool-btn" data-pane="healPane" title="Remove (Q)" aria-label="Remove"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 14 9-9a2.1 2.1 0 0 1 3 3l-9 9a2.1 2.1 0 0 1-3-3zM10 9l3 3M3 6h4M5 4v4"/></svg><span>Remove</span></button>
-      <button class="tool-btn" data-pane="maskPane" title="Masking (M)" aria-label="Masking"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="6.5"/><path d="M10 3.5a6.5 6.5 0 0 1 0 13M10 6.5v7M6.5 10h7"/></svg><span>Mask</span></button>
-      <button class="tool-btn" data-pane="infoPane" title="Info and keywords" aria-label="Info and keywords"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="7"/><path d="M10 9v5M10 6.5h.01"/></svg><span>Info</span></button>
-      <button class="tool-btn" data-pane="historyPane" title="History" aria-label="History"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M3 10a7 7 0 1 0 2-4.9M3 3v3h3M10 6v4.5l3 1.8"/></svg><span>History</span></button>
-      <button class="tool-btn" data-pane="presetsPane" title="Presets" aria-label="Presets"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m10 2 1.5 4.5L16 8l-4.5 1.5L10 14l-1.5-4.5L4 8l4.5-1.5zM15.5 13l.7 2.3 2.3.7-2.3.7-.7 2.3-.7-2.3-2.3-.7 2.3-.7z"/></svg><span>Presets</span></button>
+      <button class="tool-btn on" data-pane="editPane" title="Edit" aria-label="Edit"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 5h12M7 3v4M4 10h12M13 8v4M4 15h12M9 13v4"/></svg></button>
+      <button class="tool-btn" data-pane="filmPane" title="Film" aria-label="Film"><svg viewBox="0 0 20 20" aria-hidden="true"><rect x="3" y="4" width="14" height="12" rx="1"/><path d="M7 4v12M13 4v12M3 8h4M13 8h4M3 12h4M13 12h4"/></svg></button>
+      <button class="tool-btn" data-pane="cropPane" title="Crop and rotate" aria-label="Crop and rotate"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M5 2v11a2 2 0 0 0 2 2h11M2 5h11a2 2 0 0 1 2 2v11"/></svg></button>
+      <button class="tool-btn" data-pane="healPane" title="Remove (Q)" aria-label="Remove"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 14 9-9a2.1 2.1 0 0 1 3 3l-9 9a2.1 2.1 0 0 1-3-3zM10 9l3 3M3 6h4M5 4v4"/></svg></button>
+      <button class="tool-btn" data-pane="maskPane" title="Masking (M)" aria-label="Masking"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="6.5"/><path d="M10 3.5a6.5 6.5 0 0 1 0 13M10 6.5v7M6.5 10h7"/></svg></button>
+      <button class="tool-btn" data-pane="infoPane" title="Info and keywords" aria-label="Info and keywords"><svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="7"/><path d="M10 9v5M10 6.5h.01"/></svg></button>
+      <button class="tool-btn" data-pane="historyPane" title="History" aria-label="History"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="M3 10a7 7 0 1 0 2-4.9M3 3v3h3M10 6v4.5l3 1.8"/></svg></button>
+      <button class="tool-btn" data-pane="presetsPane" title="Presets" aria-label="Presets"><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m10 2 1.5 4.5L16 8l-4.5 1.5L10 14l-1.5-4.5L4 8l4.5-1.5zM15.5 13l.7 2.3 2.3.7-2.3.7-.7 2.3-.7-2.3-2.3-.7 2.3-.7z"/></svg></button>
     </nav>
 
     <div class="panel" id="panel">

--- a/web/style.css
+++ b/web/style.css
@@ -777,8 +777,8 @@ body.filmstrip-resizing { cursor:ns-resize; user-select:none; }
 .app.grid-mode .panel { opacity:0; pointer-events:none; }
 .toolrail { grid-column:2; grid-row:1; display:flex; flex-direction:column; align-items:center; gap:2px; padding:7px 4px 12px; overflow-y:auto; border-left:1px solid var(--line-soft); background:linear-gradient(var(--inset) 92%,rgba(26,26,26,.76)); scrollbar-width:none; }
 .toolrail::-webkit-scrollbar { display:none; }
-.tool-btn { width:48px; min-height:46px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:3px; border:0; border-radius:var(--radius); padding:4px 2px; background:transparent; color:var(--muted); font-size:10px; font-weight:500; letter-spacing:.01em; }
-.tool-btn svg { width:19px; height:19px; }
+.tool-btn { width:48px; min-height:52px; flex-shrink:0; display:flex; align-items:center; justify-content:center; border:0; border-radius:var(--radius); padding:4px; background:transparent; color:var(--muted); }
+.tool-btn svg { width:24px; height:24px; }
 .tool-btn:hover { background:var(--hover); color:#fff; }
 .tool-btn.on { background:var(--active); color:#fff; }
 .tool-btn.on svg { color:var(--accent); }
@@ -1908,7 +1908,6 @@ body { display:flex; flex-direction:column; }
 .workspace-cullbar .cullbar-auto { width:auto; font-size:11px; }
 .cullbar-context strong { font-size:12px; }
 .cullbar-context span { color:var(--muted); font-size:11px; }
-.tool-btn { font-size:11px; }
 .panel-title { position:sticky; top:0; z-index:5; background:var(--edit-panel); }
 .panel .field-label, .panel .hint, .panel .check-row { font-size:12px; }
 .panel .hint { color:#b4b4ba; line-height:1.5; }


### PR DESCRIPTION
The eight sidebar tool buttons now show icons only, with names retained in tooltips and accessibility labels. Buttons increase from 48 × 46 to 48 × 52 pixels, and icons from 19 to 24 pixels. Sidebar width and tool order stay the same.

Updated the in-app Help description and reviewed its source records.

Validation: 16 focused Python tests and eight Help search tests passed; Help build/check and git diff --check passed. The local running preview confirmed all eight button dimensions, empty visible labels, retained names, and working panel switching. The installed app has not been rebuilt.
