### PR TITLE
Redesign the macOS About window

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -45,7 +45,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2026 Nicholas Reville. Bundled film-engine components are GPLv3.</string>
+	<string>Copyright © 2026 LightTable contributors. Free and open source under GNU GPL v3.</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/app/main.swift
+++ b/app/main.swift
@@ -933,6 +933,132 @@ func presetExportData(content: String, encoding: String = "utf8") throws -> Data
     }
 }
 
+// MARK: - About
+
+private final class AboutWindowController: NSWindowController {
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 408),
+            styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        window.title = "About LightTable"
+        window.isReleasedWhenClosed = false
+        window.isExcludedFromWindowsMenu = true
+        super.init(window: window)
+
+        guard let content = window.contentView else { return }
+        let icon = NSImageView()
+        icon.image = NSApp.applicationIconImage
+        icon.imageScaling = .scaleProportionallyUpOrDown
+        icon.setAccessibilityElement(false)
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 88),
+            icon.heightAnchor.constraint(equalToConstant: 88),
+        ])
+
+        let title = label("LightTable", size: 32, weight: .bold)
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+            as? String ?? "1.0"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        let versionText = build.map { $0 != version ? "Version \(version) (\($0))" : "Version \(version)" }
+            ?? "Version \(version)"
+        let identity = NSStackView(views: [
+            title, label(versionText, size: 12, color: .secondaryLabelColor),
+        ])
+        identity.orientation = .vertical
+        identity.alignment = .leading
+        identity.spacing = 6
+        let header = NSStackView(views: [icon, identity])
+        header.alignment = .centerY
+        header.spacing = 24
+
+        let divider = NSBox()
+        divider.boxType = .separator
+
+        let description = NSTextField(wrappingLabelWithString:
+            "Photo editing and realistic film simulation. Explore the source, report an issue, or contribute on GitHub.")
+        description.font = .systemFont(ofSize: 14)
+        description.textColor = .secondaryLabelColor
+        description.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        let openSource = NSStackView(views: [
+            label("Free and open source", size: 19, weight: .semibold), description,
+        ])
+        openSource.orientation = .vertical
+        openSource.alignment = .leading
+        openSource.spacing = 8
+
+        let website = linkButton("Website", symbol: "globe", action: #selector(openWebsite(_:)))
+        website.toolTip = "Open lighttable.app in your browser"
+        let github = linkButton("GitHub", symbol: "chevron.left.forwardslash.chevron.right",
+                                action: #selector(openGitHub(_:)))
+        github.toolTip = "View the LightTable source code on GitHub"
+        let links = NSStackView(views: [website, github])
+        links.distribution = .fillEqually
+        links.spacing = 16
+
+        let layout = NSStackView(views: [
+            header, divider, openSource, links,
+            label("Licensed under the GNU GPL v3.", size: 12, color: .secondaryLabelColor),
+        ])
+        layout.orientation = .vertical
+        layout.alignment = .leading
+        layout.spacing = 24
+        layout.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(layout)
+        NSLayoutConstraint.activate([
+            layout.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 32),
+            layout.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -32),
+            layout.topAnchor.constraint(equalTo: content.topAnchor, constant: 32),
+            layout.bottomAnchor.constraint(lessThanOrEqualTo: content.bottomAnchor, constant: -32),
+            header.widthAnchor.constraint(equalTo: layout.widthAnchor),
+            identity.trailingAnchor.constraint(equalTo: header.trailingAnchor),
+            divider.widthAnchor.constraint(equalTo: layout.widthAnchor),
+            openSource.widthAnchor.constraint(equalTo: layout.widthAnchor),
+            description.widthAnchor.constraint(equalTo: openSource.widthAnchor),
+            links.widthAnchor.constraint(equalTo: layout.widthAnchor),
+        ])
+        window.center()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func label(_ text: String, size: CGFloat, weight: NSFont.Weight = .regular,
+                       color: NSColor = .labelColor) -> NSTextField {
+        let field = NSTextField(labelWithString: text)
+        field.font = .systemFont(ofSize: size, weight: weight)
+        field.textColor = color
+        return field
+    }
+
+    private func linkButton(_ title: String, symbol: String, action: Selector) -> NSButton {
+        let button = NSButton(title: title, target: self, action: action)
+        button.bezelStyle = .rounded
+        button.controlSize = .large
+        button.font = .systemFont(ofSize: 14, weight: .medium)
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        button.imagePosition = .imageLeading
+        button.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        return button
+    }
+
+    @objc private func openWebsite(_ sender: Any?) {
+        openLink("https://lighttable.app/")
+    }
+
+    @objc private func openGitHub(_ sender: Any?) {
+        openLink("https://github.com/reville/lighttable-digital-darkroom")
+    }
+
+    private func openLink(_ address: String) {
+        guard let url = URL(string: address) else { return }
+        if !NSWorkspace.shared.open(url), let window {
+            let alert = NSAlert()
+            alert.messageText = "Could not open your browser"
+            alert.informativeText = "You can visit \(address) in your browser."
+            alert.beginSheetModal(for: window)
+        }
+    }
+}
+
 // MARK: - App
 
 final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDelegate,
@@ -950,6 +1076,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
     var webView: WKWebView!
     private var javaScriptConfirmation: (alert: NSAlert, reply: NativeJavaScriptReply)?
     private var secondaryLoupeWindow: NSWindow?
+    private lazy var aboutWindowController = AboutWindowController()
     var nativePreview: NativePreviewRenderer?
     let nativePerfLogQueue = DispatchQueue(label: "lighttable.native-perf-log")
     let server = ServerController()
@@ -2969,15 +3096,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
         }
     }
 
+    @objc private func showAbout(_ sender: Any?) {
+        aboutWindowController.showWindow(sender)
+        aboutWindowController.window?.makeKeyAndOrderFront(sender)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
     private func buildMenu() {
         let main = NSMenu()
         editorCommandItems.removeAll()
         schemeCommandItems.removeAll()
 
         let appMenu = NSMenu(title: "LightTable")
-        appMenu.addItem(withTitle: "About LightTable",
-                        action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
-                        keyEquivalent: "")
+        let aboutItem = appMenu.addItem(withTitle: "About LightTable",
+                                       action: #selector(showAbout(_:)), keyEquivalent: "")
+        aboutItem.target = self
 #if canImport(Sparkle)
         let updateItem = appMenu.addItem(
             withTitle: "Check for Updates…",

--- a/build-app.sh
+++ b/build-app.sh
@@ -57,7 +57,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>LSMinimumSystemVersion</key><string>13.0</string>
   <key>NSPhotoLibraryUsageDescription</key><string>LightTable reads your Photos library to copy original photos into your LightTable import folder. Your Photos library is never changed.</string>
   <key>NSHighResolutionCapable</key><true/>
-  <key>NSHumanReadableCopyright</key><string>Local tool. spektrafilm is GPLv3.</string>
+  <key>NSHumanReadableCopyright</key><string>Copyright © 2026 LightTable contributors. Free and open source under GNU GPL v3.</string>
   <key>NSAppTransportSecurity</key><dict>
     <key>NSAllowsLocalNetworking</key><true/>
   </dict>

--- a/docs/help/film-export-settings.json
+++ b/docs/help/film-export-settings.json
@@ -441,5 +441,27 @@
         "anchor": "showCatalogResult('Find duplicates'"
       }
     ]
+  },
+  {
+    "id": "about-lighttable",
+    "title": "About LightTable and open source",
+    "category": "Settings",
+    "summary": "Find the Mac app version, website, and source code.",
+    "keywords": ["about", "version", "website", "github", "open source", "license", "gpl"],
+    "sections": [
+      {
+        "title": "Open About on macOS",
+        "paragraphs": [
+          "Choose LightTable → About LightTable in the Mac menu bar. The About window shows the app version and, when different, its build number.",
+          "Website opens lighttable.app in your default browser. GitHub opens the public LightTable source repository, where you can explore the code, report issues, and contribute.",
+          "LightTable is free and open source under the GNU GPL v3."
+        ]
+      }
+    ],
+    "related": ["settings-and-defaults", "catalog-health-recovery"],
+    "sources": [
+      {"path": "app/main.swift", "anchor": "private final class AboutWindowController: NSWindowController"},
+      {"path": "README.md", "anchor": "**GPL-3.0-only**"}
+    ]
   }
 ]

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -1,9 +1,16 @@
 {
   "articles": {
+    "about-lighttable": {
+      "content": "f176c760d71f2141d024f089715f371828dcb3916a9a86bdfbea36dbae67ce87",
+      "sources": {
+        "README.md": "0914c040e18327b56b3c6d1f35c6723fa70a2d79c32d323eb21b889f144f70b4",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a"
+      }
+    },
     "add-photos": {
       "content": "78282b14cc31bbf1590b392567e0fe5837406ff0cc71045134480816ea9f491e",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "web/first-run.js": "e581b791c20303a43c54e2e6565cea7a3e8072729b82c7dbef9838cb1cd25cb3",
         "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
       }
@@ -19,7 +26,7 @@
     "browse-folders": {
       "content": "2d1e827ab09443dd4cdf72f487c00e04b622cb325d624ba6825a827a7e82851e",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
         "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c"
@@ -35,7 +42,7 @@
     "catalog-health-recovery": {
       "content": "cc43a7d2d0f37307bba27168f31b351257def6934dfa1d84528b4fdae30aed22",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "web/catalog-ui.js": "0c247e2000a7f5f74be34c0806da2fa387a5919bc7fb89befe188d6878462e98",
         "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/recovery.js": "0b0c984746976d3895b5b922a6f2aecd4bf5ab0a3bd1bbcac1c18322acd306bb",
@@ -73,7 +80,7 @@
     "editing-copy-paste-match-exposure": {
       "content": "ea587a5f680591f686563eed6326436e6413f5da512086974be55c4603bebe85",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/edit-transfer.js": "4575e626c642cf4604cc1574dc52120d96d820f7a3e4b283b6598d64ca57d166"
@@ -95,7 +102,7 @@
     "editing-detail-effects-enhance": {
       "content": "f84a04de3fa2ccdcd9de2e81e51b6e7b7143c76507424fc852e15d5d4f969ccb",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "enhance_workflow.py": "28b67a61a50e86d5c9da51ed69266d96ce317f1e0996db31e0854e1532a32ed6",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/enhance-panel.js": "7d711f35ab34b4a87868123fb12456b8efa436fc611c4f2c0fa4109daca8b4db",
@@ -151,7 +158,7 @@
     "editing-photo-merge": {
       "content": "79288ea8afc3621d945d5e55ca0716c8b4f4ae064c4d9007b7d686d6b9553895",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "merge_workflow.py": "af4489a9b4bdeb2374640e59d09a65b567a65da6b04ad7519b6d390eabee8e91",
         "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
@@ -161,7 +168,7 @@
     "editing-presets": {
       "content": "b408454541155b51882efc3dd3822b7e51aea09adca52799fe3b585615bb6b3e",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "preset_io.py": "ef53c6ad973ce5ab42c7c328fdd3e88ac002f913cad158bf20446e6219a94c8c",
         "preset_library.py": "98efb1e5151d8406e158681cde6da78003e2fe8c4bea911ee645fe78a644d14d",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
@@ -316,7 +323,7 @@
     "keyboard-midi": {
       "content": "f2511061a9bddf2bcf22cd9ee3e31d52dc8f46df94d5e80587275a054bf3c5bd",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/index.html": "955c60012f1c06def8df8d746cbe52e409141f16c0a8b9c07397618da923600c",
         "web/midi.js": "b26af6994583bc28ec09294351785c77aeb0848269f5c5aa094ca85524935fb0"
@@ -325,7 +332,7 @@
     "metadata-and-keywords": {
       "content": "60f57dc6250304224728edaf38fc85642ca17a02969a90e0af070bc756938465",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "keyword_workflow.py": "7be02bdb2980cb048b4a7c42393e542947f8b2f33ce6902a178af787d71a194b",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725",
         "web/keyword-batch.js": "195652d58c404cf552e254d133b3b7a0b9c61af06c615283e4dcda1ce1eb7adb",
@@ -424,7 +431,7 @@
     "trash-rejected": {
       "content": "85731343eefbc085ca0eff4b39db0d043c537b6cc69f3b77c8722ec01725acb9",
       "sources": {
-        "app/main.swift": "0036e71da54feee01708c9cf42a9a09caeaa6f6fa5d36ba88d83c3c303d63d28",
+        "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a",
         "server.py": "9f397d2d0aa1cdf53af27ac9a94125b5eca56b46fec26de903cc7c39954fe3d9",
         "web/app.js": "d40a9779e24d87b5e7eca66e1e773971b9b0163bce22d7c7f26c67c6b7386725"
       }

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -3,7 +3,7 @@
     "about-lighttable": {
       "content": "f176c760d71f2141d024f089715f371828dcb3916a9a86bdfbea36dbae67ce87",
       "sources": {
-        "README.md": "0914c040e18327b56b3c6d1f35c6723fa70a2d79c32d323eb21b889f144f70b4",
+        "README.md": "e2bc5c1592e80c3639f2564e21375dc4dfc1d92f71495d6e3b01a84a112cf48e",
         "app/main.swift": "f883a0c632ab691c866b067a70e8cdf3a57c1914cabe926631ad27f0cd07ad7a"
       }
     },

--- a/web/help-content.json
+++ b/web/help-content.json
@@ -2486,6 +2486,35 @@
       ]
     },
     {
+      "id": "about-lighttable",
+      "title": "About LightTable and open source",
+      "category": "Settings",
+      "summary": "Find the Mac app version, website, and source code.",
+      "keywords": [
+        "about",
+        "version",
+        "website",
+        "github",
+        "open source",
+        "license",
+        "gpl"
+      ],
+      "sections": [
+        {
+          "title": "Open About on macOS",
+          "paragraphs": [
+            "Choose LightTable → About LightTable in the Mac menu bar. The About window shows the app version and, when different, its build number.",
+            "Website opens lighttable.app in your default browser. GitHub opens the public LightTable source repository, where you can explore the code, report issues, and contribute.",
+            "LightTable is free and open source under the GNU GPL v3."
+          ]
+        }
+      ],
+      "related": [
+        "settings-and-defaults",
+        "catalog-health-recovery"
+      ]
+    },
+    {
       "id": "settings-and-defaults",
       "title": "Change preferences and new-photo defaults",
       "category": "Settings",


### PR DESCRIPTION
Replace the compact standard macOS About panel with a 560 × 408 native window containing the app icon, version, a free-and-open-source description, and prominent Website and GitHub buttons. Remove the personal name from About metadata and include the GNU GPL v3 license label. The window follows the system appearance and is reused when reopened.

Add the corresponding in-app Help article and refresh the reviewed source fingerprints for existing articles whose behavior is unchanged.

Validation:
- Full native shell compiled with Swift 5 compatibility for macOS 13.
- Production About controller rendered in an isolated native preview; light and dark appearances inspected, including the final version without the subtitle.
- Clicked both native buttons and verified the website and public repository opened in Chrome.
- All 10 Help tests passed; generated Help, plist syntax, shell syntax, and diff checks passed.

The installed personal app was not replaced.
