### PR TITLE
Fix recovery test context after animated zoom integration

### DIFF
--- a/tests/edit-recovery-startup.test.mjs
+++ b/tests/edit-recovery-startup.test.mjs
@@ -56,6 +56,7 @@ async function start({catalog = true, savedExposure = 0, history = null, restore
     cur: () => S.images[S.idx], cropSession: null, lastNavigationDirection: 1,
     navigationGeneration: 0, renderTimer: null, settleRenderTimer: null,
     clearTimeout: () => {}, NATIVE_PREVIEW: false, CAPTURE_TIME: null, HISTORY: null,
+    stopZoomMotion: () => {},
     syncPhotoActions: () => {}, setRenderPresentation: () => {}, isStateLoaded: () => true, prefetch: () => {},
     snapshot: () => JSON.stringify(S.images[S.idx].grade),
     fetch: async () => {


### PR DESCRIPTION
The recovery navigation tests extract showCurrentImage into a small VM context. Supply its new zoom-cancellation dependency so the three recovery tests reach their existing state and save assertions. Application code is unchanged.

Validation: all 258 JavaScript tests pass locally. This corrects the missing-helper failures reported by the web behavior CI check for the animated zoom change.
