### PR TITLE
Remove box backgrounds from section switches

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -279,7 +279,7 @@
         "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
-        "web/style.css": "bdd83666d3341b9a1a42fd08cae0aa640a9730bcdae33aa9ac26a6bbd04d465d"
+        "web/style.css": "c8d8c1d3b4e7b382d82ab4f4aa0b45a4a79a7b94e5d94f9535d2c0f5ffc787e9"
       }
     },
     "film-grain-and-format": {
@@ -385,7 +385,7 @@
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "2c1d102a7d35fb655a79a9cd57779c2b9d2a6e63d9bbc69742398cc3e946de92",
-        "web/style.css": "bdd83666d3341b9a1a42fd08cae0aa640a9730bcdae33aa9ac26a6bbd04d465d",
+        "web/style.css": "c8d8c1d3b4e7b382d82ab4f4aa0b45a4a79a7b94e5d94f9535d2c0f5ffc787e9",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
     },
@@ -398,7 +398,7 @@
         "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "bdd83666d3341b9a1a42fd08cae0aa640a9730bcdae33aa9ac26a6bbd04d465d"
+        "web/style.css": "c8d8c1d3b4e7b382d82ab4f4aa0b45a4a79a7b94e5d94f9535d2c0f5ffc787e9"
       }
     },
     "raw-jpeg-pairs": {
@@ -497,7 +497,7 @@
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "bdd83666d3341b9a1a42fd08cae0aa640a9730bcdae33aa9ac26a6bbd04d465d",
+        "web/style.css": "c8d8c1d3b4e7b382d82ab4f4aa0b45a4a79a7b94e5d94f9535d2c0f5ffc787e9",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },

--- a/web/style.css
+++ b/web/style.css
@@ -814,9 +814,10 @@ body.filmstrip-resizing { cursor:ns-resize; user-select:none; }
 .sec > summary::after { content:""; flex:0 0 auto; width:6px; height:6px; margin:-3px 2px 0 4px; border-right:1.5px solid var(--muted); border-bottom:1.5px solid var(--muted); transform:rotate(-45deg); transform-origin:60% 60%; transition:transform .14s ease; }
 .sec[open] > summary::after { transform:rotate(45deg); }
 .sec > summary > span { flex:1; }
-.section-switch { min-width:52px; min-height:24px; display:flex; align-items:center; justify-content:flex-end; gap:6px; padding:0; border:0; border-radius:3px; background:transparent; color:var(--muted); font-size:11px; font-weight:500; }
-.section-switch:hover:not(:disabled) { border:0; background:transparent; color:#fff; }
-.section-switch:active:not(:disabled) { background:transparent; transform:none; }
+/* Switch chrome belongs to the track; override the generic button states. */
+button.section-switch { min-width:52px; min-height:24px; display:flex; align-items:center; justify-content:flex-end; gap:6px; padding:0; border:0; border-radius:3px; background:transparent; box-shadow:none; color:var(--muted); font-size:11px; font-weight:500; }
+button.section-switch:hover:not(:disabled) { border:0; background:transparent; color:#fff; }
+button.section-switch:active:not(:disabled) { background:transparent; box-shadow:none; transform:none; }
 .switch-label { min-width:16px; text-align:right; font-variant-numeric:tabular-nums; }
 .switch-track { position:relative; width:26px; height:15px; flex:0 0 26px; border:1px solid var(--field-line); border-radius:8px; background:var(--field-inset); box-shadow:inset 0 1px 1px rgba(0,0,0,.45); transition:background-color .14s ease,border-color .14s ease; }
 .switch-track > span { position:absolute; top:2px; left:2px; width:9px; height:9px; border-radius:50%; background:#aaa; transition:transform .14s ease,background-color .14s ease; }


### PR DESCRIPTION
Section switches inherited a rectangular shadow and hover background from the shared button styles. Keep the Film profile, Photo contents index, and Face matching switches transparent in normal, hover, and pressed states while preserving their track and keyboard focus styling.

Validation: all 319 JavaScript tests pass; reviewed the four affected Help articles, rebuilt the bundle, and verified all 58 articles and 19 translated catalogs. `git diff --check` passes.
