### PR TITLE
Keep Visualize Spots sharp and synchronized with edits

### DIFF
--- a/app/NativePreview.metal
+++ b/app/NativePreview.metal
@@ -57,6 +57,7 @@ struct GradeUniforms {
     float4 colorGrade3;
     float4 colorGradeSettings;
     float4 softProof;
+    float4 spotVisualization; // preview only: enabled, threshold
     float4 optics0;     // distortion, vertical, horizontal, rotation radians
     float4 optics1;     // scale, vignette, heal count, mask atlas tiles
     float4 optics2;     // horizontal flip, vertical flip, reserved, reserved
@@ -707,6 +708,11 @@ fragment float4 nativePreviewFragment(
             image, fallback, linearSampler, grade, texel);
     }
     color = applySoftProof(color, grade.softProof, input.position.xy);
+    if (grade.spotVisualization.x > 0.5) {
+        float threshold = grade.spotVisualization.y;
+        float value = (0.5 - dot(color, LUMA)) * (2.0 + threshold * 7.0) + 0.5;
+        color = float3(clamp(clamp(value, 0.0, 1.0) * (0.72 + threshold * 0.35), 0.0, 1.0));
+    }
     if (grade.reference0.x > 0.5) {
         float2 referenceUv = (uv - 0.5 - grade.reference1.xy)
             / max(grade.reference0.w, 0.01) + 0.5;

--- a/app/NativePreview.swift
+++ b/app/NativePreview.swift
@@ -229,6 +229,7 @@ private struct GradeUniforms {
     var colorGrade3 = SIMD4<Float>(repeating: 0)
     var colorGradeSettings = SIMD4<Float>(0, 0.5, 0, 0)
     var softProof = SIMD4<Float>(repeating: 0)
+    var spotVisualization = SIMD4<Float>(repeating: 0)
     var optics0 = SIMD4<Float>(repeating: 0)
     var optics1 = SIMD4<Float>(1, 0, 0, 0)
     var optics2 = SIMD4<Float>(repeating: 0)
@@ -342,6 +343,7 @@ final class NativePreviewRenderer {
     private var maskTexturePixels = [UInt8](repeating: 0, count: 4)
     private var grade: [String: Any] = [:]
     private var softProof: [String: Any] = [:]
+    private var spotVisualization = SIMD4<Float>(repeating: 0)
     private var localMasks: [[String: Any]] = []
     private var optics: [String: Any] = [:]
     private var heals: [[String: Any]] = []
@@ -586,6 +588,14 @@ final class NativePreviewRenderer {
                 mipmapLevel: 0, withBytes: base,
                 bytesPerRow: maskLayout.rowBytes)
         }
+        scheduleRender()
+    }
+
+    func updateSpotVisualization(_ payload: [String: Any]) {
+        let threshold = (payload["threshold"] as? NSNumber)?.doubleValue ?? 0
+        spotVisualization = SIMD4<Float>(
+            (payload["enabled"] as? Bool ?? false) ? 1 : 0,
+            Float(threshold.isFinite ? max(0, min(1, threshold)) : 0), 0, 0)
         scheduleRender()
     }
 
@@ -1086,6 +1096,7 @@ final class NativePreviewRenderer {
             Float(proofTargets[softProof["profile"] as? String ?? "srgb"] ?? 0),
             (softProof["paper"] as? Bool ?? false) ? 1 : 0,
             (softProof["gamut"] as? Bool ?? false) ? 1 : 0)
+        output.spotVisualization = spotVisualization
         func optic(_ key: String, _ fallback: Double = 0) -> Float {
             Float(number(optics[key]) ?? fallback)
         }

--- a/app/main.swift
+++ b/app/main.swift
@@ -2686,6 +2686,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             }
         case "nativeMasks":
             nativePreview?.updateMasks(body)
+        case "nativeSpotVisualization":
+            nativePreview?.updateSpotVisualization(body)
         case "nativeEdits":
             nativePreview?.updateEdits(
                 optics: body["optics"] as? [String: Any] ?? [:],

--- a/docs/help/editing.json
+++ b/docs/help/editing.json
@@ -541,7 +541,9 @@
       {"path": "web/app.js", "anchor": "$('healRefresh').hidden = spot.mode === 'remove';"},
       {"path": "web/app.js", "anchor": "Click the new target position."},
       {"path": "web/index.html", "anchor": "Drag either on-image circle to refine the target or source."},
-      {"path": "web/screen-overlay.js", "anchor": "export function screenOverlayGeometry("}
+      {"path": "web/screen-overlay.js", "anchor": "export function screenOverlayGeometry("},
+      {"path": "web/gl.js", "anchor": "uniform vec2 u_spotVisualization;"},
+      {"path": "app/NativePreview.metal", "anchor": "grade.spotVisualization.x > 0.5"}
     ]
   },
   {

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -4,13 +4,13 @@
       "content": "f176c760d71f2141d024f089715f371828dcb3916a9a86bdfbea36dbae67ce87",
       "sources": {
         "README.md": "717056d48e1551cff16f9cd6b630c142633072be319632a15753ae21bde43e6b",
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952"
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b"
       }
     },
     "add-photos": {
       "content": "ed9c4ac18836826ad67c0ad52e2689c5d46d696548161570ecb8374c777632fa",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "web/first-run.js": "d3e3cc68759c3c7634b44c9edf562b2ae163120ae6255c38941222fa33eeebda",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "windows-shell/src/main.rs": "4b25a775c2d4a9bc18f228a385bfc5f23f56f12b186095014e3f5e0be3a71643"
@@ -20,7 +20,7 @@
       "content": "a586c04d57e4f936d8a46326c8bf281ff28ee53b1c0679f262a032ec3747d554",
       "sources": {
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786"
       }
@@ -28,8 +28,8 @@
     "browse-folders": {
       "content": "83110cc81ab7af3bec5273ae311e070f452a2972b13822f1164cfde7699d13ac",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
@@ -46,7 +46,7 @@
       "content": "9300fd7e981c26e4f2997363e9327fe23bbf8df404cfd80db32dee5cb865abd1",
       "sources": {
         "app/DiagnosticReports.swift": "f658b768399f0b1da70cd1158812c4bd726cafd032155398b266434882054c02",
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "catalog_scan.py": "a4f36ffa249b431642ae6b8af927da3a359ae5c7354f0ab0140491bdfe1759e1",
         "fatal_diagnostics.py": "56b1deacd97f83a19f3d41e0d77ac46e3f3d6b75cb815c043fafec5f443ef2f9",
         "file_identity.py": "e6516b82a587821c2dcb4d7d015847884e72c10f74cb28ce5b18cb60dd9a1c2b",
@@ -60,14 +60,14 @@
     "collections": {
       "content": "95bc3775974e6454f3d55661cf2db268196f4d73750fb1ba7f796bb23379cd36",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -81,16 +81,16 @@
     "editing-color-mixer-point-color": {
       "content": "9cfba81ef549fe43a8d1e2dc1ed7c7cc660202b4f2a640506af71f8e59fb0d7e",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "editing-copy-paste-match-exposure": {
       "content": "efa1eca4d219fc2f23de68e0ee3c69c2d583b900569bd8fdd64f3ea013207e01",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "server.py": "cd845dceaba485f9e6e50c0fe97c1926620fb67e1428f8aee1f92dd8a9a854e2",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd"
       }
     },
@@ -104,16 +104,16 @@
     "editing-curves": {
       "content": "a2280ce4abd9f79d1c1e6d0673c3d2ef6015fb01a14e4385e3c8621bd6b13a54",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "editing-detail-effects-enhance": {
       "content": "49911d9d38fd2ceaf03c72fb033100ed2b6683610df8c2d67b8139dce6bd03e8",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "enhance_workflow.py": "b2b3fe529770388b3c4bf04345bf995a6d9a70ef866a5e917313f8b3de72506a",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/enhance-panel.js": "6efc59ea9686bf72062453c76d61a9a09ad86511b4d9737e8ba95409fd95daa7",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
@@ -122,14 +122,14 @@
       "content": "e65c38833c6557b83b0e471394ed3d4fda54c7e44a5a7f4cba7a7e25fd04df71",
       "sources": {
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "editing-history-snapshots": {
       "content": "86dc3f8196fa62cc452db8d0cf86e40f2fe2450a1c8166cfe812177272853273",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/history-panel.js": "5f7a77338be697479c921dc76a9668e7846c50e75cab47bfd634dfe924faec25",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
@@ -137,7 +137,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
@@ -145,7 +145,7 @@
       "content": "b93d29b8af3e46c1f77976f9fec3732bb152c6b506e7bfe1f681d8b6381d4644",
       "sources": {
         "semantic_masks.py": "d48eb799d0c3188d4dc48a573d193eec94fc087b4eb9fba9560ed41b8de585f7",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
@@ -153,7 +153,7 @@
       "content": "05b85d684a6eefa912091c8b7ae284b9eaa4a7feb5a477fd8e08c808538c8fd4",
       "sources": {
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/editor-panels.js": "cbb1e16f590167c8f948629f3a851866a94e641daf0bc9af9694cb893d937446",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/mask-curve.js": "4db1ce1aa1d7c959762be56651cc5f7076bd363540309aef6aba3ba5a1bcf281",
@@ -165,7 +165,7 @@
     "editing-masks-ranges-refinements": {
       "content": "69559a947ccd17ddcf891ab7791585d708eaa3b452ac32e1fe6fee456fe90167",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254"
       }
@@ -173,22 +173,22 @@
     "editing-photo-merge": {
       "content": "5030e3092b04c12520f62d83ac0dd9b1f5b09b50e8af8cd1693f190bc63b47c1",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
         "server.py": "cd845dceaba485f9e6e50c0fe97c1926620fb67e1428f8aee1f92dd8a9a854e2",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "editing-presets": {
       "content": "8deccb179e402b4f907687ea12cd7650abaad71b59d14b2901ae26e9812894ec",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "preset_io.py": "ad379b80b1b534c5afde2b54587892440c1be80d314b8a60b6532793a763b97e",
         "preset_library.py": "fb8d27cde136b026d25fe512a281a0d8f6d80a97b9bcbdca667e229162c26358",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "server.py": "cd845dceaba485f9e6e50c0fe97c1926620fb67e1428f8aee1f92dd8a9a854e2",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
         "web/preset-browser.css": "b219f60ea85fe2adbb9b40834248137bad15eb9c46074e6a1c56f6b3dbdade9b",
@@ -197,9 +197,11 @@
       }
     },
     "editing-remove-heal": {
-      "content": "430f3a6c8cf70a80ac1734ece3d17532ced4716d367cf3a889045770a5024cd8",
+      "content": "3d70eb73feed29823cf507dacaaefa5e836efbeda3815657693341cdb79c297d",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "app/NativePreview.metal": "45aa8ae595982903f61554d60f6da370d0e77e905fad335f7ba9e250f0daaa02",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
+        "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
@@ -207,21 +209,21 @@
     "editing-save-recovery": {
       "content": "5ea77476828b252a78757b30d827464a516994d3c1cf84a3a6041bec601e2b2d",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/edit-save-queue.js": "0d56b96358f6de5ade38c3dd554260f876a746145a89476c0a68e3c16620a574"
       }
     },
     "editing-tone": {
       "content": "2e83d0be17ae55ef2edbd5cb335d18e9d96de22d032056f3dc9027bbe48fc35d",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "editing-white-balance": {
       "content": "f6b3b37c291e9d60356355f3668f15990e40995bedc9062c9a67a3da9425e271",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
@@ -229,7 +231,7 @@
       "content": "007309327e1d2aa65e1c38fea9ce0347ee5b343c9a12b881419000c5ccd44999",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
@@ -237,7 +239,7 @@
       "content": "5945724f1f5a9ad80dabdbb9b1943978a77aa5a373366307f8acc38aabd165f0",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
@@ -252,14 +254,14 @@
       "content": "dbb37c4fdeb501f59294843e33d6aea92727bd952e76e11978a4a14af5535086",
       "sources": {
         "server.py": "cd845dceaba485f9e6e50c0fe97c1926620fb67e1428f8aee1f92dd8a9a854e2",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "external-editor": {
       "content": "905a7f2d9fc297adb88b6aa0c2f0f5bf7b21513ca1db891c3b7a3bf137aac2de",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "windows-shell/src/main.rs": "4b25a775c2d4a9bc18f228a385bfc5f23f56f12b186095014e3f5e0be3a71643"
       }
@@ -267,7 +269,7 @@
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
@@ -276,7 +278,7 @@
       "content": "2ea19e843ce9c9a59afd0e8d2e0a3dd7927a6e7a413dc92a9b64c23f328516b6",
       "sources": {
         "film_tuning.py": "133a5e3200b69b2aa3b92f8bb471c93af449b5036bb8dfdd6610292175693860",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/style.css": "c8d8c1d3b4e7b382d82ab4f4aa0b45a4a79a7b94e5d94f9535d2c0f5ffc787e9"
@@ -293,7 +295,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
@@ -301,7 +303,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
@@ -309,14 +311,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -342,8 +344,8 @@
     "keyboard-midi": {
       "content": "afa81f9e0bf349d0df5d83bf5a2b09497fd62c2c0ecc69fa629d2fa04382fdf0",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/midi.js": "a74a05ad2303790b15efaf9953afcf60f20ccfabf4d4f8bde7ae2eb99c834175"
       }
@@ -351,9 +353,9 @@
     "metadata-and-keywords": {
       "content": "4070dd0015da08ec42ca3dbf872e0d0e24c046eb2f938cf594101846244587ec",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "keyword_workflow.py": "5c545bd45205bf294d15cddbaf43f27a39ad5c30b69e7f98fab579d2b61a73a4",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/keyword-batch.js": "e38195a5528e40635522473776ba9b0a2052f11a78ac77fb7cfe81fa3cc8a88e",
         "web/metadata-panel.js": "1df7028d86ab8b0969c3461caf9b1612e9515d1c4c144519326f00be312f7e1e"
       }
@@ -373,13 +375,13 @@
     "performance-previews": {
       "content": "88f3537c3ed37d64a149de4d310a66a5e67d9580659ce349a5ec8cf294c81b48",
       "sources": {
-        "app/NativePreview.swift": "db7f4b031e48f65a8e3275224ad9bacf1a2108c36542e42e8c3f87b8735a5533",
+        "app/NativePreview.swift": "7be33afe7149c83432631f81c4193dd7b1c410d801e8ca8a65929ca25f0ed08b",
         "gpu_compute.py": "6aaf344c93689e2673c957fdad76c1aed4c81cc144d9d64e3b91cc3a44859ba4",
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
         "server.py": "cd845dceaba485f9e6e50c0fe97c1926620fb67e1428f8aee1f92dd8a9a854e2",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
-        "web/gl.js": "0617724af02eee68f6a5fa4a50c4f6c243b46df64823ed3938dd78f5e7957d82",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
+        "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/preview-detail.js": "8601034c83de06c042fdd5528d7fde5ff69db567bdac7225f3b133b739836acc",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
@@ -395,7 +397,7 @@
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
         "film_lab_ai/service.py": "fd684477d966d1014c1b72cb843871379db98b41fb800ec9f98a8d75c1eea842",
         "media_availability.py": "cfdfc4495f979f9c6b11686a9bb3610a1c894059eecf896bbcd8730582363272",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
         "web/style.css": "c8d8c1d3b4e7b382d82ab4f4aa0b45a4a79a7b94e5d94f9535d2c0f5ffc787e9"
@@ -404,7 +406,7 @@
     "raw-jpeg-pairs": {
       "content": "63ef5d08a8d6515e2677eb9344c41edafd7d2b2266703648040f4080033691b2",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -422,7 +424,7 @@
       "sources": {
         "catalog_scan.py": "a4f36ffa249b431642ae6b8af927da3a359ae5c7354f0ab0140491bdfe1759e1",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/library-filters.js": "eea02c5ed7b026e4be6ec7983b1af5af9f66b917c274be54e3b04744b57a4b00",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
@@ -442,7 +444,7 @@
     "settings-language": {
       "content": "94778fce4730a2170969e2c8021322069e60563dc48890e749ff36fbfbc55f6f",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "web/i18n.js": "48ec7b56c856a8db9bcd47315a6c697582a0207a1656d42ed43260c3627b7388",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/locale-bootstrap.js": "06fc13de85d1b216f01742ae5667c03b18a4fd413913281bb87aa7866b287845",
@@ -453,7 +455,7 @@
     "shortcut-schemes": {
       "content": "e6cf59f5fde950bf351b74084189c3d6fb585b9ef8f86c78a01c82db94da584d",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
@@ -462,7 +464,7 @@
       "content": "9b7e47fe1ac1a2ae85a54070f12b51d8876a2d4497b5f3dc3c0857cca2e1da6b",
       "sources": {
         "catalog.py": "835689c7a908f5bb3c620adee1450270365f68c9b709aa5f099330d4770d2df8",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
       }
     },
@@ -470,30 +472,30 @@
       "content": "667d42680ff9d3d60918660cb348f4d0add54a7577d29d9db4a20a48495425f0",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be"
       }
     },
     "survey-photos": {
       "content": "dc19b008aa782297e49f1abcb77345dba833aaf1d04fed0e7dd83521edff56c1",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/survey.js": "79fd7a71ef314f25e5a6452f9def6d5edeac62799fd1305631f1607724363cc3"
       }
     },
     "trash-rejected": {
       "content": "f52bb62055da510b5960532a68f9c82786187593aaa50a1172a5f2173f8d2fbd",
       "sources": {
-        "app/main.swift": "0ad81cbc531c08ff4f85dae625c94dcea737fb09705f523c2a9b02b316460952",
+        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
         "server.py": "cd845dceaba485f9e6e50c0fe97c1926620fb67e1428f8aee1f92dd8a9a854e2",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "windows-shell/src/main.rs": "4b25a775c2d4a9bc18f228a385bfc5f23f56f12b186095014e3f5e0be3a71643"
       }
     },
     "views-and-selection": {
       "content": "5671b035e23cb8bb257863e9ec19b58cad37c37393946f51b4c4e8203313133e",
       "sources": {
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61",
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "04ca72ff1fc5388bb6893010c1700387a8a8408cc280b3c56e2b532645fd82be",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
@@ -505,7 +507,7 @@
       "content": "de9620831ddcd8ecee7ce1f29fa1442122cfe5fa8183c0650ee8b3b34210d498",
       "sources": {
         "library_workflow.py": "b07bc79b58666fe92ce189ac4132a6904457e166f73c155f3f636fc683966e3c",
-        "web/app.js": "c08afd509056a33fae165c503baef4ca22e75d246744f0baa340a9d179f36b61"
+        "web/app.js": "f498609345b1f1d4df1dd3bb1f348a8e8912cdd655f8d2d4db60b0d032e97b05"
       }
     },
     "xmp-interchange": {

--- a/tests/before-preview.test.mjs
+++ b/tests/before-preview.test.mjs
@@ -23,6 +23,7 @@ for (const native of [false, true]) for (const baked of [false, true]) test(`Bef
     syncBrowserOriginal:() => calls.push({originalRequested:true}),
     nativePreviewActive:() => native, scheduleHistogram:noop, GRADE_PERF:{take:() => null},
     nativeGradePayload:grade => ({grade}), postNative:(action,detail) => calls.push({action,...detail}),
+    spotVisualization:() => ({enabled:true, threshold:0.5}),
     previewSourceX:position => position, syncCompareView:noop, syncCompareControl:noop,
     setCompareActive:on => {S.compareActive=on;}};
   const code = between('function drawGradeNow(', 'function drawGrade()') +

--- a/tests/processing_webgl.mjs
+++ b/tests/processing_webgl.mjs
@@ -9,7 +9,7 @@ const browser = await chromium.launch({headless: true,
   args: ['--enable-unsafe-swiftshader', '--force-color-profile=srgb']});
 for (const signal of ['SIGTERM', 'SIGINT']) process.on(signal, async () => {await browser.close(); process.exit(1);});
 try {
-  const page = await browser.newPage({viewport: {width: 640, height: 480}, deviceScaleFactor: 1});
+  const page = await browser.newPage({viewport: {width: 1280, height: 800}, deviceScaleFactor: 1});
   const errors = [];
   page.on('pageerror', e => errors.push(e.message));
   await page.goto(config.baseUrl);
@@ -35,15 +35,52 @@ try {
         await original.decode(); renderer.setOriginalImage(original);
       }
       renderer.comparePosition = test.compare || 0;
-      renderer.draw(test.grade);
+      const draw = () => renderer.draw(test.grade, [], undefined, null, test.spotVisualization);
+      draw();
       const gl = renderer.gl, canvas = renderer.canvas;
       const rgba = new Uint8Array(canvas.width * canvas.height * 4);
       // Read immediately in the draw task, before the nonpersistent buffer retires.
       gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+      if (test.spotVisualization?.enabled) {
+        if (test.fixture === 'spots' && !Object.keys(test.grade).length) {
+          const reference = document.createElement('canvas');
+          reference.width = canvas.width; reference.height = canvas.height;
+          const ctx = reference.getContext('2d');
+          const t = test.spotVisualization.threshold;
+          ctx.filter = `grayscale(1) invert(1) contrast(${2 + t * 7}) brightness(${0.72 + t * 0.35})`;
+          ctx.drawImage(image, 0, 0);
+          const expected = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+          for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+            const i = (y * canvas.width + x) * 4;
+            const j = ((canvas.height - 1 - y) * canvas.width + x) * 4;
+            if (Math.abs(rgba[j] - expected[i]) > 2) {
+              ctx.filter = 'none'; ctx.drawImage(image, 0, 0);
+              const input = Array.from(ctx.getImageData(x,y,1,1).data);
+              throw Error(`Visualization changed existing filter appearance at ${test.name} ${x},${y}: ${rgba[j]} vs ${expected[i]}, input ${input}`);
+            }
+          }
+        }
+        const pixel = renderer.samplePixel(0.5, 0.5);
+        const histogram = Uint8Array.from(renderer.sample().px);
+        // The sampling calls must restore display uniforms, including for a
+        // compare-only redraw that does not upload the grade again.
+        renderer.drawCompare(0);
+        const restored = new Uint8Array(rgba.length);
+        gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, restored);
+        if (restored.some((v, i) => v !== rgba[i])) throw Error('Sampling changed the displayed visualization');
+        renderer.draw(test.grade);
+        const normalPixel = renderer.samplePixel(0.5, 0.5);
+        const normalHistogram = renderer.sample().px;
+        if (pixel.some((v, i) => v !== normalPixel[i]) ||
+            histogram.some((v, i) => v !== normalHistogram[i])) {
+          throw Error('Visualize Spots contaminated color sampling or histogram');
+        }
+        draw();
+      }
       const error = gl.getError();
       if (error) throw Error(`WebGL error ${error}`);
       const debug = gl.getExtension('WEBGL_debug_renderer_info');
-      window.drawForCapture = () => renderer.draw(test.grade);
+      window.drawForCapture = draw;
       return {width: canvas.width, height: canvas.height, pixels: Array.from(rgba),
         renderer: debug ? gl.getParameter(debug.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER)};
     }, test);

--- a/tests/processing_webgl.py
+++ b/tests/processing_webgl.py
@@ -31,6 +31,12 @@ def run(output_dir):
     reverse = np.ascontiguousarray(source[::-1, ::-1, ::-1])
     portrait = target_rgb8(96, 128)
     sources = {'target': source, 'reverse': reverse, 'portrait': portrait}
+    # Alternating one-pixel stripes and isolated dust are erased by the old
+    # 256px sampling-helper overlay, even though the main preview resolves them.
+    spots = np.full((512, 1024, 3), 180, dtype=np.uint8)
+    spots[:, ::2] = 90
+    spots[240:244, 500:504] = 25
+    sources['spots'] = spots
     for name, pixels in sources.items():
         Image.fromarray(pixels).save(output_dir / f'{name}.png')
 
@@ -56,6 +62,16 @@ def run(output_dir):
         {'name': 'portrait', 'grade': {'exposure': 0.4}, 'fixture': 'portrait'},
         {'name': 'compare-half', 'grade': {'exposure': 0.4}, 'compare': 0.5},
         {'name': 'compare-off', 'grade': {'exposure': 0.4}},
+    ])
+    for threshold in [0, 0.55, 1]:
+        tests.append({'name': f'spots-{threshold}', 'grade': {}, 'fixture': 'spots',
+                      'spotVisualization': {'enabled': True, 'threshold': threshold}})
+    tests.extend([
+        {'name': 'spots-graded', 'grade': {'exposure': -0.5}, 'fixture': 'spots',
+         'spotVisualization': {'enabled': True, 'threshold': 0.55}},
+        {'name': 'spots-navigate-portrait', 'grade': {}, 'fixture': 'portrait',
+         'spotVisualization': {'enabled': True, 'threshold': 0.55}},
+        {'name': 'spots-off', 'grade': {}, 'fixture': 'spots'},
     ])
     for test in tests:
         test.update(source=f"{base}/{test.get('fixture', 'target')}.png",
@@ -84,6 +100,12 @@ def run(output_dir):
     for test, result in zip(tests, metadata['records'], strict=True):
         pixels = sources[test.get('fixture', 'target')].astype(np.float32) / 255
         expected = grade.apply(pixels, test['grade'])
+        if test.get('spotVisualization', {}).get('enabled'):
+            threshold = test['spotVisualization']['threshold']
+            luminance = expected @ np.array([0.2126, 0.7152, 0.0722])
+            value = ((0.5 - luminance) * (2 + threshold * 7) + 0.5)
+            expected = np.repeat(np.clip(np.clip(value, 0, 1) * (0.72 + threshold * 0.35),
+                                         0, 1)[..., None], 3, axis=2)
         if test.get('compare'):
             expected[:, :64] = reverse[:, :64] / 255
         actual = np.fromfile(test['raw'], dtype=np.uint8).reshape(result['height'], result['width'], 4)

--- a/tests/screen-overlay.test.mjs
+++ b/tests/screen-overlay.test.mjs
@@ -74,10 +74,12 @@ test('photo zoom enlarges correction areas while line widths, dashes and pins st
     cv: { width: 256, height: 171, getBoundingClientRect: () => image },
     cmp: { getBoundingClientRect: () => image },
     zoomwrap: { getBoundingClientRect: () => viewport },
-    healVisualize: { checked: false },
+    healVisualize: { checked: true },
+    healVisualizeThreshold: { value: '0.55' },
   };
   const S = { activePane: 'healPane', localPinsVisible: true, selectedHealId: 'spot',
     heals: [{ id: 'spot', target: [0.5, 0.5], source: [0.55, 0.5], radius: 0.1, mode: 'clone' }],
+    baseImg: { complete: true, naturalWidth: 256 },
     overlayHoverPoint: null, healBrush: { radius: 0.1, feather: 0.5 } };
   const draw = new Function('S', '$', 'window', 'screenOverlayGeometry', 'prepareScreenOverlay',
     'syncOverlayCursorClass', source.slice(source.indexOf('function drawBrushCursor('),
@@ -89,6 +91,8 @@ test('photo zoom enlarges correction areas while line widths, dashes and pins st
     image = rect(120 - 450 * (zoom - 1), 80 - 300 * (zoom - 1), 900 * zoom, 600 * zoom);
     overlay.calls.length = 0;
     draw();
+    assert.ok(!overlay.calls.some(c => c.method === 'drawImage'),
+      'Visualize Spots must not cover the sharp preview with the sampling helper');
     const arcs = overlay.calls.filter(c => c.method === 'arc');
     assert.deepEqual(arcs.map(c => c.args[2]), [60 * zoom, 4.5, 60 * zoom, 4.5]);
     assert.ok(overlay.calls.filter(c => c.method === 'stroke').every(c => c.lineWidth === 2.2));

--- a/tests/spot-visualization.test.mjs
+++ b/tests/spot-visualization.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { createFrameScheduler } from '../web/render-scheduler.js';
+
+const source = fs.readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+const between = (a, b) => source.slice(source.indexOf(a), source.indexOf(b, source.indexOf(a)));
+
+test('coalesced visualization uses current pane and threshold even during a pending photo load', () => {
+  let callback;
+  const calls = [];
+  const S = { activePane: 'healPane', previewLoadGeneration: 4 };
+  const elements = { healVisualize: { checked: true }, healVisualizeThreshold: { value: '0.55' } };
+  const context = { S, $: id => elements[id],
+    createFrameScheduler: fn => createFrameScheduler(fn),
+    drawGradeNow: () => calls.push('grade'), drawEditOverlayNow: () => calls.push('overlay'),
+    nativePreviewActive: () => true, postNative: (type, data) => calls.push({type, data}),
+  };
+  const previous = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = fn => { callback = fn; return 1; };
+  try {
+    vm.runInNewContext(between('const previewFrameScheduler =', 'function drawEditOverlay()') +
+      between('function spotVisualization()', 'function nativeEditsPayload('), context);
+    context.refreshSpotVisualization();
+    elements.healVisualizeThreshold.value = '0.8';
+    context.refreshSpotVisualization();
+    callback();
+    assert.equal(calls.length, 3);
+    assert.equal(calls[1].type, 'nativeSpotVisualization');
+    assert.equal(calls[1].data.enabled, true);
+    assert.equal(calls[1].data.threshold, 0.8);
+    calls.length = 0;
+    context.refreshSpotVisualization();
+    S.activePane = 'editPane';
+    callback();
+    assert.equal(calls[1].data.enabled, false, 'leaving healing clears the diagnostic view');
+    S.activePane = 'healPane';
+    elements.healVisualize.checked = false;
+    assert.equal(context.spotVisualization().enabled, false);
+  } finally { globalThis.requestAnimationFrame = previous; }
+});

--- a/tests/test_native_compare_redraw.py
+++ b/tests/test_native_compare_redraw.py
@@ -26,6 +26,9 @@ class NativeCompareRedrawTests(unittest.TestCase):
     def test_zoom_submits_matching_geometry_and_pixels_before_returning(self):
         self.run_harness(ZOOM_HARNESS, "PASS: 8 atomic zoom frames", probe=True)
 
+    def test_spot_visualization_preserves_detail_and_tracks_current_preview(self):
+        self.run_harness(SPOT_HARNESS, "PASS: spot visualization")
+
     def run_harness(self, harness_source, expected_output, *, probe=False):
         swiftc = shutil.which("swiftc")
         if not swiftc:
@@ -42,6 +45,10 @@ class NativeCompareRedrawTests(unittest.TestCase):
             coordinates.save(temporary / "coordinates.png")
             coordinates.putdata([(x, y, 160) for y in range(256) for x in range(256)])
             coordinates.save(temporary / "coordinates-blue.png")
+            spots = Image.new("RGB", (1024, 512))
+            spots.putdata([(90, 90, 90) if x % 2 else (180, 180, 180)
+                           for y in range(512) for x in range(1024)])
+            spots.save(temporary / "spots.png")
 
             class QuietHandler(http.server.SimpleHTTPRequestHandler):
                 def log_message(self, *_args):
@@ -485,6 +492,114 @@ struct ZoomRedraw {
         print("PASS: 8 atomic zoom frames preserve submitted geometry and clipped source pixels")
         print("PASS: HTTP and cached surface swaps submit exactly one matching texture/grade/viewport")
         print("Drawable presentation callbacks: \(presentationCallbacks); background window, no visible-screen claim")
+    }
+}
+'''
+
+
+SPOT_HARNESS = r'''
+import AppKit
+import MetalKit
+
+@main struct SpotVisualization {
+    static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() { fputs("FAIL: \(message)\n", stderr); exit(1) }
+    }
+    static func wait(_ condition: () -> Bool) {
+        let deadline = Date().addingTimeInterval(5)
+        while !condition() && Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        require(condition(), "timed out waiting for GPU completion")
+    }
+    static func main() {
+        guard MTLCreateSystemDefaultDevice() != nil else { exit(77) }
+        let focus = BackgroundFocusGuard()
+        defer { focus.verify() }
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory); app.finishLaunching()
+        guard let renderer = NativePreviewRenderer() else { exit(1) }
+        let window = NSWindow(contentRect: NSRect(x:80,y:80,width:512,height:256),
+                              styleMask:[.titled], backing:.buffered, defer:false)
+        window.contentView!.addSubview(renderer.view)
+        renderer.view.framebufferOnly = false
+        renderer.setFrame(NSRect(x:0,y:0,width:512,height:256), visible:true)
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+        window.orderBack(nil); focus.verify()
+        defer { window.orderOut(nil) }
+        let device = renderer.view.device!, queue = device.makeCommandQueue()!
+        let base = URL(string:CommandLine.arguments[1])!
+        var generation = 0
+        func load(_ name: String) {
+            generation += 1
+            let surface = NativeSurfaceDescription(payload:["url":name + ".png"], baseURL:base)!
+            var result: Result<NativePreviewTimings, Error>?
+            renderer.load(surface, generation:generation, grade:[:]) { result = $0 }
+            wait { result != nil }
+            if case .failure(let error) = result! { require(false, "surface: \(error)") }
+        }
+        load("spots")
+        var completed = -1, frame = 0
+        renderer.onInteractionPresented = { sample in
+            if sample["measurement"] as? String == "gpu-completed" {
+                completed = sample["frame"] as? Int ?? -1
+            }
+        }
+        func capture(_ enabled: Bool, _ threshold: Double) -> [UInt8] {
+            let drawable = renderer.view.currentDrawable!
+            frame += 1
+            renderer.recordInteraction(["frame":frame])
+            renderer.updateSpotVisualization(["enabled":enabled, "threshold":threshold])
+            wait { completed == frame }
+            let width = drawable.texture.width, height = drawable.texture.height
+            let desc = MTLTextureDescriptor.texture2DDescriptor(pixelFormat:.bgra8Unorm,
+                width:width, height:height, mipmapped:false)
+            desc.storageMode = .shared
+            let target = device.makeTexture(descriptor:desc)!
+            let command = queue.makeCommandBuffer()!, blit = command.makeBlitCommandEncoder()!
+            blit.copy(from:drawable.texture,to:target); blit.endEncoding()
+            command.commit(); command.waitUntilCompleted()
+            require(command.status == .completed, "display readback failed")
+            var pixels = [UInt8](repeating:0,count:width*height*4)
+            target.getBytes(&pixels,bytesPerRow:width*4,
+                from:MTLRegionMake2D(0,0,width,height),mipmapLevel:0)
+            return pixels
+        }
+        for name in ["spots", "coordinates-blue", "spots"] {
+            load(name)
+            for zoom: Float in [1, 2, 4] {
+                renderer.setFrame(NSRect(x:0,y:0,width:512,height:256),
+                    uvScale:SIMD2(1/zoom,1/zoom),
+                    uvOffset:SIMD2(0.5-0.5/zoom,0.5-0.5/zoom),visible:true)
+                for exposure in [0.0, -0.5] {
+                    renderer.updateGrade(["exposure":exposure])
+                    let normal = capture(false, 0)
+                    for threshold in [0.0, 0.55, 1.0] {
+                        let visual = capture(true, threshold)
+                        for i in stride(from:0,to:normal.count,by:4) {
+                            let luma = (Double(normal[i])*0.0722 + Double(normal[i+1])*0.7152
+                                + Double(normal[i+2])*0.2126)/255
+                            let contrast = max(0,min(1,(0.5-luma)*(2+threshold*7)+0.5))
+                            let value = contrast*(0.72+threshold*0.35)
+                            let expected = max(0,min(255,Int((value*255).rounded())))
+                            require(abs(Int(visual[i])-expected) <= 5,
+                                    "visualization lost current detail at \(name), zoom \(zoom), pixel \(i/4)")
+                            require(visual[i] == visual[i+1] && visual[i+1] == visual[i+2],
+                                    "visualization must be grayscale")
+                        }
+                        require(capture(false,threshold) == normal, "turning off did not restore exact pixels")
+                    }
+                }
+                focus.verify()
+            }
+        }
+        // A late source upload must not restore the checkbox state captured
+        // when that upload started. Visualization is independent display state.
+        _ = capture(true,0.55)
+        load("coordinates")
+        let retained = capture(true,0.55)
+        require(retained != capture(false,0.55), "navigation lost visualization")
+        print("PASS: spot visualization retains fine detail, threshold, zoom, grade, navigation and exact off pixels")
     }
 }
 '''

--- a/tests/test_photo_tool_flow.py
+++ b/tests/test_photo_tool_flow.py
@@ -34,6 +34,7 @@ const syncGrade = noop, drawGrade = noop, syncCurveFromGrade = noop, syncHsl = n
 const renderKeywords = noop, renderVersions = noop, refreshLists = noop, updateUndoRedoButtons = noop;
 const normalizeFilmParams = value => cloneValue(value);
 const serializableMasks = () => cloneValue(S.masks);
+const refreshSpotVisualization = noop;
 const drawEditOverlay = noop, scheduleNativeMenuState = noop, savePrefs = noop;
 const renderEditItems = noop, syncOverlayCursorClass = noop;
 const nativePreviewActive = () => false;

--- a/web/app.js
+++ b/web/app.js
@@ -1855,13 +1855,6 @@ function drawEditOverlayNow() {
         S.maskRefineMode === 'subtract' ? '#ff9c9c' : '#fff');
     }
   } else if (S.activePane === 'healPane') {
-    if ($('healVisualize').checked && S.baseImg?.complete && S.baseImg.naturalWidth) {
-      const threshold = +$('healVisualizeThreshold').value;
-      ctx.save();
-      ctx.filter = `grayscale(1) invert(1) contrast(${2 + threshold * 7}) brightness(${0.72 + threshold * 0.35})`;
-      ctx.drawImage(S.baseImg, 0, 0, surface.width, surface.height);
-      ctx.restore();
-    }
     for (const spot of S.localPinsVisible ? S.heals : []) {
       const selected = spot.id === S.selectedHealId;
       const tx = spot.target[0] * surface.width, ty = spot.target[1] * surface.height;
@@ -1899,6 +1892,9 @@ const previewFrameScheduler = createFrameScheduler((work) => {
   if (work.grade) drawGradeNow(Boolean(work.forceWebGL));
   if (work.edits && !work.grade && nativePreviewActive()) {
     postNative('nativeEdits', nativeEditsPayload());
+  }
+  if (work.visualization && nativePreviewActive()) {
+    postNative('nativeSpotVisualization', spotVisualization());
   }
   if (work.overlay) drawEditOverlayNow();
 });
@@ -1957,7 +1953,7 @@ function drawGradeNow(forceWebGL = false, refreshScope = true) {
   // or after a new helper texture arrives.
   if (S.gl && (!native || forceWebGL) && !interactiveMask) {
     S.gl.draw(activeGrade, S.gradeEditsBaked ? [] : S.masks, upload,
-      S.softProof);
+      S.softProof, spotVisualization());
     if (refreshScope) scheduleHistogram();
     if (!native) {
       const input = GRADE_PERF.take();
@@ -2002,6 +1998,17 @@ function nativeMaskChannelPayload(channel, edge) {
   const { width, height } = maskTextureSize(edge);
   return { width, height, channel: channel % 4, tile: Math.floor(channel / 4),
     data: bytesToBase64(maskGeometryValues(mask, width, height)), masks };
+}
+
+function spotVisualization() {
+  return {
+    enabled: S.activePane === 'healPane' && $('healVisualize').checked,
+    threshold: +$('healVisualizeThreshold').value,
+  };
+}
+
+function refreshSpotVisualization() {
+  previewFrameScheduler.request({ grade: true, visualization: true, overlay: true });
 }
 
 function nativeEditsPayload(baked = S.baseEditsBaked) {
@@ -2629,11 +2636,11 @@ $('healRefresh').onclick = () => {
 };
 $('healVisualize').onchange = () => {
   $('healVisualizeRow').hidden = !$('healVisualize').checked;
-  drawEditOverlay();
+  refreshSpotVisualization();
 };
 $('healVisualizeThreshold').addEventListener('input', () => {
   $('healVisualizeThresholdV').textContent = `${Math.round(+$('healVisualizeThreshold').value * 100)}%`;
-  drawEditOverlay();
+  refreshSpotVisualization();
 });
 for (const id of ['healRadius', 'healFeather', 'healOpacity']) {
   const rememberUndo = () => { if (selectedHeal()) pushUndo(); };
@@ -6022,6 +6029,7 @@ function switchPane(id, { fromCompare = false } = {}) {
     paneScrollPositions.set(previousPane, panel.scrollTop);
   }
   S.activePane = id;
+  if (previousPane === 'healPane' || id === 'healPane') refreshSpotVisualization();
   $('appShell').classList.toggle('grid-info-open', S.viewMode !== 'detail' && id === 'infoPane');
   if (S.viewMode !== 'detail') { _gridLayoutKey = ''; requestAnimationFrame(renderGrid); }
   let activeButton = null;

--- a/web/gl.js
+++ b/web/gl.js
@@ -54,6 +54,7 @@ uniform float u_pointColorCount;
 uniform vec3 u_cgShadows, u_cgMidtones, u_cgHighlights, u_cgGlobal;
 uniform float u_cgBalance, u_cgBlending, u_cgOn;
 uniform vec4 u_softProof;            // enabled, target id, paper simulation, gamut warning
+uniform vec2 u_spotVisualization;    // preview only: enabled, threshold
 uniform vec4 u_localOn[4], u_localOpacity[4], u_localLumaLow[4], u_localLumaHigh[4];
 uniform vec4 u_localExposure[4], u_localContrast[4], u_localHighlights[4], u_localShadows[4];
 uniform vec4 u_localTemp[4], u_localTint[4], u_localSaturation[4];
@@ -466,6 +467,12 @@ void main() {
 
   c = applySoftProof(c);
 
+  if (u_spotVisualization.x > 0.5) {
+    float threshold = u_spotVisualization.y;
+    float value = (0.5 - dot(c, LUMA)) * (2.0 + threshold * 7.0) + 0.5;
+    c = vec3(clamp(clamp(value, 0.0, 1.0) * (0.72 + threshold * 0.35), 0.0, 1.0));
+  }
+
   if (u_referenceView.x > 0.5) {
     vec2 referenceUv = (uv - vec2(0.5) - u_referenceOffset)
       / max(u_referenceView.w, 0.01) + vec2(0.5);
@@ -594,6 +601,8 @@ export class GradeRenderer {
       'Balance', 'Blending', 'On'].map((key) => [key,
       gl.getUniformLocation(this.prog, `u_cg${key}`)]));
     this.uSoftProof = gl.getUniformLocation(this.prog, 'u_softProof');
+    this.uSpotVisualization = gl.getUniformLocation(this.prog, 'u_spotVisualization');
+    this.spotVisualization = [0, 0];
     this.uImg = gl.getUniformLocation(this.prog, 'u_img');
     this.uOriginal = gl.getUniformLocation(this.prog, 'u_original');
     this.uReference = gl.getUniformLocation(this.prog, 'u_reference');
@@ -812,10 +821,13 @@ export class GradeRenderer {
     }
   }
 
-  draw(grade, localEdits = [], maskCanvas = undefined, softProof = null) {
+  draw(grade, localEdits = [], maskCanvas = undefined, softProof = null, spotVisualization = null) {
     if (!this.ready) return;
     const gl = this.gl;
     gl.useProgram(this.prog);
+    this.spotVisualization = [spotVisualization?.enabled ? 1 : 0,
+      Math.max(0, Math.min(1, +spotVisualization?.threshold || 0))];
+    gl.uniform2f(this.uSpotVisualization, ...this.spotVisualization);
     for (const [k, def] of Object.entries(GRADE_DEFAULTS)) {
       const v = grade && grade[k] !== undefined ? +grade[k] : def;
       gl.uniform1f(this.uniforms[k], v);
@@ -921,6 +933,7 @@ export class GradeRenderer {
   sample() {
     if (!this.ready) return null;
     const gl = this.gl;
+    gl.uniform2f(this.uSpotVisualization, 0, 0);
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.sampleFramebuffer);
     gl.viewport(0, 0, this.sampleWidth, this.sampleHeight);
     gl.uniform2f(this.uUvScale, 1, 1);
@@ -934,6 +947,7 @@ export class GradeRenderer {
     gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     gl.uniform1f(this.uCompare, this.comparePosition);
     this.applyReferenceUniforms();
+    gl.uniform2f(this.uSpotVisualization, ...this.spotVisualization);
     return { px: this.samplePixels, w: this.sampleWidth, h: this.sampleHeight };
   }
 
@@ -941,6 +955,7 @@ export class GradeRenderer {
   samplePixel(u, v) {
     if (!this.ready) return null;
     const gl = this.gl, pixel = new Uint8Array(4);
+    gl.uniform2f(this.uSpotVisualization, 0, 0);
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.sampleFramebuffer);
     gl.viewport(0, 0, 1, 1);
     gl.uniform2f(this.uUvScale, 0, 0);
@@ -953,6 +968,7 @@ export class GradeRenderer {
     gl.uniform2f(this.uUvOffset, 0, 0);
     gl.uniform1f(this.uCompare, this.comparePosition);
     this.applyReferenceUniforms();
+    gl.uniform2f(this.uSpotVisualization, ...this.spotVisualization);
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     return pixel;


### PR DESCRIPTION
Visualize Spots enlarged the 256-pixel histogram/sampling helper over the sharp preview, obscuring fine detail and omitting current finishing adjustments. Apply the diagnostic view in Metal and WebGL using the current preview texture, keep its state separate from image loading, and restore the normal view when leaving Remove. Histogram and color sampling remain unaffected.

Validation: 320 JavaScript tests; 134 WebGL pixel/compositor checks; focused Metal checks for threshold, zoom, navigation, grading, and exact restoration; 138 focused Python tests (137 passed, one skipped). Verified the controls at 1:1 in the running isolated app. Help and all 19 localization catalogs pass validation. The installed app has not been updated.
