### PR TITLE
Integrate filmstrip, mask, preset, and recorded journey improvements

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           # The cross-platform suite also exercises Linux float ICC transforms.
           # macOS itself uses ColorSync, so this is a test dependency only.
-          brew install little-cms2
+          brew install little-cms2 ffmpeg
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix little-cms2)/lib:/usr/local/lib:/usr/lib" >> "$GITHUB_ENV"
           python -m pip install --upgrade pip
           python -m pip install -r requirements-runtime.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,13 @@ lighttable history list @current --json
 
 See `lighttable --help`, `lighttable schema`, and `CLI.md` for the generated
 command and route reference.
+
+## Recorded journey review
+
+For an on-demand recorded journey review, follow
+`scripts/visual-review/README.md`. Start with `--preflight`; the real native
+recording requires an unlocked graphical session and explicit foreground-test
+authorization. Keep `recorded`, `functional checks passed`, and `visually
+reviewed` separate. Inspect clips and transition frames before recording
+findings in `review.json`; do not automatically approve a baseline. The first
+version covers browse, zoom, basic editing, and bounded exploratory interaction.

--- a/app/main.swift
+++ b/app/main.swift
@@ -1634,7 +1634,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             }
             if let layer = ProcessInfo.processInfo.environment[
                 "LIGHTTABLE_NATIVE_JOURNEY_LAYER"],
-               ["pr", "package", "raw-curated", "raw-full"].contains(layer),
+               ["pr", "package", "raw-curated", "raw-full", "visual-review"].contains(layer),
                let encoded = try? JSONEncoder().encode(layer),
                let json = String(data: encoded, encoding: .utf8) {
                 nativeBootstrap +=
@@ -1670,6 +1670,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, 
             forMainFrameOnly: true))
         webView = LightTableWebView(frame: .zero, configuration: cfg)
         webView.navigationDelegate = self
+        // Only recorded reviews wait for an external recorder's first captured frame.
+        if benchmarkRequested,
+           let readyPath = ProcessInfo.processInfo.environment["LIGHTTABLE_RECORDING_READY"] {
+            let deadline = Date().addingTimeInterval(45)
+            Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] timer in
+                if Date() > deadline { timer.invalidate(); return }
+                if FileManager.default.fileExists(atPath: readyPath) {
+                    self?.webView.evaluateJavaScript("location.protocol === 'http:' && document.querySelector('#appShell') ? (window.__LIGHTTABLE_RECORDING_READY__=true) : false") { result, error in
+                        if error == nil && (result as? Bool) == true { timer.invalidate() }
+                    }
+                }
+            }
+        }
         webView.uiDelegate = self
         webView.setValue(false, forKey: "drawsBackground")
         // The page handles pinch itself; don't let WebKit scale the whole UI.

--- a/build-app.sh
+++ b/build-app.sh
@@ -69,6 +69,10 @@ PLIST
 /usr/libexec/PlistBuddy -c "Add :LightTableProjectDir string $PROJECT" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Add :LightTableSourceRevision string $(git rev-parse HEAD)" "$APP/Contents/Info.plist"
 
+# Record the exact native source inputs; review runs refuse stale developer shells.
+NATIVE_SOURCE_DIGEST="$(cat app/main.swift app/NativePreview.swift app/DiagnosticReports.swift | shasum -a 256 | cut -d ' ' -f 1)"
+/usr/libexec/PlistBuddy -c "Add :LightTableNativeSourceDigest string $NATIVE_SOURCE_DIGEST" "$APP/Contents/Info.plist"
+
 # --- binary -----------------------------------------------------------------
 SWIFT_CACHE="${TMPDIR:-/tmp}/lighttable-swift-module-cache"
 CLANG_CACHE="${TMPDIR:-/tmp}/lighttable-clang-module-cache"

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -191,8 +191,8 @@
         "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
-        "web/preset-browser.css": "b219f60ea85fe2adbb9b40834248137bad15eb9c46074e6a1c56f6b3dbdade9b",
-        "web/preset-browser.js": "0781d320c91562620299d49478dd29ea5b1b6ae9a0e131448c1220500b29780d",
+        "web/preset-browser.css": "095690d8148f331b4cabda69acab59d4a4704fb9769fd2e00b2cb73685bc85d9",
+        "web/preset-browser.js": "57906372bd5988c7d4480ec561912de00654dd4d44e7795ac7e86107f9f92730",
         "web/presets.js": "60dc4c7700e0f41761dfb562ff1b8cf4fb0b2761fe444145e544f1b10ad004af"
       }
     },

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -4,13 +4,13 @@
       "content": "f176c760d71f2141d024f089715f371828dcb3916a9a86bdfbea36dbae67ce87",
       "sources": {
         "README.md": "65abe69d3346211b36de65304d9d48d57945a8506d2826aed13d6ae8ecf41b80",
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b"
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23"
       }
     },
     "add-photos": {
       "content": "ed9c4ac18836826ad67c0ad52e2689c5d46d696548161570ecb8374c777632fa",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "web/first-run.js": "d3e3cc68759c3c7634b44c9edf562b2ae163120ae6255c38941222fa33eeebda",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
@@ -20,7 +20,7 @@
       "content": "a586c04d57e4f936d8a46326c8bf281ff28ee53b1c0679f262a032ec3747d554",
       "sources": {
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786"
       }
@@ -28,8 +28,8 @@
     "browse-folders": {
       "content": "83110cc81ab7af3bec5273ae311e070f452a2972b13822f1164cfde7699d13ac",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -46,7 +46,7 @@
       "content": "9300fd7e981c26e4f2997363e9327fe23bbf8df404cfd80db32dee5cb865abd1",
       "sources": {
         "app/DiagnosticReports.swift": "f658b768399f0b1da70cd1158812c4bd726cafd032155398b266434882054c02",
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "catalog_scan.py": "a4f36ffa249b431642ae6b8af927da3a359ae5c7354f0ab0140491bdfe1759e1",
         "fatal_diagnostics.py": "56b1deacd97f83a19f3d41e0d77ac46e3f3d6b75cb815c043fafec5f443ef2f9",
         "file_identity.py": "e6516b82a587821c2dcb4d7d015847884e72c10f74cb28ce5b18cb60dd9a1c2b",
@@ -60,14 +60,14 @@
     "collections": {
       "content": "95bc3775974e6454f3d55661cf2db268196f4d73750fb1ba7f796bb23379cd36",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -81,16 +81,16 @@
     "editing-color-mixer-point-color": {
       "content": "9cfba81ef549fe43a8d1e2dc1ed7c7cc660202b4f2a640506af71f8e59fb0d7e",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "editing-copy-paste-match-exposure": {
       "content": "efa1eca4d219fc2f23de68e0ee3c69c2d583b900569bd8fdd64f3ea013207e01",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd"
       }
     },
@@ -104,16 +104,16 @@
     "editing-curves": {
       "content": "a2280ce4abd9f79d1c1e6d0673c3d2ef6015fb01a14e4385e3c8621bd6b13a54",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "editing-detail-effects-enhance": {
       "content": "49911d9d38fd2ceaf03c72fb033100ed2b6683610df8c2d67b8139dce6bd03e8",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "enhance_workflow.py": "b2b3fe529770388b3c4bf04345bf995a6d9a70ef866a5e917313f8b3de72506a",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/enhance-panel.js": "6efc59ea9686bf72062453c76d61a9a09ad86511b4d9737e8ba95409fd95daa7",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -122,14 +122,14 @@
       "content": "e65c38833c6557b83b0e471394ed3d4fda54c7e44a5a7f4cba7a7e25fd04df71",
       "sources": {
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "editing-history-snapshots": {
       "content": "86dc3f8196fa62cc452db8d0cf86e40f2fe2450a1c8166cfe812177272853273",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/history-panel.js": "5f7a77338be697479c921dc76a9668e7846c50e75cab47bfd634dfe924faec25",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -137,7 +137,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
@@ -145,7 +145,7 @@
       "content": "b93d29b8af3e46c1f77976f9fec3732bb152c6b506e7bfe1f681d8b6381d4644",
       "sources": {
         "semantic_masks.py": "d48eb799d0c3188d4dc48a573d193eec94fc087b4eb9fba9560ed41b8de585f7",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
@@ -153,7 +153,7 @@
       "content": "9e545e5ed89a7b168be2b0a8eabfea5cec8e882c010910a4615ae425f61bbd5b",
       "sources": {
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/editor-panels.js": "cbb1e16f590167c8f948629f3a851866a94e641daf0bc9af9694cb893d937446",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/mask-curve.js": "4db1ce1aa1d7c959762be56651cc5f7076bd363540309aef6aba3ba5a1bcf281",
@@ -165,7 +165,7 @@
     "editing-masks-ranges-refinements": {
       "content": "69559a947ccd17ddcf891ab7791585d708eaa3b452ac32e1fe6fee456fe90167",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254"
       }
@@ -173,22 +173,22 @@
     "editing-photo-merge": {
       "content": "5030e3092b04c12520f62d83ac0dd9b1f5b09b50e8af8cd1693f190bc63b47c1",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
         "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "editing-presets": {
       "content": "8deccb179e402b4f907687ea12cd7650abaad71b59d14b2901ae26e9812894ec",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "preset_io.py": "ad379b80b1b534c5afde2b54587892440c1be80d314b8a60b6532793a763b97e",
         "preset_library.py": "fb8d27cde136b026d25fe512a281a0d8f6d80a97b9bcbdca667e229162c26358",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
         "web/preset-browser.css": "095690d8148f331b4cabda69acab59d4a4704fb9769fd2e00b2cb73685bc85d9",
@@ -200,7 +200,7 @@
       "content": "3d70eb73feed29823cf507dacaaefa5e836efbeda3815657693341cdb79c297d",
       "sources": {
         "app/NativePreview.metal": "45aa8ae595982903f61554d60f6da370d0e77e905fad335f7ba9e250f0daaa02",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
@@ -209,21 +209,21 @@
     "editing-save-recovery": {
       "content": "5ea77476828b252a78757b30d827464a516994d3c1cf84a3a6041bec601e2b2d",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/edit-save-queue.js": "0d56b96358f6de5ade38c3dd554260f876a746145a89476c0a68e3c16620a574"
       }
     },
     "editing-tone": {
       "content": "2e83d0be17ae55ef2edbd5cb335d18e9d96de22d032056f3dc9027bbe48fc35d",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "editing-white-balance": {
       "content": "f6b3b37c291e9d60356355f3668f15990e40995bedc9062c9a67a3da9425e271",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
@@ -231,7 +231,7 @@
       "content": "007309327e1d2aa65e1c38fea9ce0347ee5b343c9a12b881419000c5ccd44999",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
@@ -239,7 +239,7 @@
       "content": "5945724f1f5a9ad80dabdbb9b1943978a77aa5a373366307f8acc38aabd165f0",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
@@ -254,14 +254,14 @@
       "content": "dbb37c4fdeb501f59294843e33d6aea92727bd952e76e11978a4a14af5535086",
       "sources": {
         "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "external-editor": {
       "content": "905a7f2d9fc297adb88b6aa0c2f0f5bf7b21513ca1db891c3b7a3bf137aac2de",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
@@ -269,7 +269,7 @@
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -278,10 +278,10 @@
       "content": "2ea19e843ce9c9a59afd0e8d2e0a3dd7927a6e7a413dc92a9b64c23f328516b6",
       "sources": {
         "film_tuning.py": "133a5e3200b69b2aa3b92f8bb471c93af449b5036bb8dfdd6610292175693860",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
-        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a"
+        "web/style.css": "f9028a21f691542589e513add5e90a78e11f60fc992c0ddb41fdebd99661c8e8"
       }
     },
     "film-grain-and-format": {
@@ -295,7 +295,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
@@ -303,7 +303,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -311,14 +311,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -344,8 +344,8 @@
     "keyboard-midi": {
       "content": "afa81f9e0bf349d0df5d83bf5a2b09497fd62c2c0ecc69fa629d2fa04382fdf0",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/midi.js": "a74a05ad2303790b15efaf9953afcf60f20ccfabf4d4f8bde7ae2eb99c834175"
       }
@@ -353,9 +353,9 @@
     "metadata-and-keywords": {
       "content": "4070dd0015da08ec42ca3dbf872e0d0e24c046eb2f938cf594101846244587ec",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "keyword_workflow.py": "5c545bd45205bf294d15cddbaf43f27a39ad5c30b69e7f98fab579d2b61a73a4",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/keyword-batch.js": "e38195a5528e40635522473776ba9b0a2052f11a78ac77fb7cfe81fa3cc8a88e",
         "web/metadata-panel.js": "d6be67c2b0b58d543fabee1349bab40bbe40afffb5fe2ecd4414d7c996f69cda"
       }
@@ -380,14 +380,14 @@
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
         "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/preview-detail.js": "8601034c83de06c042fdd5528d7fde5ff69db567bdac7225f3b133b739836acc",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a",
+        "web/style.css": "f9028a21f691542589e513add5e90a78e11f60fc992c0ddb41fdebd99661c8e8",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
     },
@@ -397,16 +397,16 @@
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
         "film_lab_ai/service.py": "fd684477d966d1014c1b72cb843871379db98b41fb800ec9f98a8d75c1eea842",
         "media_availability.py": "cfdfc4495f979f9c6b11686a9bb3610a1c894059eecf896bbcd8730582363272",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a"
+        "web/style.css": "f9028a21f691542589e513add5e90a78e11f60fc992c0ddb41fdebd99661c8e8"
       }
     },
     "raw-jpeg-pairs": {
       "content": "63ef5d08a8d6515e2677eb9344c41edafd7d2b2266703648040f4080033691b2",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -424,7 +424,7 @@
       "sources": {
         "catalog_scan.py": "a4f36ffa249b431642ae6b8af927da3a359ae5c7354f0ab0140491bdfe1759e1",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/library-filters.js": "eea02c5ed7b026e4be6ec7983b1af5af9f66b917c274be54e3b04744b57a4b00",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
@@ -448,7 +448,7 @@
     "settings-language": {
       "content": "94778fce4730a2170969e2c8021322069e60563dc48890e749ff36fbfbc55f6f",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "web/i18n.js": "48ec7b56c856a8db9bcd47315a6c697582a0207a1656d42ed43260c3627b7388",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/locale-bootstrap.js": "06fc13de85d1b216f01742ae5667c03b18a4fd413913281bb87aa7866b287845",
@@ -459,7 +459,7 @@
     "shortcut-schemes": {
       "content": "e6cf59f5fde950bf351b74084189c3d6fb585b9ef8f86c78a01c82db94da584d",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
@@ -468,7 +468,7 @@
       "content": "9b7e47fe1ac1a2ae85a54070f12b51d8876a2d4497b5f3dc3c0857cca2e1da6b",
       "sources": {
         "catalog.py": "9d6441c2da7ae5b4e672776ee7cad5e5fbbde0a8af8a77809244f70644a60110",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
       }
     },
@@ -476,34 +476,34 @@
       "content": "667d42680ff9d3d60918660cb348f4d0add54a7577d29d9db4a20a48495425f0",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "survey-photos": {
       "content": "dc19b008aa782297e49f1abcb77345dba833aaf1d04fed0e7dd83521edff56c1",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/survey.js": "79fd7a71ef314f25e5a6452f9def6d5edeac62799fd1305631f1607724363cc3"
       }
     },
     "trash-rejected": {
       "content": "f52bb62055da510b5960532a68f9c82786187593aaa50a1172a5f2173f8d2fbd",
       "sources": {
-        "app/main.swift": "dc27e7806ea2a0f50f3204f6130893ac5ac71ce87f84a6bc3aac8fbb964b7a0b",
+        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
     "views-and-selection": {
       "content": "5671b035e23cb8bb257863e9ec19b58cad37c37393946f51b4c4e8203313133e",
       "sources": {
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a",
+        "web/style.css": "f9028a21f691542589e513add5e90a78e11f60fc992c0ddb41fdebd99661c8e8",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },
@@ -511,7 +511,7 @@
       "content": "de9620831ddcd8ecee7ce1f29fa1442122cfe5fa8183c0650ee8b3b34210d498",
       "sources": {
         "library_workflow.py": "b07bc79b58666fe92ce189ac4132a6904457e166f73c155f3f636fc683966e3c",
-        "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52"
+        "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20"
       }
     },
     "xmp-interchange": {

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -281,7 +281,7 @@
         "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
-        "web/style.css": "dd54588b2859f6d5bd44102d04c78bdd8ad7ac6d36a7e39a11b473248c3171c6"
+        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a"
       }
     },
     "film-grain-and-format": {
@@ -387,7 +387,7 @@
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "dd54588b2859f6d5bd44102d04c78bdd8ad7ac6d36a7e39a11b473248c3171c6",
+        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
     },
@@ -400,7 +400,7 @@
         "web/app.js": "8057a581880ea4cb461ccafd93ea6aa007fabe6285bf77089a58ef175c734d52",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "dd54588b2859f6d5bd44102d04c78bdd8ad7ac6d36a7e39a11b473248c3171c6"
+        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a"
       }
     },
     "raw-jpeg-pairs": {
@@ -503,7 +503,7 @@
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "dd54588b2859f6d5bd44102d04c78bdd8ad7ac6d36a7e39a11b473248c3171c6",
+        "web/style.css": "4c9190b92967f70cc4bfd76009d9c0f1b1c0891955e3394860c5bf313d648c5a",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },

--- a/docs/localization/source.json
+++ b/docs/localization/source.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd",
   "pluralPairs": [
     {
       "one": " · {count} paired file linked",
@@ -230,10 +230,6 @@
     {
       "one": "{count} preset file could not be read",
       "other": "{count} preset files could not be read"
-    },
-    {
-      "one": "{count} preset · click to apply, click again to turn off",
-      "other": "{count} presets · click to apply, click again to turn off"
     },
     {
       "one": "{count} rated photo",
@@ -4299,8 +4295,6 @@
     "{count} picked photos",
     "{count} preset file could not be read",
     "{count} preset files could not be read",
-    "{count} preset · click to apply, click again to turn off",
-    "{count} presets · click to apply, click again to turn off",
     "{count} rated photo",
     "{count} rated photos",
     "{count} selected",

--- a/docs/localization/web-dynamic-source.json
+++ b/docs/localization/web-dynamic-source.json
@@ -1156,8 +1156,6 @@
   "{count} picked photos",
   "{count} preset file could not be read",
   "{count} preset files could not be read",
-  "{count} preset · click to apply, click again to turn off",
-  "{count} presets · click to apply, click again to turn off",
   "{count} rated photo",
   "{count} rated photos",
   "{count} selected",

--- a/docs/localization/web-plural-source.json
+++ b/docs/localization/web-plural-source.json
@@ -229,10 +229,6 @@
       "other": "{count} preset files could not be read"
     },
     {
-      "one": "{count} preset · click to apply, click again to turn off",
-      "other": "{count} presets · click to apply, click again to turn off"
-    },
-    {
       "one": "{count} rated photo",
       "other": "{count} rated photos"
     },

--- a/scripts/visual-review/README.md
+++ b/scripts/visual-review/README.md
@@ -29,6 +29,22 @@ not launch the app or open a permission prompt. Runs have a hard time limit,
 stop their own app/server/recorder, preserve partial evidence on failure, and
 never automatically approve a baseline.
 
+The first native trial (2026-09-09) produced a partial 90-second recording.
+Do not assume another macOS Space makes this reliable: a second run failed
+to acquire a Metal drawable while Chrome was foreground. No separate Space
+was tested. The first run also showed roughly one-second gesture pacing,
+consistent with background timer throttling; it cannot establish smoothness.
+Each new step logs document visibility and focus to help diagnose this.
+Keep the app visible and active during an authorized trial, or use a dedicated
+test machine. Captured state checks alone do not prove the displayed pixels:
+the trial showed Fit selected while the photograph remained enlarged.
+
+Visual review uses normal saving and edited-thumbnail updates in its isolated
+data. Other benchmark layers retain their existing suppression. The first run
+predated this exemption and failed persistence because the harness suppressed
+saving; that result is not evidence of production data loss. A complete native
+rerun of this correction is still required.
+
 Outputs are in `output/visual-reviews/<timestamp>/`: the original movie,
 source/bundle/fixture hashes, app and server logs, recorded steps, measured
 capture timing, extracted evidence, journey clips, and `index.html`.

--- a/scripts/visual-review/README.md
+++ b/scripts/visual-review/README.md
@@ -1,0 +1,79 @@
+# Recorded journey review
+
+On-demand native visual review, starting with browse, zoom and edit. Run this
+when requested, rather than on every commit. This is a review aid, not an
+exhaustive test or an automated certification of visual quality.
+
+The runner copies the three CC0 photo fixtures into a disposable folder and
+isolates preferences, catalog, caches, presets and instance registration. It
+launches an explicit developer bundle from this checkout. It never launches
+or changes the installed personal app. ScreenCaptureKit records only the
+unique main window owned by the new process, at a requested 60 fps. Recording
+must deliver a frame before the journey starts. Actual timestamps, frame counts
+and dropped frames are retained; requested frame rate is not proof of cadence.
+
+## Run
+
+Build a developer bundle with a distinct identifier:
+
+```sh
+LIGHTTABLE_BUNDLE_IDENTIFIER=org.lighttable.recorded-review bash build-app.sh
+.venv/bin/python scripts/visual-review/run.py --preflight
+.venv/bin/python scripts/visual-review/run.py --allow-foreground
+```
+
+The native launch activates its window. Only pass `--allow-foreground` after
+Nicholas has authorized a foreground testing window, or on a dedicated test
+machine. Screen Recording permission must already be enabled. Preflight does
+not launch the app or open a permission prompt. Runs have a hard time limit,
+stop their own app/server/recorder, preserve partial evidence on failure, and
+never automatically approve a baseline.
+
+Outputs are in `output/visual-reviews/<timestamp>/`: the original movie,
+source/bundle/fixture hashes, app and server logs, recorded steps, measured
+capture timing, extracted evidence, journey clips, and `index.html`.
+
+Use `--previous /absolute/path/to/run` to place a prior recording beside the new
+one. Comparability requires the same fixture hashes, journey script, viewport,
+and capture settings; app changes are expected and recorded. A prior run is
+only a comparison, never an implicitly approved baseline.
+
+## Review protocol
+
+1. Check capture coverage and dropped frames first. Missing or truncated video
+   makes visual verification NOT DONE even if functional assertions passed.
+2. Inspect the browse, zoom and edit clips, including the exploratory section.
+   Examine transition frames at native resolution. A contact sheet is an index,
+   not sufficient evidence that every frame is good.
+3. Inspect flagged transient changes around their timestamps. A flash candidate
+   can be an intended edit, navigation, or recorder artifact. Reproduce it before
+   calling it a product defect. Unflagged video is not a clean visual bill of health.
+4. Record findings in `review.json` with classification `confirmed-bug`,
+   `suspected-bug`, `usability-observation`, or `capture-limitation`, plus journey,
+   timestamp, evidence filename, reproduction steps, impact, and confidence.
+   Set `reviewStatus` to `reviewed` only after actual evidence inspection.
+5. Generate the report again with `run.py --report /absolute/path/to/run`.
+
+The script uses the app's UI command executor and DOM slider/pointer events.
+It does not prove OS input routing, menu interaction, or every feature. Presets,
+RAW decoding, crop, masks, window resizing, export, and restart recovery are
+explicit future coverage. The initial explore section interleaves navigation
+and zoom; add bounded variations after reviewing the core journeys.
+
+## Reference videos
+
+Use `references.json` in a run folder to attach externally obtained references:
+
+```json
+[{"title":"Reference editor zoom workflow", "url":"https://example.org/video",
+  "journey":"zoom", "startSeconds":12, "endSeconds":28,
+  "version":"Version shown in source", "purpose":"workflow-only",
+  "notes":"Tutorial recording; hardware and playback speed unknown"}]
+```
+
+Choose the editor and edition requested by the user. Record source URL,
+app version/date, exact timestamps, and whether footage is edited. Compare
+feedback, discoverability, step count and continuity. Do not infer comparative
+latency or rendering quality from unmatched tutorial recordings. Matched
+performance comparisons require the same photos, machine, settings, dimensions
+and recording method. Missing reference footage is reported as NOT DONE.

--- a/scripts/visual-review/record-window.swift
+++ b/scripts/visual-review/record-window.swift
@@ -1,0 +1,128 @@
+import Foundation
+import AppKit
+import ScreenCaptureKit
+import AVFoundation
+import CoreGraphics
+import QuartzCore
+
+// Dedicated PID/window capture; never captures a display or activates an application.
+final class Recorder: NSObject, SCStreamOutput, SCStreamDelegate {
+    let writer: AVAssetWriter
+    let input: AVAssetWriterInput
+    let ready: URL
+    let metadata: URL
+    var firstPTS: CMTime?
+    var firstEpochMs = 0.0
+    var lastPTS = 0.0
+    var frames = 0
+    var dropped = 0
+    var failure: String?
+    var sampleStatuses: [String: Int] = [:]
+    init(output: URL, ready: URL, metadata: URL, width: Int, height: Int) throws {
+        self.ready = ready; self.metadata = metadata
+        writer = try AVAssetWriter(outputURL: output, fileType: .mov)
+        input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264, AVVideoWidthKey: width,
+            AVVideoHeightKey: height, AVVideoCompressionPropertiesKey: [
+                AVVideoAverageBitRateKey: 16_000_000, AVVideoMaxKeyFrameIntervalKey: 60]])
+        input.expectsMediaDataInRealTime = true
+        super.init()
+        writer.add(input)
+        guard writer.startWriting() else { throw writer.error! }
+    }
+    func stream(_ stream: SCStream, didStopWithError error: Error) { failure = error.localizedDescription }
+    func stream(_ stream: SCStream, didOutputSampleBuffer sample: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .screen else { return }
+        let attachments = CMSampleBufferGetSampleAttachmentsArray(sample, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]]
+        let status = attachments?.first?[.status] as? Int ?? -1
+        sampleStatuses[String(status), default: 0] += 1
+        guard sample.isValid, status == SCFrameStatus.complete.rawValue else { return }
+        let pts = CMSampleBufferGetPresentationTimeStamp(sample)
+        guard input.isReadyForMoreMediaData else { dropped += 1; return }
+        if firstPTS == nil {
+            firstPTS = pts
+            firstEpochMs = (Date().timeIntervalSince1970 + pts.seconds - CACurrentMediaTime()) * 1000
+            writer.startSession(atSourceTime: pts)
+        }
+        if input.append(sample) {
+            frames += 1; lastPTS = pts.seconds
+            if frames == 1 { try? Data("ready".utf8).write(to: ready, options: .atomic) }
+        } else { failure = writer.error?.localizedDescription ?? "Video append failed" }
+    }
+    func finish(window: SCWindow) async throws {
+        let stopPTS = CMClockGetTime(CMClockGetHostTimeClock())
+        if firstPTS != nil {
+            writer.endSession(atSourceTime: stopPTS)
+            input.markAsFinished()
+            await writer.finishWriting()
+        } else {
+            writer.cancelWriting()
+            failure = failure ?? "No complete screen frames were delivered; the session may be locked or the window unavailable"
+        }
+        let result: [String: Any] = ["windowId": window.windowID,
+            "pid": window.owningApplication?.processID ?? 0, "sampleStatuses": sampleStatuses,
+            "firstFrameEpochMs": firstEpochMs, "frames": frames, "droppedFrames": dropped,
+            "durationSeconds": firstPTS.map { stopPTS.seconds - $0.seconds } ?? 0,
+            "lastCompleteFrameSeconds": firstPTS.map { lastPTS - $0.seconds } ?? 0,
+            "width": window.frame.width, "height": window.frame.height,
+            "writerStatus": writer.status.rawValue,
+            "error": failure ?? writer.error?.localizedDescription ?? ""]
+        try JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys]).write(to: metadata)
+        guard writer.status == .completed, frames > 0, failure == nil else {
+            throw NSError(domain: "Recording failed", code: 1)
+        }
+    }
+}
+
+@main struct Main {
+    static func main() async {
+        do {
+            let args = CommandLine.arguments
+            // Initialize WindowServer without a Dock icon, window or activation.
+            _ = await MainActor.run { NSApplication.shared.setActivationPolicy(.prohibited) }
+            if args.count == 2 && args[1] == "--preflight" {
+                let allowed = CGPreflightScreenCaptureAccess()
+                let session = CGSessionCopyCurrentDictionary() as? [String: Any]
+                let locked = session?["CGSSessionScreenIsLocked"] as? Bool ?? false
+                let value: [String: Any] = ["screenRecordingAllowed": allowed, "sessionLocked": locked]
+                print(String(data: try JSONSerialization.data(withJSONObject: value, options: .sortedKeys), encoding: .utf8)!)
+                exit(allowed && !locked ? 0 : 2)
+            }
+            guard args.count == 7, let pid = Int32(args[1]), let duration = Double(args[6]),
+                  duration >= 1, duration <= 600 else {
+                throw NSError(domain: "Usage: record-window PID output.mov ready-file stop-file metadata.json seconds", code: 2)
+            }
+            guard CGPreflightScreenCaptureAccess() else {
+                throw NSError(domain: "Screen Recording permission is required; no permission prompt was opened", code: 3)
+            }
+            let deadline = Date().addingTimeInterval(30)
+            var selected: SCWindow?
+            while Date() < deadline {
+                let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
+                let windows = content.windows.filter { $0.owningApplication?.processID == pid && $0.frame.width >= 1000 && $0.frame.height >= 600 }
+                if windows.count == 1 { selected = windows[0]; break }
+                if windows.count > 1 { throw NSError(domain: "Ambiguous target windows", code: 4) }
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+            guard let window = selected else { throw NSError(domain: "No unique visible window for the launched PID", code: 5) }
+            let config = SCStreamConfiguration()
+            config.width = Int(window.frame.width) / 2 * 2
+            config.height = Int(window.frame.height) / 2 * 2
+            config.minimumFrameInterval = CMTime(value: 1, timescale: 60)
+            config.queueDepth = 6; config.showsCursor = false
+            let recorder = try Recorder(output: URL(fileURLWithPath: args[2]), ready: URL(fileURLWithPath: args[3]),
+                metadata: URL(fileURLWithPath: args[5]), width: config.width, height: config.height)
+            let stream = SCStream(filter: SCContentFilter(desktopIndependentWindow: window), configuration: config, delegate: recorder)
+            let queue = DispatchQueue(label: "lighttable.review.capture")
+            try stream.addStreamOutput(recorder, type: .screen, sampleHandlerQueue: queue)
+            try await stream.startCapture()
+            let end = Date().addingTimeInterval(duration)
+            while Date() < end && !FileManager.default.fileExists(atPath: args[4]) {
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+            try await stream.stopCapture()
+            queue.sync {}
+            try await recorder.finish(window: window)
+        } catch { fputs("\(error)\n", stderr); exit(1) }
+    }
+}

--- a/scripts/visual-review/run.py
+++ b/scripts/visual-review/run.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Record bounded native journeys and retain honest, reviewable evidence."""
+from __future__ import annotations
+import argparse
+import hashlib
+import html
+import importlib.util
+import json
+import os
+from pathlib import Path
+import platform
+import plistlib
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location('native_smoke', ROOT / 'scripts/native-app-smoke.py')
+smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(smoke)
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + '\n')
+
+
+def digest(path):
+    h = hashlib.sha256()
+    with path.open('rb') as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b''): h.update(block)
+    return h.hexdigest()
+
+
+def checked(args, **kwargs):
+    return subprocess.run([str(x) for x in args], check=True, capture_output=True,
+                          text=True, timeout=kwargs.pop('timeout', 120), **kwargs).stdout
+
+
+def stop(process):
+    if process is None: return
+    # Each child gets a new session. Kill only the owned group, including servers.
+    try: os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError: return
+    try: process.wait(timeout=5)
+    except subprocess.TimeoutExpired: pass
+    try: os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError: pass
+    process.wait(timeout=5)
+
+
+def recorder_binary():
+    source = HERE / 'record-window.swift'
+    folder = ROOT / 'build/visual-review'
+    folder.mkdir(parents=True, exist_ok=True)
+    binary = folder / 'record-window'
+    stamp = folder / 'recorder.sha256'
+    if not binary.is_file() or not stamp.is_file() or stamp.read_text() != digest(source):
+        checked(['swiftc', '-parse-as-library', '-O', source, '-o', binary])
+        stamp.write_text(digest(source))
+    return binary
+
+
+def preflight(app):
+    checks = []
+    for tool in ['swiftc', 'ffmpeg', 'ffprobe']:
+        checks.append({'check': tool, 'ok': bool(shutil.which(tool))})
+    recorder = None
+    if platform.system() != 'Darwin':
+        checks.append({'check': 'macOS required', 'ok': False})
+        return checks, recorder
+    try:
+        recorder = recorder_binary()
+        result = subprocess.run([str(recorder), '--preflight'], capture_output=True, text=True, timeout=10)
+        permission = json.loads(result.stdout)
+        checks.append({'check': 'screen-recording-permission', 'ok': permission['screenRecordingAllowed'],
+                       'detail': 'Run outside the filesystem sandbox if the host already has permission'})
+        checks.append({'check': 'unlocked-graphical-session', 'ok': not permission['sessionLocked'],
+                       'detail': 'Unlock the Mac before native capture'})
+    except Exception as error:
+        checks.append({'check': 'recorder-build', 'ok': False, 'detail': str(error)})
+    try:
+        smoke.require_bundle(app)
+        info = plistlib.loads((app / 'Contents/Info.plist').read_bytes())
+        if Path(info.get('LightTableProjectDir', '')).resolve() != ROOT:
+            raise ValueError('Use a developer bundle built from this review checkout')
+        if info.get('CFBundleIdentifier') in {'com.reville.lighttable', 'org.lighttable.LightTable'}:
+            raise ValueError('Build with a distinct recorded-review bundle identifier')
+        native_sources = b''.join((ROOT / path).read_bytes() for path in
+            ['app/main.swift', 'app/NativePreview.swift', 'app/DiagnosticReports.swift'])
+        if info.get('LightTableNativeSourceDigest') != hashlib.sha256(native_sources).hexdigest():
+            raise ValueError('Native sources changed after this bundle was built; rebuild before recording')
+        checks.append({'check': 'isolated-review-bundle', 'ok': True})
+    except Exception as error:
+        checks.append({'check': 'isolated-review-bundle', 'ok': False, 'detail': str(error)})
+    return checks, recorder
+
+
+def completed_steps(folder):
+    log = folder / 'native-perf.jsonl'
+    records = []
+    if log.is_file():
+        for line in log.read_text().splitlines():
+            try:
+                entry = json.loads(line)
+                if entry.get('stage') == 'visual-step-end': records.append(entry)
+            except json.JSONDecodeError: continue
+    return records
+
+
+def capture_coverage(metadata, steps):
+    start = metadata.get('firstFrameEpochMs', 0)
+    end = start + metadata.get('durationSeconds', 0) * 1000
+    return bool(steps and metadata.get('frames', 0) > 0 and not metadata.get('error')
+                and start <= min(s['startedEpochMs'] for s in steps)
+                and end >= max(s['endedEpochMs'] for s in steps))
+
+
+def transient_candidates(frames, fps=60):
+    """A-B-A transient changes; only review candidates, never confirmed defects."""
+    import numpy as np
+    candidates = []
+    for i in range(1, len(frames) - 1):
+        a, b, c = (np.asarray(frame, dtype=np.float32) for frame in frames[i-1:i+2])
+        incoming = float(np.mean(np.abs(b - a)))
+        outgoing = float(np.mean(np.abs(c - b)))
+        returned = float(np.mean(np.abs(c - a)))
+        if min(incoming, outgoing) > 12 and returned < min(incoming, outgoing) * .35:
+            candidates.append({'seconds': i / fps, 'meanChange': round(incoming, 2),
+                               'classification': 'unreviewed-transient-candidate'})
+    return candidates
+
+
+def analyze(folder, steps):
+    import numpy as np
+    movie = folder / 'window.mov'
+    metadata = json.loads((folder / 'capture.json').read_text())
+    origin = metadata['firstFrameEpochMs']
+    probe = json.loads(checked(['ffprobe', '-v', 'error', '-show_streams', '-show_format', '-of', 'json', movie]))
+    write_json(folder / 'video-probe.json', probe)
+    metadata['encodedDurationSeconds'] = float(probe['format']['duration'])
+    metadata['durationSeconds'] = min(metadata['durationSeconds'], metadata['encodedDurationSeconds'])
+    # Decode continuously at 60fps; reduced grayscale is for flags, not visual proof.
+    # The run cap bounds this allocation to approximately 132 MB at 600 seconds.
+    decoded = subprocess.run(['ffmpeg', '-v', 'error', '-i', str(movie), '-vf',
+        'fps=60,scale=80:46,format=gray', '-f', 'rawvideo', '-'],
+        check=True, capture_output=True, timeout=120).stdout
+    frames = np.frombuffer(decoded, dtype=np.uint8).reshape(-1, 46, 80)
+    candidates = transient_candidates(frames)
+    write_json(folder / 'frame-analysis.json', {'method': 'A-B-A mean absolute grayscale difference; threshold 12/255, return ratio <0.35',
+        'limitations': 'Candidates only. Resampling cannot reveal uncaptured frames. Not a stretching detector or a visual pass.',
+        'decodedFrames': len(frames), 'candidates': candidates})
+    assets = folder / 'evidence'; assets.mkdir(exist_ok=True)
+    for journey in dict.fromkeys(s['journey'] for s in steps):
+        group = [s for s in steps if s['journey'] == journey]
+        start = max(0, (group[0]['startedEpochMs'] - origin) / 1000 - .3)
+        end = (group[-1]['endedEpochMs'] - origin) / 1000 + .3
+        checked(['ffmpeg', '-v', 'error', '-y', '-ss', start, '-i', movie, '-t', end-start,
+                 '-an', '-c:v', 'libx264', '-crf', '18', '-pix_fmt', 'yuv420p', '-movflags', '+faststart',
+                 assets / f'{journey}.mp4'])
+    for i, step in enumerate(steps):
+        start = (step['startedEpochMs'] - origin) / 1000
+        duration = step['durationMs'] / 1000
+        step['videoStartSeconds'] = round(start, 3)
+        for label, offset in [('start', .05), ('middle', duration / 2), ('end', max(0, duration-.05))]:
+            checked(['ffmpeg', '-v', 'error', '-y', '-ss', max(0, start+offset), '-i', movie,
+                     '-frames:v', '1', assets / f'{i:02d}-{label}.png'])
+    for i, candidate in enumerate(candidates[:20]):
+        checked(['ffmpeg', '-v', 'error', '-y', '-ss', max(0, candidate['seconds']-.2), '-i', movie,
+                 '-t', '.5', '-an', '-c:v', 'libx264', '-crf', '16', assets / f'candidate-{i:02d}.mp4'])
+    write_json(folder / 'steps.json', steps)
+    return {'coverageComplete': capture_coverage(metadata, steps), 'capture': metadata,
+            'transientCandidates': len(candidates), 'reviewStatus': 'not-reviewed'}
+
+
+def report(folder):
+    def load(name, default):
+        path = folder / name
+        return json.loads(path.read_text()) if path.is_file() else default
+    result = load('result.json', {'status': 'NOT DONE'})
+    steps = load('steps.json', [])
+    review = load('review.json', {'reviewStatus': 'not-reviewed', 'findings': []})
+    refs = load('references.json', [])
+    analysis = load('frame-analysis.json', {})
+    esc = lambda x: html.escape(str(x), quote=True)
+    parts = [f'<p class="label">LightTable · Recorded journey review</p><h1>{esc(result.get("status", "NOT DONE"))}</h1>',
+             '<p>Functional assertions, capture coverage and visual inspection are reported separately.</p>',
+             f'<p>Visual review: <strong>{esc(review.get("reviewStatus", "not-reviewed"))}</strong></p>']
+    if result.get('error'): parts.append(f'<p><strong>Blocker:</strong> {esc(result["error"])}</p>')
+    parts.append('<h2>Run evidence</h2><ul>')
+    for name in ['setup.json', 'preflight.json', 'provenance.json', 'result.json', 'capture.json', 'frame-analysis.json', 'review.json', 'steps.json', 'window.mov']:
+        if (folder / name).is_file(): parts.append(f'<li><a href="{name}">{name}</a></li>')
+    parts.append('</ul>')
+    if result.get('previous'):
+        previous = Path(result['previous'])
+        parts.append(f'<p>Previous run: <a href="{esc(os.path.relpath(previous / "index.html", folder))}">open report</a>. '
+                     f'Comparable setup: {esc(result.get("previousComparable", False))}. This does not approve a baseline.</p>')
+    for journey in ['browse', 'zoom', 'edit', 'explore']:
+        clip = folder / 'evidence' / f'{journey}.mp4'
+        parts.append(f'<h2>{journey.title()}</h2>')
+        if clip.is_file():
+            parts.append(f'<video controls preload="metadata" src="evidence/{journey}.mp4"></video>')
+            previous_clip = Path(result.get('previous', '/nonexistent')) / 'evidence' / f'{journey}.mp4'
+            if previous_clip.is_file():
+                parts.append(f'<p>Previous recording</p><video controls preload="metadata" src="{esc(os.path.relpath(previous_clip, folder))}"></video>')
+        else: parts.append('<p>Video: NOT DONE.</p>')
+        parts.append('<table><tr><th>Action</th><th>Functional check</th><th>Time in full video</th></tr>')
+        for step in steps:
+            if step['journey'] == journey:
+                parts.append(f'<tr><td>{esc(step["name"])}</td><td>{esc(step["status"])}</td><td>{esc(step.get("videoStartSeconds", "unavailable"))}</td></tr>')
+        parts.append('</table>')
+        for i, step in enumerate(steps):
+            if step['journey'] != journey: continue
+            images = [f'evidence/{i:02d}-{label}.png' for label in ['start', 'middle', 'end']]
+            if all((folder / name).is_file() for name in images):
+                parts.append(f'<details><summary>{esc(step["name"])} — three frame samples</summary><div class="frames">')
+                for name, label in zip(images, ['Start', 'Middle', 'End']):
+                    parts.append(f'<a href="{name}"><img loading="lazy" src="{name}" alt="{esc(step["name"])}: {label}"><span>{label}</span></a>')
+                parts.append('</div></details>')
+    parts.append('<h2>Transient candidates</h2><p>Automated flags for inspection, not confirmed product bugs.</p>')
+    for i, candidate in enumerate(analysis.get('candidates', [])[:20]):
+        clip = f'evidence/candidate-{i:02d}.mp4'
+        if (folder / clip).is_file():
+            parts.append(f'<p>Full recording: {esc(candidate["seconds"])} seconds</p><video controls preload="metadata" src="{clip}"></video>')
+    if not analysis: parts.append('<p>NOT DONE — no analyzable recording.</p>')
+    elif not analysis.get('candidates'): parts.append('<p>No transient candidates at the configured threshold. Visual review is still required.</p>')
+    parts.append('<h2>Findings</h2>')
+    if not review.get('findings'): parts.append('<p>No reviewed findings recorded. This is not a claim that the app has no issues.</p>')
+    for finding in review.get('findings', []):
+        parts.append(f'<article><h3>{esc(finding.get("title", "Finding"))}</h3><p>{esc(finding.get("classification"))} · {esc(finding.get("confidence"))}</p><p>{esc(finding.get("journey", ""))} · {esc(finding.get("timestampSeconds", ""))} seconds · {esc(finding.get("impact", ""))}</p><p>{esc(finding.get("description", ""))}</p><p>{esc(finding.get("reproduction", ""))}</p>')
+        evidence = finding.get('evidence')
+        if isinstance(evidence, str):
+            target = (folder / evidence).resolve()
+            if target.is_relative_to(folder.resolve()) and target.is_file():
+                parts.append(f'<p><a href="{esc(evidence)}">Finding evidence</a></p>')
+        parts.append('</article>')
+    parts.append('<h2>Reference comparisons</h2>')
+    if not refs: parts.append('<p>NOT DONE — no reference footage has been attached and reviewed.</p>')
+    for ref in refs:
+        url = str(ref.get('url', ''))
+        if not url.startswith(('https://', 'http://')): continue
+        parts.append(f'<p><a href="{esc(url)}">{esc(ref.get("title", "Reference"))}</a> · {esc(ref.get("journey"))} · {esc(ref.get("purpose"))}</p><p>{esc(ref.get("notes", ""))}</p>')
+    parts.append('<h2>Coverage limits</h2><p>Scripted UI commands and DOM events. This first version covers browse, zoom, basic exposure, undo/redo, compare, and navigation persistence. Presets, RAW decoding, crop, masks, window resizing, export, restart recovery and OS input routing are not covered.</p><p>Frame-change flags require review. Sparse extracted frames cannot rule out brief flicker. Capture settings and dropped frames affect what can be concluded.</p>')
+    page = '''<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>LightTable journey review</title><style>
+:root{--ink:#1a1a1a;--muted:#55575c;--line:#e5e5e5}*{box-sizing:border-box}body{margin:0;background:#fff;color:var(--ink);font:16px/1.6 Inter,system-ui,sans-serif}main{max-width:1120px;margin:auto;padding:56px 24px 96px}h1,h2,h3,.label{font-family:"Space Mono",ui-monospace,monospace}h1{font-size:40px}h2{font-size:22px;margin-top:56px;border-bottom:1px solid var(--line);padding-bottom:16px}.label{font-size:13px;letter-spacing:.22em;text-transform:uppercase;color:var(--muted)}a{color:#1e40af}video{width:100%;background:#111}table{width:100%;border-collapse:collapse;font-size:15px}td,th{text-align:left;border-bottom:1px solid var(--line);padding:12px}article{border:1px solid var(--line);padding:20px;margin:24px 0}p{max-width:76ch}.frames{display:flex;gap:12px;margin:16px 0}.frames a{flex:1;min-width:0;font-size:13px}.frames img{width:100%;height:auto}summary{cursor:pointer;padding:12px 0}@media(max-width:600px){.frames{display:block}h1{font-size:30px}}</style><main>'''+''.join(parts)+'</main></html>'
+    (folder / 'index.html').write_text(page)
+    return folder / 'index.html'
+
+
+def run(args):
+    folder = args.output.resolve() if args.output else ROOT / 'output/visual-reviews' / time.strftime('%Y%m%d-%H%M%S')
+    folder.mkdir(parents=True, exist_ok=False)
+    result = {'status': 'NOT DONE', 'functionalStatus': 'not-run', 'visualStatus': 'not-reviewed', 'run': str(folder)}
+    write_json(folder / 'setup.json', {'sourceRevision': checked(['git', 'rev-parse', 'HEAD'], cwd=ROOT).strip(),
+        'app': str(args.app), 'foregroundAuthorized': args.allow_foreground, 'timeoutSeconds': args.timeout})
+    app_process = recording = None
+    logs = []
+    try:
+        checks, recorder = preflight(args.app)
+        write_json(folder / 'preflight.json', checks)
+        if not all(c['ok'] for c in checks): raise RuntimeError('Preflight failed: ' + '; '.join(c['check']+': '+c.get('detail', 'unavailable') for c in checks if not c['ok']))
+        if not args.allow_foreground: raise RuntimeError('Foreground testing is not authorized; pass --allow-foreground only after permission')
+        fixtures = [ROOT / 'tests/fixtures/photos' / name for name in ['field.jpg', 'portrait.jpg', 'still-life.jpg']]
+        smoke.validate_fixtures(tuple(fixtures), 'pr')
+        state = folder / 'isolated'; photos = state / 'photos'; photos.mkdir(parents=True)
+        for source in fixtures: shutil.copy2(source, photos / source.name)
+        # Enough entries for a real scrolling grid; copies stay in disposable data.
+        for i in range(30): shutil.copy2(fixtures[i % 3], photos / f'review-{i:02d}.jpg')
+        native = args.app / 'Contents/MacOS/LightTable'
+        provenance = {'sourceRevision': checked(['git', 'rev-parse', 'HEAD'], cwd=ROOT).strip(),
+            'sourceDiffSha256': hashlib.sha256(checked(['git', 'diff', 'HEAD'], cwd=ROOT).encode()).hexdigest(),
+            'journeySha256': digest(ROOT / 'web/visual-journey.js'), 'nativeBinarySha256': digest(native),
+            'engineBinarySha256': digest(ROOT / 'rust-engine/target/release/lighttable-engine'),
+            'fixtureHashes': {p.name: digest(p) for p in fixtures}, 'requestedFps': 60,
+            'captureSize': 'window logical size, even pixels', 'machine': platform.platform(),
+            'app': str(args.app), 'sourceFiles': {str(p.relative_to(ROOT)): digest(p) for p in [ROOT/'app/main.swift', ROOT/'web/app.js', ROOT/'web/visual-journey.js', HERE/'run.py', HERE/'record-window.swift']}}
+        write_json(folder / 'provenance.json', provenance)
+        if args.previous:
+            prior = json.loads((args.previous / 'provenance.json').read_text())
+            result['previous'] = str(args.previous.resolve())
+            result['previousComparable'] = all(prior.get(k) == provenance[k] for k in ['journeySha256', 'fixtureHashes', 'requestedFps', 'captureSize', 'machine'])
+        gate = folder / 'recording.ready'; stop_file = folder / 'recording.stop'
+        env = smoke.smoke_environment(state, photos, folder / 'benchmark.json', folder / 'unused.png', 'visual-review')
+        env.pop('LIGHTTABLE_NATIVE_JOURNEY_SCREENSHOT', None)
+        env['LIGHTTABLE_RECORDING_READY'] = str(gate)
+        env['LIGHTTABLE_NATIVE_BENCHMARK_QUIT'] = '0'
+        env['LIGHTTABLE_NATIVE_PERF_LOG'] = str(folder / 'native-perf.jsonl')
+        env['LIGHTTABLE_SERVER_LOG'] = str(folder / 'server.log')
+        env['LIGHTTABLE_PREFS_FILE'] = str(state / 'prefs.json')
+        write_json(state / 'prefs.json', {'smoothZoom': True, 'allowAutomation': True, 'autoAdvance': False})
+        app_log = (folder / 'app.log').open('w'); logs.append(app_log)
+        app_process = subprocess.Popen([str(native)], cwd=args.app.parent, env=env,
+            stdout=app_log, stderr=subprocess.STDOUT, start_new_session=True)
+        result['appPid'] = app_process.pid
+        record_log = (folder / 'recorder.log').open('w'); logs.append(record_log)
+        recording = subprocess.Popen([str(recorder), str(app_process.pid), str(folder / 'window.mov'),
+            str(gate), str(stop_file), str(folder / 'capture.json'), str(args.timeout)],
+            stdout=record_log, stderr=subprocess.STDOUT, start_new_session=True)
+        deadline = time.monotonic() + args.timeout
+        while time.monotonic() < deadline and app_process.poll() is None and not (folder / 'benchmark.json').is_file():
+            if recording.poll() is not None: raise RuntimeError('Recorder exited before the native journey finished; inspect recorder.log')
+            time.sleep(.2)
+        if not (folder / 'benchmark.json').is_file(): raise RuntimeError(f'Native review did not finish within {args.timeout}s (exit={app_process.poll()})')
+        # Capture a short tail, then finish the movie before analyzing it.
+        time.sleep(.5)
+        stop_file.write_text('stop')
+        recording.wait(timeout=20)
+        if recording.returncode: raise RuntimeError('Recording did not finalize successfully')
+        payload = json.loads((folder / 'benchmark.json').read_text())
+        steps = completed_steps(folder); write_json(folder / 'steps.json', steps)
+        result.update(analyze(folder, steps))
+        if payload.get('error'): raise RuntimeError(payload['error'])
+        if not steps or any(s['status'] != 'passed' for s in steps): raise RuntimeError('Functional journey incomplete')
+        if {s['journey'] for s in steps} != {'browse', 'zoom', 'edit', 'explore'}: raise RuntimeError('Required journeys missing')
+        if not result['coverageComplete']: raise RuntimeError('Video did not cover every journey step')
+        if any(digest(ROOT / name) != sha for name, sha in provenance['sourceFiles'].items()):
+            raise RuntimeError('Source files changed during the recorded review')
+        result['functionalStatus'] = 'passed'
+        result['status'] = 'RECORDED — visual review pending'
+    except Exception as error:
+        result['error'] = str(error)
+    finally:
+        if recording and recording.poll() is None:
+            (folder / 'recording.stop').write_text('stop')
+            try: recording.wait(timeout=15)
+            except subprocess.TimeoutExpired: pass
+        stop(recording); stop(app_process)
+        for log in logs: log.close()
+        steps = completed_steps(folder)
+        if steps and (folder / 'capture.json').is_file() and (folder / 'window.mov').is_file() and not (folder / 'frame-analysis.json').exists():
+            try: result.update(analyze(folder, steps))
+            except Exception as error: result['partialAnalysisError'] = str(error)
+        if not (folder / 'steps.json').exists(): write_json(folder / 'steps.json', steps)
+        write_json(folder / 'result.json', result)
+        write_json(folder / 'review.json', {'reviewStatus': 'not-reviewed', 'findings': []})
+        report(folder)
+    print(json.dumps(result, indent=2))
+    return 0 if result['functionalStatus'] == 'passed' else 2
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--app', type=Path, default=ROOT / 'build/LightTable.app')
+    parser.add_argument('--preflight', action='store_true')
+    parser.add_argument('--allow-foreground', action='store_true')
+    parser.add_argument('--timeout', type=int, default=300)
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--previous', type=Path)
+    parser.add_argument('--report', type=Path)
+    args = parser.parse_args()
+    args.app = args.app.expanduser().resolve()
+    if not 30 <= args.timeout <= 600: parser.error('--timeout must be between 30 and 600 seconds')
+    if args.report: print(report(args.report.resolve())); return
+    if args.preflight:
+        checks, _ = preflight(args.app); print(json.dumps(checks, indent=2))
+        sys.exit(0 if all(c['ok'] for c in checks) else 2)
+    sys.exit(run(args))
+
+
+if __name__ == '__main__': main()

--- a/scripts/visual-review/run.py
+++ b/scripts/visual-review/run.py
@@ -188,6 +188,7 @@ def report(folder):
     parts = [f'<p class="label">LightTable · Recorded journey review</p><h1>{esc(result.get("status", "NOT DONE"))}</h1>',
              '<p>Functional assertions, capture coverage and visual inspection are reported separately.</p>',
              f'<p>Visual review: <strong>{esc(review.get("reviewStatus", "not-reviewed"))}</strong></p>']
+    if review.get('summary'): parts.append(f'<p>{esc(review["summary"])}</p>')
     if result.get('error'): parts.append(f'<p><strong>Blocker:</strong> {esc(result["error"])}</p>')
     parts.append('<h2>Run evidence</h2><ul>')
     for name in ['setup.json', 'preflight.json', 'provenance.json', 'result.json', 'capture.json', 'frame-analysis.json', 'review.json', 'steps.json', 'window.mov']:
@@ -311,7 +312,9 @@ def run(args):
         payload = json.loads((folder / 'benchmark.json').read_text())
         steps = completed_steps(folder); write_json(folder / 'steps.json', steps)
         result.update(analyze(folder, steps))
-        if payload.get('error'): raise RuntimeError(payload['error'])
+        if payload.get('error'):
+            result['functionalStatus'] = 'failed'
+            raise RuntimeError(payload['error'])
         if not steps or any(s['status'] != 'passed' for s in steps): raise RuntimeError('Functional journey incomplete')
         if {s['journey'] for s in steps} != {'browse', 'zoom', 'edit', 'explore'}: raise RuntimeError('Required journeys missing')
         if not result['coverageComplete']: raise RuntimeError('Video did not cover every journey step')

--- a/tests/test_visual_review.py
+++ b/tests/test_visual_review.py
@@ -1,0 +1,88 @@
+"""Evidence-integrity tests for the opt-in review runner."""
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location('visual_review', ROOT / 'scripts/visual-review/run.py')
+review = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(review)
+
+
+class VisualReviewTests(unittest.TestCase):
+    def test_capture_must_cover_first_and_last_action(self):
+        steps = [{'startedEpochMs': 1000, 'endedEpochMs': 2000}]
+        metadata = {'firstFrameEpochMs': 900, 'frames': 60, 'durationSeconds': 1.2}
+        self.assertTrue(review.capture_coverage(metadata, steps))
+        for bad in [dict(metadata, firstFrameEpochMs=1100),
+                    dict(metadata, durationSeconds=.9), dict(metadata, frames=0),
+                    dict(metadata, error='encoder failed')]:
+            self.assertFalse(review.capture_coverage(bad, steps))
+        self.assertFalse(review.capture_coverage(metadata, []))
+
+    def test_single_frame_flash_is_a_candidate_not_a_bug(self):
+        frames = np.full((8, 8, 8), 80, dtype=np.uint8)
+        frames[3] = 200
+        found = review.transient_candidates(frames)
+        self.assertEqual(len(found), 1)
+        self.assertAlmostEqual(found[0]['seconds'], 3 / 60)
+        self.assertEqual(found[0]['classification'], 'unreviewed-transient-candidate')
+
+    def test_steady_frames_and_persistent_edits_are_not_flash_candidates(self):
+        frames = np.full((8, 8, 8), 80, dtype=np.uint8)
+        self.assertEqual(review.transient_candidates(frames), [])
+        frames[3:] = 200
+        self.assertEqual(review.transient_candidates(frames), [])
+
+    def test_partial_log_preserves_failed_action(self):
+        with tempfile.TemporaryDirectory() as name:
+            folder = Path(name)
+            (folder / 'native-perf.jsonl').write_text('\n'.join([
+                json.dumps({'stage': 'visual-step-start', 'name': 'pan'}),
+                json.dumps({'stage': 'visual-step-end', 'name': 'pan', 'status': 'failed'}),
+                '{truncated']))
+            self.assertEqual(review.completed_steps(folder)[0]['status'], 'failed')
+
+    def test_report_never_claims_missing_video_or_unreviewed_success(self):
+        with tempfile.TemporaryDirectory() as name:
+            folder = Path(name)
+            review.write_json(folder / 'result.json', {'status': 'NOT DONE', 'error': '<script>alert(1)</script>'})
+            output = review.report(folder).read_text()
+            self.assertIn('Video: NOT DONE.', output)
+            self.assertIn('not-reviewed', output)
+            self.assertIn('&lt;script&gt;', output)
+            self.assertNotIn('<script>alert', output)
+            self.assertNotIn('<video', output)
+
+    def test_real_video_pipeline_produces_clips_and_reviewable_frames(self):
+        # Synthetic codec fixture only; never used as product screenshot evidence.
+        with tempfile.TemporaryDirectory() as name:
+            folder = Path(name)
+            review.checked(['ffmpeg', '-v', 'error', '-f', 'lavfi', '-i',
+                'testsrc2=size=160x100:rate=60:duration=3', '-c:v', 'libx264',
+                '-pix_fmt', 'yuv420p', folder / 'window.mov'])
+            review.write_json(folder / 'capture.json', {'firstFrameEpochMs': 1000,
+                'frames': 180, 'durationSeconds': 3, 'error': ''})
+            steps = [{'journey': journey, 'name': journey, 'status': 'passed',
+                'startedEpochMs': 1100 + i * 600, 'endedEpochMs': 1500 + i * 600,
+                'durationMs': 400} for i, journey in enumerate(['browse', 'zoom', 'edit', 'explore'])]
+            result = review.analyze(folder, steps)
+            self.assertTrue(result['coverageComplete'])
+            self.assertEqual(result['reviewStatus'], 'not-reviewed')
+            for journey in ['browse', 'zoom', 'edit', 'explore']:
+                self.assertGreater((folder / 'evidence' / f'{journey}.mp4').stat().st_size, 100)
+            self.assertEqual(len(list((folder / 'evidence').glob('*.png'))), 12)
+            self.assertIn('three frame samples', review.report(folder).read_text())
+
+    def test_cleanup_terminates_owned_process(self):
+        child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'], start_new_session=True)
+        review.stop(child)
+        self.assertIsNotNone(child.poll())
+
+
+if __name__ == '__main__': unittest.main()

--- a/web/app.js
+++ b/web/app.js
@@ -3053,6 +3053,13 @@ function waitForBenchmarkSettled(
 
 async function runNativeBenchmark(width, iterations) {
   try {
+    if (window.__LIGHTTABLE_NATIVE_JOURNEY_LAYER__ === 'visual-review') {
+      const deadline = performance.now() + 45000;
+      while (!window.__LIGHTTABLE_RECORDING_READY__) {
+        if (performance.now() > deadline) throw new Error('Window recording did not become ready');
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
     const presentation = nativePreviewActive() ? 'native-metal' : 'webgl';
     postNative('nativeBenchmarkProgress', { stage: 'started', width, iterations });
     $('engine').value = 'rs';
@@ -3220,6 +3227,12 @@ async function waitForJourneyExport(timeoutMs = 180000) {
 }
 
 async function runNativeProductJourney(width, layer) {
+  if (layer === 'visual-review') {
+    const { runVisualJourney } = await import('/web/visual-journey.js');
+    return runVisualJourney({ S, $, cur, visible, executeUICommand, uiStateReport,
+      nativePreviewActive, postNative, pushUndo, drawGrade, saveState,
+      waitForJourneyFrame, editSaveQueue });
+  }
   if (layer === 'raw-curated' || layer === 'raw-full') {
     return runNativeRawJourney(width, layer);
   }

--- a/web/app.js
+++ b/web/app.js
@@ -4623,7 +4623,7 @@ window.addEventListener('beforeunload', (event) => {
 });
 
 function saveState(immediate = false) {
-  if (window.__LIGHTTABLE_BENCHMARK__) return Promise.resolve(true);
+  if (window.__LIGHTTABLE_BENCHMARK__ && window.__LIGHTTABLE_NATIVE_JOURNEY_LAYER__ !== 'visual-review') return Promise.resolve(true);
   const im = cur();
   if (!im || S.editingName !== im.name) return immediate ? flushEditSaves() : Promise.resolve(true);
   readControls();
@@ -4922,7 +4922,7 @@ function pumpEditedThumbnailQueue() {
 
 function queueEditedThumbnail(im, attempt = 0) {
   if (im?.availability === 'cloud-only') return;
-  if (!im || im.kind === 'video' || window.__LIGHTTABLE_BENCHMARK__) return;
+  if (!im || im.kind === 'video' || (window.__LIGHTTABLE_BENCHMARK__ && window.__LIGHTTABLE_NATIVE_JOURNEY_LAYER__ !== 'visual-review')) return;
   const visible = !_editedThumbnailObserver || im === cur() ||
     [...document.querySelectorAll('img[data-thumbnail-name]')].some(
       (image) => image.dataset.thumbnailName === im.name &&

--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ar",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} صور مختارة",
     "{count} preset file could not be read": "تعذر قراءة {count} ملف إعداد مسبق",
     "{count} preset files could not be read": "تعذر قراءة {count} من ملفات الإعدادات المسبقة",
-    "{count} preset · click to apply, click again to turn off": "{count} إعداد مسبق · انقر لتطبيقه، وانقر مرة أخرى لإيقافه",
-    "{count} presets · click to apply, click again to turn off": "{count} إعدادات مسبقة · انقر لتطبيقها، وانقر مرة أخرى لإيقافها",
     "{count} rated photo": "{count} صورة مُقيَّمة",
     "{count} rated photos": "{count} صورة مُقيَّمة",
     "{count} selected": "{count} محدد",
@@ -4640,14 +4638,6 @@
       "many": "‏{value} حالات خروج غير متوقعة خلال آخر 24 ساعة.",
       "other": "‏{value} حالة خروج غير متوقعة خلال آخر 24 ساعة."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "zero": "{count} إعدادات مسبقة · انقر لتطبيقها، وانقر مرة أخرى لإيقافها",
-      "one": "{count} إعداد مسبق · انقر لتطبيقه، وانقر مرة أخرى لإيقافه",
-      "two": "{count} إعدادان مسبقان · انقر لتطبيقهما، وانقر مرة أخرى لإيقافهما",
-      "few": "{count} إعدادات مسبقة · انقر لتطبيقها، وانقر مرة أخرى لإيقافها",
-      "many": "{count} إعدادات مسبقة · انقر لتطبيقها، وانقر مرة أخرى لإيقافها",
-      "other": "{count} إعدادات مسبقة · انقر لتطبيقها، وانقر مرة أخرى لإيقافها"
-    },
     "{count} empty file": {
       "zero": "{count} ملفات فارغة",
       "one": "{count} ملف فارغ",
@@ -4713,5 +4703,5 @@
       "other": "تم تخطي {count} صورة غير متاحة"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/bn.json
+++ b/web/locales/bn.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "bn",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count}টি ফটো বাছাই করা হয়েছে",
     "{count} preset file could not be read": "{count}টি প্রিসেট ফাইল পড়া যায়নি",
     "{count} preset files could not be read": "{count}টি প্রিসেট ফাইল পড়া যায়নি",
-    "{count} preset · click to apply, click again to turn off": "{count}টি প্রিসেট · প্রয়োগ করতে ক্লিক করুন, বন্ধ করতে আবার ক্লিক করুন",
-    "{count} presets · click to apply, click again to turn off": "{count}টি প্রিসেটসমূহ · প্রয়োগ করতে ক্লিক করুন, বন্ধ করতে আবার ক্লিক করুন",
     "{count} rated photo": "{count}টি রেটেড ছবি",
     "{count} rated photos": "{count}টি ফটো রেটেড",
     "{count} selected": "{count}টি নির্বাচিত",
@@ -4384,10 +4382,6 @@
       "one": "গত ২৪ ঘণ্টায় {value}টি অপ্রত্যাশিত প্রস্থান হয়েছে।",
       "other": "গত ২৪ ঘণ্টায় {value}টি অপ্রত্যাশিত প্রস্থান হয়েছে।"
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count}টি প্রিসেট · প্রয়োগ করতে ক্লিক করুন, বন্ধ করতে আবার ক্লিক করুন",
-      "other": "{count}টি প্রিসেটগুলো · প্রয়োগ করতে ক্লিক করুন, বন্ধ করতে আবার ক্লিক করুন"
-    },
     "{count} empty file": {
       "one": "{count}টি ফাঁকা ফাইল",
       "other": "{count}টি ফাঁকা ফাইল"
@@ -4421,5 +4415,5 @@
       "other": "{count}টি অনুপলব্ধ ফটো এড়িয়ে গেছে"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "de",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} Fotos ausgewählt",
     "{count} preset file could not be read": "{count} Vorgabedatei konnte nicht gelesen werden",
     "{count} preset files could not be read": "{count} Vorgabedateien konnten nicht gelesen werden",
-    "{count} preset · click to apply, click again to turn off": "{count} Vorgabe · zum Anwenden klicken, erneut klicken zum Ausschalten",
-    "{count} presets · click to apply, click again to turn off": "{count} Vorgaben · zum Anwenden klicken, erneut klicken zum Ausschalten",
     "{count} rated photo": "{count} bewertetes Foto",
     "{count} rated photos": "{count} bewertete Fotos",
     "{count} selected": "{count} ausgewählt",
@@ -4384,10 +4382,6 @@
       "one": "{value} unerwarteter Beenden in den letzten 24 Stunden.",
       "other": "{value} unerwartete Beenden in den letzten 24 Stunden."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} Vorgabe · zum Anwenden klicken, erneut klicken zum Ausschalten",
-      "other": "{count} Vorgaben · zum Anwenden klicken, erneut klicken zum Ausschalten"
-    },
     "{count} empty file": {
       "one": "{count} leere Datei",
       "other": "{count} leere Dateien"
@@ -4421,5 +4415,5 @@
       "other": "{count} nicht verfügbare Fotos übersprungen"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "locale": "en",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd",
   "plurals": {
     " · {count} paired file linked": {
       "one": " · {count} paired file linked",
@@ -231,10 +231,6 @@
     "{count} preset file could not be read": {
       "one": "{count} preset file could not be read",
       "other": "{count} preset files could not be read"
-    },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} preset · click to apply, click again to turn off",
-      "other": "{count} presets · click to apply, click again to turn off"
     },
     "{count} rated photo": {
       "one": "{count} rated photo",
@@ -4300,8 +4296,6 @@
     "{count} picked photos": "{count} picked photos",
     "{count} preset file could not be read": "{count} preset file could not be read",
     "{count} preset files could not be read": "{count} preset files could not be read",
-    "{count} preset · click to apply, click again to turn off": "{count} preset · click to apply, click again to turn off",
-    "{count} presets · click to apply, click again to turn off": "{count} presets · click to apply, click again to turn off",
     "{count} rated photo": "{count} rated photo",
     "{count} rated photos": "{count} rated photos",
     "{count} selected": "{count} selected",

--- a/web/locales/es.json
+++ b/web/locales/es.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "es",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} fotos seleccionadas",
     "{count} preset file could not be read": "no se pudo leer {count} archivo de ajuste preestablecido",
     "{count} preset files could not be read": "no se pudieron leer {count} archivos de ajuste preestablecido",
-    "{count} preset · click to apply, click again to turn off": "{count} ajuste preestablecido · haz clic para aplicar, haz clic de nuevo para desactivarlo",
-    "{count} presets · click to apply, click again to turn off": "{count} ajustes preestablecidos · haz clic para aplicar, haz clic de nuevo para desactivarlos",
     "{count} rated photo": "{count} foto calificada",
     "{count} rated photos": "{count} fotos calificadas",
     "{count} selected": "{count} seleccionado",
@@ -4448,11 +4446,6 @@
       "many": "{value} salidas inesperadas en las últimas 24 horas.",
       "other": "{value} salidas inesperadas en las últimas 24 horas."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} ajuste preestablecido · haz clic para aplicar, haz clic de nuevo para desactivarlo",
-      "many": "{count} ajustes preestablecidos · haz clic para aplicar, haz clic de nuevo para desactivarlos",
-      "other": "{count} ajustes preestablecidos · haz clic para aplicar, haz clic de nuevo para desactivarlos"
-    },
     "{count} empty file": {
       "one": "{count} archivo vacío",
       "many": "{count} archivos vacíos",
@@ -4494,5 +4487,5 @@
       "other": "Se omitieron {count} fotos no disponibles"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "fr",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} photos sélectionnées",
     "{count} preset file could not be read": "{count} fichier de préréglage n’a pas pu être lu",
     "{count} preset files could not be read": "{count} fichier de préréglage n’a pas pu être lu",
-    "{count} preset · click to apply, click again to turn off": "{count} préréglage · cliquez pour appliquer, cliquez à nouveau pour désactiver",
-    "{count} presets · click to apply, click again to turn off": "{count} préréglages · cliquez pour appliquer, cliquez à nouveau pour désactiver",
     "{count} rated photo": "{count} photo notée",
     "{count} rated photos": "{count} photos notées",
     "{count} selected": "{count} sélectionné",
@@ -4448,11 +4446,6 @@
       "many": "{value} fermetures inattendues au cours des dernières 24 heures.",
       "other": "{value} fermetures inattendues au cours des dernières 24 heures."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} préréglage · cliquez pour appliquer, cliquez à nouveau pour désactiver",
-      "many": "{count} préréglages · cliquez pour appliquer, cliquez à nouveau pour désactiver",
-      "other": "{count} préréglages · cliquez pour appliquer, cliquez à nouveau pour désactiver"
-    },
     "{count} empty file": {
       "one": "{count} fichier vide",
       "many": "{count} fichiers vides",
@@ -4494,5 +4487,5 @@
       "other": "{count} photos indisponibles ignorées"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/help/ar.json
+++ b/web/locales/help/ar.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "ar",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/bn.json
+++ b/web/locales/help/bn.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "bn",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/de.json
+++ b/web/locales/help/de.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "de",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/es.json
+++ b/web/locales/help/es.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "es",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/fr.json
+++ b/web/locales/help/fr.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "fr",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/hi.json
+++ b/web/locales/help/hi.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "hi",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/id.json
+++ b/web/locales/help/id.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "id",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/it.json
+++ b/web/locales/help/it.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "it",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/ja.json
+++ b/web/locales/help/ja.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "ja",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/ko.json
+++ b/web/locales/help/ko.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "ko",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/nl.json
+++ b/web/locales/help/nl.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "nl",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/pl.json
+++ b/web/locales/help/pl.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "pl",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/pt.json
+++ b/web/locales/help/pt.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "pt",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/ru.json
+++ b/web/locales/help/ru.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "ru",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/th.json
+++ b/web/locales/help/th.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "th",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/tr.json
+++ b/web/locales/help/tr.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "tr",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/vi.json
+++ b/web/locales/help/vi.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "vi",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/zh-Hans.json
+++ b/web/locales/help/zh-Hans.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "zh-Hans",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/help/zh-Hant.json
+++ b/web/locales/help/zh-Hant.json
@@ -3156,5 +3156,5 @@
     }
   ],
   "locale": "zh-Hant",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2"
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87"
 }

--- a/web/locales/hi.json
+++ b/web/locales/hi.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "hi",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} फ़ोटो चुना गया",
     "{count} preset file could not be read": "{count} प्रीसेट फ़ाइल पढ़ी नहीं जा सकी",
     "{count} preset files could not be read": "{count} प्रीसेट फ़ाइलें पढ़ी नहीं जा सकीं",
-    "{count} preset · click to apply, click again to turn off": "{count} प्रीसेट · लागू करने के लिए क्लिक करें, बंद करने के लिए फिर से क्लिक करें",
-    "{count} presets · click to apply, click again to turn off": "{count} प्रीसेट · लागू करने के लिए क्लिक करें, बंद करने के लिए फिर से क्लिक करें",
     "{count} rated photo": "{count} रेटेड फ़ोटो",
     "{count} rated photos": "{count} रेटेड फ़ोटो",
     "{count} selected": "{count} चयनित",
@@ -4384,10 +4382,6 @@
       "one": "पिछले 24 घंटों में {value} अप्रत्याशित निकास।",
       "other": "पिछले 24 घंटों में {value} अप्रत्याशित निकास।"
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} प्रीसेट · लागू करने के लिए क्लिक करें, बंद करने के लिए फिर से क्लिक करें",
-      "other": "{count} प्रीसेट · लागू करने के लिए क्लिक करें, बंद करने के लिए फिर से क्लिक करें"
-    },
     "{count} empty file": {
       "one": "{count} खाली फ़ाइल",
       "other": "{count} खाली फ़ाइलें"
@@ -4421,5 +4415,5 @@
       "other": "{count} अनुपलब्ध फ़ोटो छोड़ी गईं"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/id.json
+++ b/web/locales/id.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "id",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} foto terpilih",
     "{count} preset file could not be read": "{count} file preset tidak dapat dibaca",
     "{count} preset files could not be read": "{count} file preset tidak dapat dibaca",
-    "{count} preset · click to apply, click again to turn off": "{count} preset · klik untuk menerapkan, klik lagi untuk mematikan",
-    "{count} presets · click to apply, click again to turn off": "{count} preset · klik untuk menerapkan, klik lagi untuk mematikan",
     "{count} rated photo": "{count} foto dinilai",
     "{count} rated photos": "{count} foto dinilai",
     "{count} selected": "{count} terpilih",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "{value} keluar tak terduga dalam 24 jam terakhir."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count} preset · klik untuk menerapkan, klik lagi untuk mematikan"
-    },
     "{count} empty file": {
       "other": "{count} file kosong"
     },
@@ -4348,5 +4343,5 @@
       "other": "{count} foto tidak tersedia dilewati"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "it",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} foto selezionata",
     "{count} preset file could not be read": "non è stato possibile leggere {count} file di predefiniti",
     "{count} preset files could not be read": "non è stato possibile leggere {count} file di predefiniti",
-    "{count} preset · click to apply, click again to turn off": "{count} predefinito · fai clic per applicare, fai clic di nuovo per disattivarlo",
-    "{count} presets · click to apply, click again to turn off": "{count} predefiniti · fai clic per applicare, fai clic di nuovo per disattivarli",
     "{count} rated photo": "{count} foto classificata",
     "{count} rated photos": "{count} foto classificate",
     "{count} selected": "{count} selezionati",
@@ -4448,11 +4446,6 @@
       "many": "{value} arresti imprevisti nelle ultime 24 ore.",
       "other": "{value} arresti imprevisti nelle ultime 24 ore."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} predefinito · fai clic per applicare, fai clic di nuovo per disattivarlo",
-      "many": "{count} predefiniti · fai clic per applicare, fai clic di nuovo per disattivarli",
-      "other": "{count} predefiniti · fai clic per applicare, fai clic di nuovo per disattivarli"
-    },
     "{count} empty file": {
       "one": "{count} file vuoto",
       "many": "{count} file vuoti",
@@ -4494,5 +4487,5 @@
       "other": "{count} foto non disponibili saltate"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ja",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count}件の写真を選択済み",
     "{count} preset file could not be read": "{count} 個のプリセットファイルを読み取れませんでした",
     "{count} preset files could not be read": "{count} 個のプリセットファイルを読み取れませんでした",
-    "{count} preset · click to apply, click again to turn off": "{count}個のプリセット · クリックして適用、もう一度クリックしてオフ",
-    "{count} presets · click to apply, click again to turn off": "{count}個のプリセット · クリックして適用、もう一度クリックしてオフ",
     "{count} rated photo": "{count}件の評価済み写真",
     "{count} rated photos": "{count}件の評価済み写真",
     "{count} selected": "{count} 件選択済み",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "過去24時間に予期しない終了が {value} 回発生しました。"
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count}個のプリセット · クリックして適用、もう一度クリックしてオフ"
-    },
     "{count} empty file": {
       "other": "{count}個の空のファイル"
     },
@@ -4348,5 +4343,5 @@
       "other": "利用できない写真 {count} 件をスキップしました"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ko",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "선택됨 {count}장 사진",
     "{count} preset file could not be read": "사전 설정 파일 {count}개를 읽을 수 없었습니다",
     "{count} preset files could not be read": "사전 설정 파일 {count}개를 읽을 수 없었습니다",
-    "{count} preset · click to apply, click again to turn off": "{count}개의 사전 설정 · 클릭하여 적용, 다시 클릭하여 끄기",
-    "{count} presets · click to apply, click again to turn off": "{count}개의 사전 설정 · 클릭하여 적용, 다시 클릭하여 끄기",
     "{count} rated photo": "평가된 사진 {count}장",
     "{count} rated photos": "평가된 사진 {count}장",
     "{count} selected": "선택됨 {count}개",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "지난 24시간 동안 예기치 않은 종료가 {value}번 있었습니다."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count}개의 사전 설정 · 클릭하여 적용, 다시 클릭하여 끄기"
-    },
     "{count} empty file": {
       "other": "빈 파일 {count}개"
     },
@@ -4348,5 +4343,5 @@
       "other": "사용할 수 없는 사진 {count}개 건너뜀"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "nl",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} foto's gekozen",
     "{count} preset file could not be read": "{count} voorinstellingsbestand kon niet worden gelezen",
     "{count} preset files could not be read": "{count} voorinstellingsbestand(en) konden niet worden gelezen",
-    "{count} preset · click to apply, click again to turn off": "{count} voorinstelling · klik om toe te passen, klik nogmaals om uit te schakelen",
-    "{count} presets · click to apply, click again to turn off": "{count} voorinstellingen · klik om toe te passen, klik nogmaals om uit te schakelen",
     "{count} rated photo": "{count} beoordeelde foto",
     "{count} rated photos": "{count} beoordeelde foto's",
     "{count} selected": "{count} geselecteerd",
@@ -4384,10 +4382,6 @@
       "one": "{value} onverwachte afsluiting in de afgelopen 24 uur.",
       "other": "{value} onverwachte afsluitingen in de afgelopen 24 uur."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} voorinstelling · klik om toe te passen, klik nogmaals om uit te schakelen",
-      "other": "{count} voorinstellingen · klik om toe te passen, klik nogmaals om uit te schakelen"
-    },
     "{count} empty file": {
       "one": "{count} leeg bestand",
       "other": "{count} lege bestanden"
@@ -4421,5 +4415,5 @@
       "other": "{count} niet-beschikbare foto's overgeslagen"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "pl",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} wybrane zdjęcia",
     "{count} preset file could not be read": "nie udało się odczytać {count} pliku presetu",
     "{count} preset files could not be read": "nie udało się odczytać {count} plików presetów",
-    "{count} preset · click to apply, click again to turn off": "{count} preset · kliknij, aby zastosować, kliknij ponownie, aby wyłączyć",
-    "{count} presets · click to apply, click again to turn off": "{count} presety · kliknij, aby zastosować, kliknij ponownie, aby wyłączyć",
     "{count} rated photo": "{count} ocenione zdjęcie",
     "{count} rated photos": "{count} ocenione zdjęcia",
     "{count} selected": "{count} wybranych",
@@ -4512,12 +4510,6 @@
       "many": "{value} nieoczekiwanych zakończeń w ciągu ostatnich 24 godzin.",
       "other": "{value} nieoczekiwanych zakończeń w ciągu ostatnich 24 godzin."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} preset · kliknij, aby zastosować, kliknij ponownie, aby wyłączyć",
-      "few": "{count} presety · kliknij, aby zastosować, kliknij ponownie, aby wyłączyć",
-      "many": "{count} presetów · kliknij, aby zastosować, kliknij ponownie, aby wyłączyć",
-      "other": "{count} presetów · kliknij, aby zastosować, kliknij ponownie, aby wyłączyć"
-    },
     "{count} empty file": {
       "one": "{count} pusty plik",
       "few": "{count} puste pliki",
@@ -4567,5 +4559,5 @@
       "other": "{count} niedostępnych zdjęć pominięto"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/pt.json
+++ b/web/locales/pt.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "pt",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} fotos selecionadas",
     "{count} preset file could not be read": "não foi possível ler {count} arquivo de predefinição",
     "{count} preset files could not be read": "não foi possível ler {count} arquivos de predefinição",
-    "{count} preset · click to apply, click again to turn off": "{count} predefinição · clique para aplicar, clique novamente para desligar",
-    "{count} presets · click to apply, click again to turn off": "{count} predefinições · clique para aplicar, clique novamente para desligar",
     "{count} rated photo": "{count} foto com avaliação",
     "{count} rated photos": "{count} fotos com avaliação",
     "{count} selected": "{count} selecionado",
@@ -4448,11 +4446,6 @@
       "many": "{value} saídas inesperadas nas últimas 24 horas.",
       "other": "{value} saídas inesperadas nas últimas 24 horas."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} predefinição · clique para aplicar, clique novamente para desligar",
-      "many": "{count} predefinições · clique para aplicar, clique novamente para desligar",
-      "other": "{count} predefinições · clique para aplicar, clique novamente para desligar"
-    },
     "{count} empty file": {
       "one": "{count} arquivo vazio",
       "many": "{count} arquivos vazios",
@@ -4494,5 +4487,5 @@
       "other": "{count} fotos indisponíveis ignoradas"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/ru.json
+++ b/web/locales/ru.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ru",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "выбрано {count} фото",
     "{count} preset file could not be read": "не удалось прочитать {count} файл пресета",
     "{count} preset files could not be read": "не удалось прочитать {count} файл пресета",
-    "{count} preset · click to apply, click again to turn off": "{count} пресет · щелкните, чтобы применить, щелкните еще раз, чтобы выключить",
-    "{count} presets · click to apply, click again to turn off": "{count} пресетов · щелкните, чтобы применить, щелкните еще раз, чтобы выключить",
     "{count} rated photo": "{count} оцененное фото",
     "{count} rated photos": "оцененных фото: {count}",
     "{count} selected": "{count} выбрано",
@@ -4512,12 +4510,6 @@
       "many": "{value} неожиданных выходов за последние 24 часа.",
       "other": "{value} неожиданных выходов за последние 24 часа."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} пресет · щелкните, чтобы применить, щелкните еще раз, чтобы выключить",
-      "few": "{count} пресета · щелкните, чтобы применить, щелкните еще раз, чтобы выключить",
-      "many": "{count} пресетов · щелкните, чтобы применить, щелкните еще раз, чтобы выключить",
-      "other": "{count} пресета · щелкните, чтобы применить, щелкните еще раз, чтобы выключить"
-    },
     "{count} empty file": {
       "one": "{count} пустой файл",
       "few": "{count} пустых файла",
@@ -4567,5 +4559,5 @@
       "other": "{count} недоступных фото пропущено"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/th.json
+++ b/web/locales/th.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "th",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "เลือกแล้ว {count} ภาพถ่าย",
     "{count} preset file could not be read": "ไม่สามารถอ่านไฟล์พรีเซ็ต {count} ไฟล์ได้",
     "{count} preset files could not be read": "ไม่สามารถอ่านไฟล์พรีเซ็ต {count} ไฟล์ได้",
-    "{count} preset · click to apply, click again to turn off": "{count} พรีเซ็ต · คลิกเพื่อใช้ คลิกอีกครั้งเพื่อปิด",
-    "{count} presets · click to apply, click again to turn off": "{count} พรีเซ็ต · คลิกเพื่อใช้ คลิกอีกครั้งเพื่อปิด",
     "{count} rated photo": "ภาพถ่ายที่มีคะแนน {count} ภาพ",
     "{count} rated photos": "ภาพถ่ายที่มีคะแนน {count} ภาพ",
     "{count} selected": "เลือกแล้ว {count} รายการ",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "การออกโดยไม่คาดคิด {value} ครั้งใน 24 ชั่วโมงที่ผ่านมา"
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count} พรีเซ็ต · คลิกเพื่อใช้ คลิกอีกครั้งเพื่อปิด"
-    },
     "{count} empty file": {
       "other": "{count} ไฟล์ที่ว่างเปล่า"
     },
@@ -4348,5 +4343,5 @@
       "other": "ข้ามรูปภาพที่ไม่พร้อมใช้งาน {count} รูป"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/tr.json
+++ b/web/locales/tr.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "tr",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} seçilmiş fotoğraf",
     "{count} preset file could not be read": "{count} hazır ayar dosyası okunamadı",
     "{count} preset files could not be read": "{count} hazır ayar dosyası okunamadı",
-    "{count} preset · click to apply, click again to turn off": "{count} hazır ayar · uygulamak için tıklayın, kapatmak için tekrar tıklayın",
-    "{count} presets · click to apply, click again to turn off": "{count} hazır ayar · uygulamak için tıklayın, kapatmak için tekrar tıklayın",
     "{count} rated photo": "{count} puanlanmış fotoğraf",
     "{count} rated photos": "{count} puanlanmış fotoğraf",
     "{count} selected": "{count} seçildi",
@@ -4384,10 +4382,6 @@
       "one": "son 24 saatte {value} beklenmeyen çıkış.",
       "other": "son 24 saatte {value} beklenmeyen çıkış."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "one": "{count} hazır ayar · uygulamak için tıklayın, kapatmak için tekrar tıklayın",
-      "other": "{count} hazır ayar · uygulamak için tıklayın, kapatmak için tekrar tıklayın"
-    },
     "{count} empty file": {
       "one": "{count} boş dosya",
       "other": "{count} boş dosya"
@@ -4421,5 +4415,5 @@
       "other": "{count} kullanılamayan fotoğraf atlandı"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/vi.json
+++ b/web/locales/vi.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "vi",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} ảnh đã chọn",
     "{count} preset file could not be read": "không thể đọc {count} tệp thiết lập sẵn",
     "{count} preset files could not be read": "không thể đọc {count} tệp thiết lập sẵn",
-    "{count} preset · click to apply, click again to turn off": "{count} thiết lập sẵn · nhấp để áp dụng, nhấp lại để tắt",
-    "{count} presets · click to apply, click again to turn off": "{count} thiết lập sẵn · nhấp để áp dụng, nhấp lại để tắt",
     "{count} rated photo": "{count} ảnh đã gắn sao",
     "{count} rated photos": "{count} ảnh đã gắn sao",
     "{count} selected": "Đã chọn {count}",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "{value} lần thoát bất thường trong 24 giờ qua."
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count} thiết lập sẵn · nhấp để áp dụng, nhấp lại để tắt"
-    },
     "{count} empty file": {
       "other": "{count} tệp trống"
     },
@@ -4348,5 +4343,5 @@
       "other": "Đã bỏ qua {count} ảnh không khả dụng"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/zh-Hans.json
+++ b/web/locales/zh-Hans.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "zh-Hans",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} 张已选取照片",
     "{count} preset file could not be read": "{count} 个预设文件无法读取",
     "{count} preset files could not be read": "{count} 个预设文件无法读取",
-    "{count} preset · click to apply, click again to turn off": "{count} 个预设 · 点击以应用，再次点击以关闭",
-    "{count} presets · click to apply, click again to turn off": "{count} 个预设 · 点击以应用，再次点击以关闭",
     "{count} rated photo": "{count} 张已评分照片",
     "{count} rated photos": "{count} 张已评分照片",
     "{count} selected": "已选择 {count} 项",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "过去 24 小时内有 {value} 次意外退出。"
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count} 个预设 · 点击以应用，再次点击以关闭"
-    },
     "{count} empty file": {
       "other": "{count} 个空文件"
     },
@@ -4348,5 +4343,5 @@
       "other": "已跳过 {count} 张不可用照片"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/locales/zh-Hant.json
+++ b/web/locales/zh-Hant.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "zh-Hant",
-  "sourceDigest": "a44068fe1e8d365cc9d6050c48c75b880717292d897e32dbbf136dd2d33ca4e2",
+  "sourceDigest": "08cf59c39b7f4278df6466a59b2e22107196fb338c1a5544c9ba6d826dba8f87",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -4005,8 +4005,6 @@
     "{count} picked photos": "{count} 張已選取相片",
     "{count} preset file could not be read": "{count} 個預設集檔案無法讀取",
     "{count} preset files could not be read": "{count} 個預設集檔案無法讀取",
-    "{count} preset · click to apply, click again to turn off": "{count} 個預設集 · 點擊以套用，再次點擊以關閉",
-    "{count} presets · click to apply, click again to turn off": "{count} 個預設集 · 點擊以套用，再次點擊以關閉",
     "{count} rated photo": "{count} 張已評分照片",
     "{count} rated photos": "{count} 張已評分照片",
     "{count} selected": "已選取 {count} 個",
@@ -4320,9 +4318,6 @@
     "{value} unexpected exit in the last 24 hours.": {
       "other": "過去 24 小時內有 {value} 次非預期結束。"
     },
-    "{count} preset · click to apply, click again to turn off": {
-      "other": "{count} 個預設集 · 點擊以套用，再次點擊以關閉"
-    },
     "{count} empty file": {
       "other": "{count} 個空白檔案"
     },
@@ -4348,5 +4343,5 @@
       "other": "已略過 {count} 張無法使用的照片"
     }
   },
-  "pluralsDigest": "b6a0d1e9d8137d9d65510e6ca73c8263efe4b04750658084992dd6d281750452"
+  "pluralsDigest": "c417039fd0d51412fbc9cb239b97feb6377486f94ed666b8e588462bb0ad46dd"
 }

--- a/web/preset-browser.css
+++ b/web/preset-browser.css
@@ -6,6 +6,7 @@
 .preset-browser-filters button[aria-pressed="true"], .preset-browser-manage[aria-expanded="true"] { border-color:var(--slider-accent); background:var(--on-soft); color:var(--on-ink); }
 .preset-browser-hint, .preset-browser-status { margin:0; color:var(--muted); font-size:11px; line-height:1.5; }
 .preset-browser-status { color:var(--ink-2); }
+.preset-browser > .preset-browser-status:empty { display:none; }
 .preset-browser-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; }
 .preset-browser-card { position:relative; min-width:0; }
 .preset-browser-apply { display:flex; flex-direction:column; width:100%; height:100%; min-height:0; padding:0 0 9px; overflow:hidden; text-align:left; white-space:normal; background:var(--inset); }

--- a/web/preset-browser.js
+++ b/web/preset-browser.js
@@ -506,8 +506,7 @@ export function createPresetBrowser({
         : search.value || tag.value ? tr('No matching presets.')
         : collection === 'yours' ? tr('Save your current look, import presets, or add one from Community.')
         : communityLoading ? '' : tr('No presets in this collection yet.')
-      : trn('{count} preset · click to apply, click again to turn off',
-        '{count} presets · click to apply, click again to turn off', filtered.length);
+      : '';
     grid.replaceChildren(); cards.clear(); detail.hidden = !selected;
     if (selected) {
       // Refresh an installed listing after updates while retaining remote identity.

--- a/web/style.css
+++ b/web/style.css
@@ -1029,10 +1029,10 @@ a.reset:hover { color:#fff; }
 .selected-tool-header span, .selected-tool-header strong { display:block; }
 .selected-tool-header span { color:var(--muted); font-size:11px; }
 .selected-tool-header strong { margin-top:2px; color:var(--ink); font-size:12px; }
-.mask-refine-bar { display:flex; gap:4px; padding:8px 0 4px; }
-.mask-refine-bar button { flex:1; min-width:0; min-height:28px; display:flex; align-items:center; justify-content:center; gap:4px; padding:3px 4px; border-radius:var(--radius-s); color:var(--muted); font-size:11px; }
+.mask-refine-bar { display:flex; flex-wrap:wrap; gap:4px; padding:8px 0 4px; }
+.mask-refine-bar button { flex:1 0 auto; min-width:0; max-width:100%; min-height:28px; display:flex; align-items:center; justify-content:center; gap:4px; padding:3px 4px; border-radius:var(--radius-s); color:var(--muted); font-size:11px; white-space:normal; overflow-wrap:anywhere; }
 .mask-refine-bar button[aria-pressed="true"] { border-color:#666; background:var(--active); color:#fff; }
-.mask-refine-bar button span { color:var(--accent); font-size:14px; }
+.mask-refine-bar button span { flex-shrink:0; color:var(--accent); font-size:14px; }
 .mask-quick-actions { display:flex; align-items:center; gap:20px; padding:2px 0 4px; }
 .mask-overlay-row { min-height:32px; display:grid; grid-template-columns:14px 12px minmax(0,1fr) auto; align-items:center; gap:8px; padding:3px 0; color:var(--ink-2); font-size:12px; }
 .mask-overlay-row small { color:var(--muted-2); font-size:11px; }

--- a/web/style.css
+++ b/web/style.css
@@ -762,14 +762,13 @@ body.filmstrip-resizing { cursor:ns-resize; user-select:none; }
 .filmstrip-context small { color:var(--muted); margin-top:3px; font-size:11px; }
 .strip { min-width:0; flex:1; display:flex; gap:6px; overflow-x:auto; overflow-y:hidden; align-items:center; padding:8px 12px; }
 .strip-spacer { flex:0 0 0; height:1px; pointer-events:none; }
-.thumb { position:relative; flex:0 0 clamp(64px,calc(var(--filmstrip-h) - 22px),238px); height:clamp(64px,calc(var(--filmstrip-h) - 22px),238px); border:2px solid transparent; border-radius:var(--radius-s); opacity:.72; transition:opacity .12s ease,border-color .12s ease; }
-.thumb:hover { opacity:1; }
-.thumb.cur { opacity:1; border-color:var(--accent); }
-.thumb.msel { opacity:1; border-color:#8ac2ff; box-shadow:inset 0 0 0 1px rgba(138,194,255,.45); }
+.thumb { position:relative; flex:0 0 clamp(64px,calc(var(--filmstrip-h) - 22px),238px); height:clamp(64px,calc(var(--filmstrip-h) - 22px),238px); border:2px solid transparent; border-radius:var(--radius-s); transition:border-color .12s ease; }
+.thumb.cur { border-color:var(--accent); }
+.thumb.msel { border-color:#8ac2ff; box-shadow:inset 0 0 0 1px rgba(138,194,255,.45); }
 .thumb img { display:block; width:100%; height:100%; object-fit:cover; border-radius:2px; background:#292929; }
-.thumb .dot { position:absolute; top:4px; right:4px; width:8px; height:8px; border-radius:50%; box-shadow:0 0 0 1px rgba(0,0,0,.7); }
-.thumb.approved .dot { background:var(--ok); }
-.thumb.skipped .dot { background:var(--skip); }
+.thumb .dot { display:none; position:absolute; top:4px; right:4px; width:8px; height:8px; border-radius:50%; box-shadow:0 0 0 1px rgba(0,0,0,.7); }
+.thumb.approved .dot { display:block; background:var(--ok); }
+.thumb.skipped .dot { display:block; background:var(--skip); }
 
 /* Right tool rail and inspector */
 .right-shell { min-width:0; min-height:0; overflow:hidden; display:grid; grid-template-columns:minmax(0,316px) 56px; border-left:1px solid var(--line); background:var(--chrome); }

--- a/web/visual-journey.js
+++ b/web/visual-journey.js
@@ -3,6 +3,7 @@ export async function runVisualJourney(ctx) {
   const { S, $, cur, executeUICommand: command, uiStateReport: state,
     nativePreviewActive, postNative, pushUndo, editSaveQueue } = ctx;
   const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const environment = () => ({visibility: document.visibilityState, hasFocus: document.hasFocus()});
   const steps = [];
   const names = S.images.map(image => image.name);
   if (names.length < 3) throw new Error('Visual review requires at least three copied photos');
@@ -17,7 +18,7 @@ export async function runVisualJourney(ctx) {
     throw new Error('Selected photo did not settle in the native renderer');
   };
   const step = async (journey, name, action, check = () => true) => {
-    const entry = {journey, name, startedEpochMs: Date.now(), before: state()};
+    const entry = {journey, name, startedEpochMs: Date.now(), before: state(), environmentBefore: environment()};
     postNative('nativeBenchmarkProgress', {stage: 'visual-step-start', ...entry});
     try {
       await action(); await sleep(650);
@@ -29,6 +30,7 @@ export async function runVisualJourney(ctx) {
     } finally {
       entry.endedEpochMs = Date.now(); entry.durationMs = entry.endedEpochMs - entry.startedEpochMs;
       entry.after = state(); steps.push(entry);
+      entry.environmentAfter = environment();
       postNative('nativeBenchmarkProgress', {stage: 'visual-step-end', ...entry});
     }
   };

--- a/web/visual-journey.js
+++ b/web/visual-journey.js
@@ -1,0 +1,121 @@
+// Loaded only by the opt-in native visual-review journey. No normal startup work.
+export async function runVisualJourney(ctx) {
+  const { S, $, cur, executeUICommand: command, uiStateReport: state,
+    nativePreviewActive, postNative, pushUndo, editSaveQueue } = ctx;
+  const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const steps = [];
+  const names = S.images.map(image => image.name);
+  if (names.length < 3) throw new Error('Visual review requires at least three copied photos');
+  const settle = async () => {
+    const deadline = performance.now() + 45000;
+    while (performance.now() < deadline) {
+      const report = state();
+      if (report.render.state === 'ready' && report.render.name === cur()?.name &&
+          report.render.backend === 'native-metal') { await sleep(400); return; }
+      await sleep(100);
+    }
+    throw new Error('Selected photo did not settle in the native renderer');
+  };
+  const step = async (journey, name, action, check = () => true) => {
+    const entry = {journey, name, startedEpochMs: Date.now(), before: state()};
+    postNative('nativeBenchmarkProgress', {stage: 'visual-step-start', ...entry});
+    try {
+      await action(); await sleep(650);
+      if (!check()) throw new Error(`Visible-state check failed: ${name}`);
+      entry.status = 'passed';
+    } catch (error) {
+      entry.status = 'failed'; entry.error = String(error.message || error);
+      throw error;
+    } finally {
+      entry.endedEpochMs = Date.now(); entry.durationMs = entry.endedEpochMs - entry.startedEpochMs;
+      entry.after = state(); steps.push(entry);
+      postNative('nativeBenchmarkProgress', {stage: 'visual-step-end', ...entry});
+    }
+  };
+  const go = async name => { await command('goto', {name}); await settle(); };
+  await step('browse', 'grid-overview', () => command('view:square'), () => S.viewMode === 'square');
+  await step('browse', 'grid-scroll-down-and-back', async () => {
+    const grid = $('library');
+    if (!grid || grid.scrollHeight <= grid.clientHeight) throw new Error('Grid does not have scrollable content');
+    for (const fraction of [0.4, 1, 0.5, 0]) {
+      grid.scrollTo({top: fraction * grid.scrollHeight, behavior: 'smooth'}); await sleep(350);
+    }
+  });
+  await step('browse', 'open-landscape', async () => { await command('view:detail'); await go('field.jpg'); });
+  await step('browse', 'rate-and-filter', async () => {
+    await command('rating:4');
+    await command('view:square');
+    await command('filter', {query: 'field'}); await sleep(700);
+    if (!ctx.visible().some(image => image.name === 'field.jpg')) throw new Error('Search lost the rated photo');
+    await command('filter', {query: ''});
+    await command('view:detail'); await settle();
+  }, () => cur()?.rating === 4);
+  await step('browse', 'portrait-landscape-navigation', async () => {
+    for (const name of ['portrait.jpg', 'still-life.jpg', 'field.jpg']) {
+      if (!names.includes(name)) throw new Error(`Missing representative fixture: ${name}`);
+      await go(name);
+    }
+  });
+  await step('zoom', 'fit-to-actual', async () => {
+    await command('zoomActual'); await sleep(1000);
+  }, () => S.zoomMode === '100');
+  await step('zoom', 'pan-across-photo', async () => {
+    const previousPan = [S.panX, S.panY];
+    const wrap = $('zoomwrap'), bounds = wrap.getBoundingClientRect();
+    const x = bounds.left + bounds.width / 2, y = bounds.top + bounds.height / 2;
+    const dispatch = (type, dx, dy) => wrap.dispatchEvent(new PointerEvent(type, {
+      clientX: x + dx, clientY: y + dy, button: 0, buttons: type === 'pointerup' ? 0 : 1,
+      pointerId: 997, bubbles: true }));
+    dispatch('pointerdown', 0, 0);
+    for (let i = 1; i <= 24; i++) { dispatch('pointermove', i * 10, i * 4); await sleep(16); }
+    dispatch('pointerup', 240, 96);
+    if (S.panX === previousPan[0] && S.panY === previousPan[1]) throw new Error('Pan gesture did not move the viewport');
+  });
+  await step('zoom', 'rapid-zoom-reversals', async () => {
+    for (const action of ['zoomIn', 'zoomIn', 'zoomOut', 'zoomIn', 'zoomOut', 'zoomOut']) {
+      await command(action); await sleep(90);
+    }
+  });
+  await step('zoom', 'navigate-while-zoomed', async () => {
+    for (const name of ['portrait.jpg', 'still-life.jpg', 'field.jpg']) await go(name);
+  });
+  await step('zoom', 'return-to-fit', async () => { await command('zoomFit'); await sleep(1200); },
+    () => S.zoomMode === 'fit');
+  await step('edit', 'open-basic-controls', () => command('pane:edit'));
+  const initialExposure = Number(S.grade.exposure || 0);
+  await step('edit', 'continuous-exposure-drag-and-reversal', async () => {
+    const input = document.querySelector('[data-g="exposure"]');
+    if (!input || input.getBoundingClientRect().width === 0) throw new Error('Exposure slider is not visible');
+    pushUndo();
+    for (const value of [0.2, 0.4, 0.6, 0.8, 1, 0.7, 0.3, 0, -0.3, 0.5]) {
+      input.value = String(value); input.dispatchEvent(new Event('input', {bubbles: true})); await sleep(90);
+    }
+    input.dispatchEvent(new Event('change', {bubbles: true}));
+  }, () => Math.abs(S.grade.exposure - 0.5) < 0.001);
+  await step('edit', 'undo-exposure', () => command('undo'),
+    () => Math.abs(S.grade.exposure - initialExposure) < 0.001);
+  await step('edit', 'redo-exposure', () => command('redo'),
+    () => Math.abs(S.grade.exposure - 0.5) < 0.001);
+  await step('edit', 'compare-on', () => command('compare'), () => S.compareActive);
+  await step('edit', 'compare-off', () => command('compare'), () => !S.compareActive);
+  await step('edit', 'save-navigate-return', async () => {
+    await ctx.saveState();
+    const deadline = performance.now() + 15000;
+    while (editSaveQueue.getStatus().state !== 'saved' && performance.now() < deadline) await sleep(100);
+    await go('portrait.jpg'); await go('field.jpg');
+    const persisted = await fetch(`/api/state?name=${encodeURIComponent('field.jpg')}`).then(r => r.json());
+    if (Math.abs(persisted.grade?.exposure - 0.5) > 0.001 || !Number.isFinite(persisted.grade?.exposure)) {
+      throw new Error('Exposure did not persist through navigation');
+    }
+  }, () => Math.abs(S.grade.exposure - 0.5) < 0.001);
+  await step('explore', 'rapid-photo-and-zoom-interleaving', async () => {
+    for (let i = 0; i < 8; i++) {
+      void command('goto', {name: ['portrait.jpg', 'still-life.jpg', 'field.jpg'][i % 3]});
+      await command(i % 2 ? 'zoomOut' : 'zoomIn'); await sleep(100);
+    }
+    await go('field.jpg'); await command('zoomFit'); await sleep(1200);
+  });
+  if (!nativePreviewActive()) throw new Error('Review left native presentation');
+  return {schema: 1, layer: 'visual-review', steps, finalState: state(),
+    coverage: 'Scripted UI commands and DOM input events; not OS-level pointer automation. Presets, crop, masks and export are outside this first review.'};
+}


### PR DESCRIPTION
Filmstrip thumbnails now remain fully opaque, and unflagged photos no longer show an empty status circle. This also integrates the completed mask-button wrapping fix, removes redundant preset helper text across all locales, and adds the opt-in native journey recorder with isolated data and explicit capture limitations.

Validation: 352 JavaScript tests pass; Help checks pass for 58 articles, with all 20 UI locales and 19 translated Help bundles current. The native recorder compiles, and the personal-update runtime preflight passes. The full Python/contract suite ran 1,755 tests with 28 platform skips; codec and foreground-stability failures passed in focused reruns after installing the isolated test dependencies. Shared-memory tests require execution outside the filesystem sandbox.

The interrupted hair-refinement work and incomplete experimental Flathub source-build draft remain separate. This does not publish a release.
