### PR TITLE
Fix NumPy annotation import and copy variable shadowing

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -89,7 +89,7 @@
       "content": "efa1eca4d219fc2f23de68e0ee3c69c2d583b900569bd8fdd64f3ea013207e01",
       "sources": {
         "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd"
       }
@@ -175,7 +175,7 @@
       "sources": {
         "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -187,7 +187,7 @@
         "preset_io.py": "ad379b80b1b534c5afde2b54587892440c1be80d314b8a60b6532793a763b97e",
         "preset_library.py": "fb8d27cde136b026d25fe512a281a0d8f6d80a97b9bcbdca667e229162c26358",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
@@ -253,7 +253,7 @@
     "export-photos": {
       "content": "dbb37c4fdeb501f59294843e33d6aea92727bd952e76e11978a4a14af5535086",
       "sources": {
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -287,14 +287,14 @@
     "film-grain-and-format": {
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
-        "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
+        "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
     },
     "film-halation-diffusion-scan": {
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
-        "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
+        "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -302,7 +302,7 @@
     "film-negative-paper-and-slides": {
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
-        "film_pipeline.py": "40b111c880654a4647bf318e1ebaa1b10187d33fe01936a65d140394e53cc579",
+        "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
@@ -327,7 +327,7 @@
       "sources": {
         "catalog.py": "9d6441c2da7ae5b4e672776ee7cad5e5fbbde0a8af8a77809244f70644a60110",
         "ingest_workflow.py": "0f7b5f1cc90a642abb6c691353af655dd1197ae6bb384477d3697e2de8c0bf64",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -336,7 +336,7 @@
       "content": "7369295e83860a0ac0963dc85e43b5cc4a711f177270b0fffb2dd2316f949476",
       "sources": {
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6"
       }
@@ -366,7 +366,7 @@
         "film_lab_ai/face_models.py": "d98d2848681d56e440a0fdb9ff8d451ced8ab257dda59747131fad8381cf85d7",
         "film_lab_ai/face_service.py": "e88e557e10bf9f64cf6d366e6fb11d3e6a1011e8e9163740921a35d115daadca",
         "film_lab_ai/face_store.py": "869ebb3cb7c6970015cfdf5603370d0277317e7ce948d973e038b4a7f53d9f4f",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8",
         "web/people.css": "5749fa637dddafb20b1eb1146cb7f5c8fae06f922c9a5f966bd5a883ff05c0b5",
         "web/people.js": "803fcf1dca40e132e438217fa6e2f456923020ef6ba838f6742891618698c1ad"
@@ -379,7 +379,7 @@
         "gpu_compute.py": "6aaf344c93689e2673c957fdad76c1aed4c81cc144d9d64e3b91cc3a44859ba4",
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "28558d9bd160d43e46e2da52089c9128b772979bd5b9dc87b812193e7659e5a6",
@@ -415,7 +415,7 @@
       "content": "daaceff084a4ad855923488dee5cc8d576d8ea63730c5ff3f89c071a3045cffb",
       "sources": {
         "ingest_workflow.py": "0f7b5f1cc90a642abb6c691353af655dd1197ae6bb384477d3697e2de8c0bf64",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7"
       }
     },
@@ -491,7 +491,7 @@
       "content": "f52bb62055da510b5960532a68f9c82786187593aaa50a1172a5f2173f8d2fbd",
       "sources": {
         "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/app.js": "44d5ea66cb16c6a82c48c9c74cdf5a299e68d79845eef5db0fa544415a016c20",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
@@ -517,7 +517,7 @@
     "xmp-interchange": {
       "content": "47a963b65ba3099f4ad70985f488864080b10612b042395cd9322f50e2e78a53",
       "sources": {
-        "server.py": "f3d408a4957a04b35f55fa10769285e54983ede4ec8bc4a4e9980a5a5313e6b5",
+        "server.py": "60b57109fed5ffc838c4a74425380d9ddd0550bbddf59be6021d5792f2f6af7e",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "xmp_sidecar.py": "7222b2987fb7f7e002e5be54fc32a6a63cdfb6abca586a9540c6764c040966af"
       }

--- a/film_pipeline.py
+++ b/film_pipeline.py
@@ -15,6 +15,8 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
+import numpy as np
+
 import film_tuning
 
 APP = Path(__file__).resolve().parent
@@ -454,7 +456,6 @@ def prepared_input_file(source: str | Path, p: dict):
     if spec is None:
         yield Path(source)
         return
-    import numpy as np
     import tifffile
     with tempfile.TemporaryDirectory(prefix="lighttable-film-input-") as directory:
         path = Path(directory) / "linear-prophoto.tif"
@@ -592,7 +593,6 @@ def build_params(p: dict):
 
 def load_linear(tif_path: str, max_width: int | None = None) -> np.ndarray:
     """Read a 16-bit TIFF into float32 [0,1] RGB, optionally downsized."""
-    import numpy as np
     import tifffile
     import color_pipeline
 
@@ -609,7 +609,6 @@ def load_linear(tif_path: str, max_width: int | None = None) -> np.ndarray:
 
 def render_float(image: np.ndarray, p: dict) -> np.ndarray:
     """Run the full pipeline and retain display-referred float precision."""
-    import numpy as np
     import spektrafilm
 
     p = clean_params(p)
@@ -633,6 +632,4 @@ def render_float(image: np.ndarray, p: dict) -> np.ndarray:
 
 def render(image: np.ndarray, p: dict) -> np.ndarray:
     """Compatibility wrapper used by the 8-bit display preview."""
-    import numpy as np
-
     return (render_float(image, p) * 255.0 + 0.5).astype(np.uint8)

--- a/server.py
+++ b/server.py
@@ -1653,10 +1653,10 @@ def _remap_state_paths_many(remaps: list[tuple[str, str]]) -> None:
                             old_prefix.rstrip("/") + "/"):
                         return new_prefix + value[len(old_prefix):]
                 return value
-            for copy in st.get("virtualCopies", []):
-                if isinstance(copy, dict):
-                    copy["source"] = remap(str(copy.get("source", "")))
-                    copy["name"] = remap(str(copy.get("name", "")))
+            for virtual_copy in st.get("virtualCopies", []):
+                if isinstance(virtual_copy, dict):
+                    virtual_copy["source"] = remap(str(virtual_copy.get("source", "")))
+                    virtual_copy["name"] = remap(str(virtual_copy.get("name", "")))
             for collection in st.get("collections", []):
                 if isinstance(collection, dict):
                     collection["members"] = [remap(str(value))


### PR DESCRIPTION
Move NumPy to module scope in `film_pipeline.py` so its array annotations resolve, and rename the virtual-copy loop variable in `server.py` so it does not shadow the `copy` module. Refresh Help source-review hashes; the documented workflows are unchanged.

Validation: 82 film-pipeline, state, CLI-route, and Help tests pass on the latest main; Help build/check and `git diff --check` pass. POST routes have no duplicate exact paths or missing declarations. The two reported Pyflakes findings are resolved; unrelated unused `started` and `soft_proof` warnings remain.
