### PR TITLE
Fix Browse folder hover cursor

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -282,7 +282,7 @@
         "web/app.js": "8817ffcdaf5d8c9a086eb0cf2238c43cb130b428076bfc8c4868ec1104dd0e79",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "569d714c03abd4d9bab11d4bff76acb584ecef1a7f423aa17829fad4fc89ce3b",
-        "web/style.css": "43f17787406ca8bf26cb68b6197d087c210f6f99898e31b5c38e767e3fbaea69"
+        "web/style.css": "04e82b8eedf5c37aa369a67a3c545072153d8c9485d6f563d16fa096bf02d8c2"
       }
     },
     "film-grain-and-format": {
@@ -388,7 +388,7 @@
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "43f17787406ca8bf26cb68b6197d087c210f6f99898e31b5c38e767e3fbaea69",
+        "web/style.css": "04e82b8eedf5c37aa369a67a3c545072153d8c9485d6f563d16fa096bf02d8c2",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
     },
@@ -401,7 +401,7 @@
         "web/app.js": "8817ffcdaf5d8c9a086eb0cf2238c43cb130b428076bfc8c4868ec1104dd0e79",
         "web/index.html": "569d714c03abd4d9bab11d4bff76acb584ecef1a7f423aa17829fad4fc89ce3b",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "43f17787406ca8bf26cb68b6197d087c210f6f99898e31b5c38e767e3fbaea69"
+        "web/style.css": "04e82b8eedf5c37aa369a67a3c545072153d8c9485d6f563d16fa096bf02d8c2"
       }
     },
     "raw-jpeg-pairs": {
@@ -504,7 +504,7 @@
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "569d714c03abd4d9bab11d4bff76acb584ecef1a7f423aa17829fad4fc89ce3b",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "43f17787406ca8bf26cb68b6197d087c210f6f99898e31b5c38e767e3fbaea69",
+        "web/style.css": "04e82b8eedf5c37aa369a67a3c545072153d8c9485d6f563d16fa096bf02d8c2",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },

--- a/web/style.css
+++ b/web/style.css
@@ -434,6 +434,7 @@ input[type=checkbox]:disabled { opacity:.4; }
 .folder-empty { padding:12px 8px; color:var(--muted); font-size:11px; line-height:1.45; }
 .folder-row {
   --depth:0;
+  cursor:default;
   width:100%;
   min-height:28px;
   display:grid;


### PR DESCRIPTION
Hovering over folder names in Browse could display a text insertion cursor. Set folder rows to use the standard arrow cursor, including their labels and counts.

Reviewed the four Help articles tracking the shared stylesheet; their wording remains accurate, and the review fingerprints are updated.

Validation: Help build/check and git diff --check passed. Native visual verification is pending a rebuilt installation.
