### PR TITLE
Add an on-demand headless UI audit suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,10 @@ results:
 scripts/run-product-journey.sh pr
 ```
 
+For occasional layout and visual bug hunts, use the [on-demand UI audit](scripts/ui-audit/README.md).
+It provides headless snapshots, DOM invariants, and seeded exploration; it is not
+part of commit checks, CI triggers, or `mnb`.
+
 See [product journey testing](JOURNEY-TESTING.md) for package and RAW-image
 journeys. The optional RAW fixtures require a separate download; routine unit
 tests and the JPEG journey do not require the full RAW collection. Passing unit

--- a/JOURNEY-TESTING.md
+++ b/JOURNEY-TESTING.md
@@ -39,3 +39,10 @@ The package layer is a blocking step in release and personal-app staging. The
 PR and RAW layers are deliberately exposed as local commands without automatic
 scheduled CI activation: enabling recurring macOS runners and the 627 MiB LFS
 download is an explicit repository-cost decision.
+
+## Occasional browser UI audits
+
+The [on-demand UI audit](scripts/ui-audit/README.md) checks layout and language
+states, captures candidate snapshots, and explores seeded command/pointer walks.
+Run it explicitly when useful. It is not part of commit checks or `mnb`, and it
+does not replace native recorded review for Metal or macOS behavior.

--- a/scripts/ui-audit/README.md
+++ b/scripts/ui-audit/README.md
@@ -1,0 +1,188 @@
+# On-demand browser UI audit
+
+Run this occasionally when requested, before a release, or while investigating
+visual bugs. **It is deliberately absent from commit hooks, normal test discovery,
+CI triggers, build scripts, and `mnb`.** No baseline is approved automatically.
+This is a headless Chromium review aid; the application's real HTML/CSS, server,
+UI command executor, and WebGL presentation run against disposable photo copies.
+It never opens the native app or uses your personal catalog.
+
+## Run
+
+Complete the source dependency setup in [CONTRIBUTING.md](../../CONTRIBUTING.md),
+including `engine/data` and the Python runtime. Node and Playwright/Chromium are
+also required. Existing benchmark discovery is reused. To install locally:
+
+```sh
+npm install --no-save --package-lock=false playwright
+npx playwright install chromium
+export LIGHTTABLE_PLAYWRIGHT_MODULE="$PWD/node_modules/playwright/index.mjs"
+```
+
+Alternatively, discovery uses an existing cached Playwright installation and
+macOS headless Chromium. `LIGHTTABLE_BROWSER_EXECUTABLE` can select an exact
+Chromium executable. On other platforms Playwright's installed default is used.
+Chromium may need permission to launch outside an agent's filesystem sandbox;
+headless launch still does not take desktop focus.
+
+From the app checkout:
+
+```sh
+# About 80 states: English, Arabic, German, Russian at 1280 × 720.
+.venv/bin/python scripts/ui-audit/run.py invariants
+
+# Capture candidate baselines, retaining both original and masked screenshots.
+.venv/bin/python scripts/ui-audit/run.py snapshot --locales en ar --timeout 600
+
+# Reproducible, bounded random walks; one walk per locale/viewport.
+.venv/bin/python scripts/ui-audit/run.py explore --seed 1234 --steps 80 --timeout 600
+
+# List the full matrix without starting a server or browser.
+.venv/bin/python scripts/ui-audit/run.py --profile full --list
+
+# Full matrix is intentionally expensive; shard it by locale/state/viewport.
+.venv/bin/python scripts/ui-audit/run.py invariants --profile full --locales ar --timeout 1800
+
+# Small, targeted run.
+.venv/bin/python scripts/ui-audit/run.py invariants --locales de ru \
+  --viewports 1280x720 1440x900 --states pane-mask-fit settings no-results
+
+# Replay a saved first violation or reduced sequence in fresh isolated data.
+.venv/bin/python scripts/ui-audit/run.py --replay /absolute/path/to/case-minimal.json
+```
+
+Exit codes: **0** means the selected automatic checks completed without hits,
+**1** means review is required (including unapproved/mismatched snapshots), and
+**2** means execution failed or coverage is incomplete. Neither 0 nor 1 certifies
+visual quality. A missing dependency, exception, browser launch failure, timeout,
+or failed state assertion cannot produce a passing run. Use an unused `--output`
+directory to name a run; existing outputs are never overwritten.
+
+The overall execution cap is `--timeout` (default 600 seconds, maximum four
+hours), plus bounded process teardown and evidence analysis. Exploration also
+caps `--steps`, `--minimize-attempts` (default 12), and `--max-frames` (default
+600 per walk). All spawned browser/server process groups are stopped on exit,
+including timeout and interruption. Keep separate worktrees for separate hunts.
+
+## State matrix
+
+`--profile full` takes the cross product of every shipped locale in
+`web/locales/manifest.json` (currently 20), three viewports (1280×720, 1440×900,
+1728×1117), and the following states. Arabic uses the application's actual RTL
+language initialization, not CSS direction injected by the harness.
+
+| State group | Coverage |
+|---|---|
+| Panes | Every `section.panel-pane` in the application source: edit, mask, heal, film, crop, presets, history, info |
+| Pane zooms | Fit, actual/100%, two steps in, one step back out |
+| Views | Grid, detail, before/after compare, selected-photo survey, secondary loupe popup, Help, Settings |
+| Stress | No search results, long multilingual filename plus 24 hierarchical keywords |
+| Separate libraries | Empty library after setup, actual first-run setup, missing disposable originals after indexing |
+
+Quick mode uses every state with Fit pane zoom, four locales, and the short
+viewport. Full mode currently contains 2,640 cases. The generated `--list` is
+authoritative if panes or locales change. The matrix is a useful sample, not all
+possible combinations of app features, nested sections, themes, fonts or OSes.
+The fixture photographs are the repository's attributed CC0 JPEGs, reduced to
+1200 pixels for speed. RAW processing belongs to the processing/native suites.
+Film is off for deterministic, fast layout checks; the Film pane still renders.
+
+## Probes and exploration
+
+The DOM oracles flag horizontal overflow, clipped text, overlapping controls,
+zero-size controls, positive tab order, focusable controls inside aria-hidden
+regions, `[hidden]` elements that still paint, language direction, and Fit bounds.
+Contrast checks apply WCAG text floors to solid opaque colors only. They skip
+unknown compositing, gradients, photos and disabled controls. These are heuristic
+candidates, not a complete accessibility or keyboard-navigation audit.
+Intentional ellipsis, scroll containers, closed details, nested controls and
+occluded overlays are handled conservatively. Custom controls and intentional
+low-emphasis text can still produce candidates. Never suppress a finding without
+inspecting its original screenshot and documenting why.
+
+Explore uses a seeded command vocabulary (panes, navigation, zoom, compare,
+library/filmstrip toggles), actual browser pointer drags, and short command bursts.
+Use `--rules fit-geometry hidden-paints` to focus a hunt; omitted rules are
+explicitly recorded in the configuration. It probes after each settled action; CDP screencast frames capture intervening
+transitions. Initial candidates are retained separately. It stops at the first
+*new* signature, saves its screenshot and full sequence before reduction, then
+tries deleting actions with a fresh browser and reset photo state each time.
+`oneMinimal: true` means every remaining single-action deletion was tried; bounded
+partial reductions remain explicitly partial. An initial-state problem may reduce
+to zero actions. The browser state reset does not assert process/restart isolation
+for arbitrary commands outside this deliberately limited vocabulary.
+
+The native review's A-B-A detector runs on the captured frames. Real frame
+timestamps and original JPEG frames are retained. This sampling is not guaranteed
+60 fps, captures may reach their frame cap, and uncaptured glitches cannot be
+excluded. A-B-A changes can also be intentional navigation, edits or recording
+artifacts. Inspect the surrounding frames before reproducing and classifying.
+
+## Evidence and review
+
+Each `output/ui-audits/<timestamp>/` contains:
+
+- `README.md`, `result.json`, and the native review-compatible `review.json` ledger.
+- Original app screenshots, masked comparison PNGs, and baseline difference PNGs.
+- Source revision/dirty status, source and fixture hashes, browser version,
+  machine, viewport, locale, seed and run bounds in provenance/config files.
+- Isolated runtime data and logs; exploration sequences, reduced repros, actual
+  screencast frames/timestamps, and `frame-analysis.json`.
+
+Keep `reviewStatus: "not-reviewed"` until a person or independent reviewer has
+opened the evidence. Add reviewed filenames to `inspectedEvidence`. Each finding
+uses the existing native ledger fields: `classification` (`confirmed-bug`,
+`suspected-bug`, `usability-observation`, `capture-limitation`), `journey`,
+`timestamp`, `evidence`, `reproduction`, `impact`, and `confidence`. Point `journey`
+at the case ID. Candidate details and selectors remain in `result.json`.
+
+A confirmed finding should become a focused regression in the normal suite once
+its cause is understood; do not promote a heuristic probe hit into a permanent
+failure. Assign hunting/fixing and verification to independent contexts when
+requested. The author of a fix must not approve its visual baseline.
+
+## Baselines
+
+Baseline approval is a separate, explicit action by Nicholas or an authorized
+independent reviewer. The snapshot run must be complete, its ledger marked
+`reviewed`, and **every original and masked PNG** listed in `inspectedEvidence`.
+Unresolved confirmed/suspected bugs block approval. Never mark a ledger reviewed
+just to get this command to succeed.
+
+```sh
+.venv/bin/python scripts/ui-audit/run.py \
+  --approve-from /absolute/path/to/reviewed-snapshot-run \
+  --baseline /absolute/path/to/new-baseline-directory --reviewer 'Reviewer name'
+
+.venv/bin/python scripts/ui-audit/run.py snapshot \
+  --baseline /absolute/path/to/approved-baseline-directory
+```
+
+Approval records the reviewer, hashes and comparison environment; it refuses to
+overwrite a baseline. Comparisons require matching browser/platform, fixture
+hashes, device scale and mask policy. App source changes are expected and recorded.
+Missing, incompatible or corrupt baselines require review. Pixel comparison uses
+a 16/255 per-channel threshold and a 0.1% changed-pixel allowance; these tolerate
+small rasterization differences and do not replace inspection. Photo pixels are
+masked while their boundaries and surrounding UI remain visible. Original
+screenshots always retain the actual photographs.
+
+## Harness self-checks
+
+These are also manual and are not added to the normal test gate:
+
+```sh
+.venv/bin/python scripts/ui-audit/test_runner.py
+LIGHTTABLE_PLAYWRIGHT_MODULE="$PWD/node_modules/playwright/index.mjs" \
+  node scripts/ui-audit/test_probes.mjs
+```
+
+Self-checks use small synthetic images/DOM to verify the oracles, matrix, baseline
+approval guard, and existing transient detector. They are never app visual proof.
+
+## Native coverage
+
+Use [recorded native review](../visual-review/README.md) in an explicitly authorized
+foreground testing window for Metal, native window chrome/insets, live resize,
+real trackpad gestures, Reduce Motion and multiple displays. This suite provides
+no native proof and never launches or installs a personal build.

--- a/scripts/ui-audit/browser.mjs
+++ b/scripts/ui-audit/browser.mjs
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {probe} from './probes.mjs';
+const cfg = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const {chromium} = await import(pathToFileURL(cfg.module).href);
+const browser = await chromium.launch({headless:true, executablePath:cfg.browser || undefined,
+  args:['--enable-unsafe-swiftshader','--force-color-profile=srgb']});
+const records = [], errors = [];
+let context, page, evidencePage, state, sequence = [], attempt = 0, commandAt = 0;
+const save = () => fs.writeFileSync(cfg.result, JSON.stringify({records,errors,browserVersion:browser.version()},null,2));
+const deadline = Date.now()+cfg.timeout*1000;
+const checkTime = () => {if(Date.now() > deadline) throw Error('Audit wall-clock limit reached');};
+const pause = ms => new Promise(r=>setTimeout(r,ms));
+const api = async (route, data) => {
+  const response = data === undefined ? await page.request.get(cfg.baseUrl+route) :
+    await page.request.post(cfg.baseUrl+route,{headers:{Origin:cfg.baseUrl},data});
+  if(!response.ok()) throw Error(`${route}: ${response.status()} ${await response.text()}`);
+  return response.json();
+};
+const command = async (name,args={}) => {
+  checkTime();
+  commandAt=Date.now()/1000;
+  const result = await api('/api/ui/command',{command:name,args,timeout:20,origin:'ui-audit'});
+  if (!result.ok) throw Error(JSON.stringify(result));
+  state = result.result; return state;
+};
+const settle = async (render = true) => {
+  const until = Math.min(deadline,Date.now()+30000);
+  do {
+    state = await api('/api/ui/state');
+    if (state.reportedAt >= commandAt && (!render || !state.current || state.render?.state === 'error' ||
+        (state.render?.state === 'ready' && state.render.name === state.current))) {
+      await pause(350); await page.evaluate(()=>document.fonts.ready); return;
+    }
+    await pause(100);
+  } while(Date.now() < until);
+  throw Error('Photo did not reach a settled render');
+};
+let images = [];
+async function reset(test) {
+  checkTime();
+  if(context) await context.close();
+  context = await browser.newContext({viewport:test.viewport,deviceScaleFactor:1,locale:test.locale});
+  page = await context.newPage(); evidencePage = page; page.setDefaultTimeout(10000);
+  page.on('pageerror', e=>errors.push({case:test.id,message:String(e)}));
+  await page.request.get(cfg.baseUrl);
+  await api('/api/prefs',{locale:test.locale,localeChosen:true,allowAutomation:true,
+    firstRunSetup:{version:cfg.fixture === 'first-run'?0:1},smoothZoom:true,autoAdvance:false});
+  images = (await api('/api/images')).images;
+  for(const image of images) await api('/api/state',{name:image.name,
+    params:{profile_enabled:false,grain_on:false,halation_on:false,glare_on:false},grade:{},masks:[],heals:[],optics:{},crop:null,
+    keywords:image.name.includes('Long-') ? Array.from({length:24},(_,i)=>`Landscape > Long keyword Deutsch Русский العربية ${i}`):[]});
+  const oldClient = (await api('/api/ui/state')).client;
+  await page.goto(cfg.baseUrl,{waitUntil:'domcontentloaded'});
+  const until = Math.min(deadline,Date.now()+45000);
+  do {
+    state = await api('/api/ui/state');
+    if(state.client && state.client !== oldClient) break;
+    await pause(100);
+  } while(Date.now()<until);
+  if(!state.client || state.client === oldClient) throw Error('Fresh browser did not connect to the UI bridge');
+  await page.waitForFunction(locale=>document.documentElement.lang===locale,test.locale);
+  if(cfg.fixture === 'first-run') {
+    await page.locator('#firstRunDialog.on').waitFor(); return;
+  }
+  await command('filter',{query:'',status:'all',rating:'all',kind:'all',label:'all'});
+  await command('view:detail'); await command('pane:edit');
+  if(images.length) await command('goto',{name:images[0].name});
+  await command('zoomFit'); await settle();
+}
+async function action(a) {
+  if(a.type === 'pointer') {
+    const r = await page.locator('#zoomwrap').boundingBox();
+    if(!r) throw Error('No pointer viewport');
+    const x=r.x+r.width*.5,y=r.y+r.height*.5;
+    await page.mouse.move(x,y); await page.mouse.down();
+    try {await page.mouse.move(x+a.dx,y+a.dy,{steps:8});} finally {await page.mouse.up();}
+  } else if(a.type === 'burst') {
+    for(const item of a.actions) {await command(item.command,item.args); await pause(30);}
+  } else if(a.command === 'secondaryLoupe') {
+    const popup=page.waitForEvent('popup'); await command(a.command,a.args);
+    evidencePage=await popup; await evidencePage.setViewportSize(page.viewportSize());
+    await evidencePage.waitForLoadState('domcontentloaded');
+    await evidencePage.locator('#loupeImg').waitFor({state:'visible'});
+    await evidencePage.waitForFunction(()=>document.querySelector('#loupeImg').naturalWidth>0);
+  } else await command(a.command,a.args);
+}
+function caseActions(test) {
+  const a=[]; const cmd=(command,args)=>a.push({command,args});
+  if(test.pane) cmd(`pane:${test.pane}`);
+  if(test.view === 'grid') cmd('view:square');
+  if(test.view === 'compare') cmd('compare');
+  if(test.view === 'survey') {cmd('select',{action:'set',names:images.slice(0,3).map(i=>i.name)});cmd('survey');}
+  if(test.view === 'loupe') cmd('secondaryLoupe');
+  if(test.view === 'help') cmd('help');
+  if(test.view === 'settings') cmd('preferences');
+  if(test.view === 'no-results') {cmd('view:square');cmd('filter',{query:'UI_AUDIT_NO_MATCH_94731'});}
+  if(test.view === 'long-name') {cmd('goto',{name:images.find(i=>i.name.includes('Long-'))?.name});cmd('pane:info');}
+  if(test.zoom === 'actual') cmd('zoomActual');
+  if(test.zoom === 'in') {cmd('zoomIn');cmd('zoomIn');}
+  if(test.zoom === 'out') {cmd('zoomIn');cmd('zoomIn');cmd('zoomOut');}
+  return a;
+}
+async function verifyState(test) {
+  if(cfg.fixture==='photos' && (state.render?.state!=='ready' || state.render.name!==state.current)) throw Error('Expected a ready matching photo render');
+  if(cfg.fixture==='missing' && state.render?.state!=='error') throw Error('Missing original did not show a render error');
+  const expected = test.pane ? `${test.pane}Pane` : null;
+  if(expected && (state.pane !== expected || !await page.locator(`#${expected}`).isVisible())) throw Error(`Pane did not open: ${expected}`);
+  for(const [view,sel] of Object.entries({help:'#helpDialog.on',settings:'#settingsDialog.on',survey:'#survey:not([hidden])','first-run':'#firstRunDialog.on'}))
+    if(test.view===view && !await page.locator(sel).isVisible()) throw Error(`View did not open: ${view} (${sel})`);
+  if(test.view==='grid' && state.viewMode!=='square') throw Error('Grid did not open');
+  if(test.view==='compare' && !state.compare?.active) throw Error('Compare did not activate');
+  if(test.view==='no-results' && state.visibleCount!==0) throw Error('Filter did not produce an empty result');
+  if(test.zoom==='actual' && state.zoomMode!=='100') throw Error('Actual zoom did not activate');
+}
+const runProbes = async test => (await evidencePage.evaluate(probe,{state,direction:test.direction}))
+  .filter(hit=>!cfg.rules || cfg.rules.includes(hit.rule));
+async function capture(test,id) {
+  const screenshot=`${id}.png`, masked=`${id}-masked.png`;
+  await evidencePage.screenshot({path:path.join(cfg.output,screenshot),animations:'disabled'});
+  await evidencePage.screenshot({path:path.join(cfg.output,masked),animations:'disabled',
+    mask:[evidencePage.locator('#cv,#glBefore,.thumb img,.survey-cell img,#loupeImg')],maskColor:'#555555'});
+  return {screenshot,masked};
+}
+// CDP keeps actual timestamps and original frames; sampling is not a 60-fps guarantee.
+async function recordFrames(id) {
+  const session=await context.newCDPSession(page), frames=[];
+  const dir=path.join(cfg.output,`${id}-frames`);fs.mkdirSync(dir);
+  session.on('Page.screencastFrame', e=>{
+    if(frames.length<cfg.maxFrames) {
+      const file=`${id}-frames/${String(frames.length).padStart(5,'0')}.jpg`;
+      fs.writeFileSync(path.join(cfg.output,file),Buffer.from(e.data,'base64'));
+      frames.push({file,timestamp:e.metadata.timestamp,receivedEpochMs:Date.now()});
+    }
+    session.send('Page.screencastFrameAck',{sessionId:e.sessionId}).catch(()=>{});
+  });
+  await session.send('Page.startScreencast',{format:'jpeg',quality:85,maxWidth:1280,maxHeight:900,everyNthFrame:1});
+  return async()=>{
+    await session.send('Page.stopScreencast');await session.detach();
+    fs.writeFileSync(path.join(cfg.output,`${id}-frames.json`),JSON.stringify({frames,capped:frames.length>=cfg.maxFrames},null,2));
+  };
+}
+function random(seed) {let x=seed>>>0;return()=>{x+=0x6D2B79F5;let t=Math.imul(x^x>>>15,1|x);t^=t+Math.imul(t^t>>>7,61|t);return((t^t>>>14)>>>0)/4294967296;};}
+const signature = hit=>`${hit.rule}:${hit.selector}:${hit.detail?.other||''}`;
+async function minimize(test,actions,target) {
+  // Greedy deletion with fresh browser + reset photo state per attempt. Only claim 1-minimal if exhausted.
+  let best=actions.slice(), complete=true;
+  for(let i=0;i<best.length;) {
+    if(attempt++>=cfg.minimizeAttempts || Date.now()+10000>deadline) {complete=false;break;}
+    const trial=best.filter((_,j)=>j!==i);
+    try {
+      await reset(test); for(const a of trial) await action(a); await settle();
+      if((await runProbes(test)).some(h=>signature(h)===target)) {best=trial;i=0;} else i++;
+    } catch {i++;}
+  }
+  return {actions:best,oneMinimal:complete,attempts:attempt};
+}
+try {
+  for(const test of cfg.cases) {
+    const record={...test,startedEpochMs:Date.now(),status:'passed',candidates:[]};
+    let stopFrames;
+    try {
+      await reset(test); sequence=[]; attempt=0;
+      if(cfg.mode==='explore') {
+        const initial=await runProbes(test), known=new Set(initial.map(signature));
+        record.initialCandidates=initial;
+        record.initialEvidence=await capture(test,`${test.id}-initial`);
+        stopFrames=await recordFrames(test.id);
+        const rng=random(cfg.seed);
+        const vocabulary=[...cfg.panes.map(p=>({command:`pane:${p}`})),
+          ...['zoomFit','zoomActual','zoomIn','zoomOut','nextPhoto','previousPhoto','compare','toggleLibrary','toggleFilmstrip'].map(command=>({command})),
+          {type:'pointer',dx:110,dy:60}, {type:'burst',actions:['zoomIn','zoomOut','nextPhoto','zoomFit'].map(command=>({command}))}];
+        const actions=cfg.replay?.actions || Array.from({length:cfg.steps},()=>vocabulary[Math.floor(rng()*vocabulary.length)]);
+        for(const a of actions) {
+          sequence.push(a); await action(a); await settle();
+          const hits=await runProbes(test);
+          const fresh=hits.filter(h=>cfg.replay ? signature(h)===cfg.replay.target : !known.has(signature(h)));
+          if(fresh.length) {
+            record.candidates=fresh;record.state=state;
+            Object.assign(record,await capture(test,test.id));
+            await stopFrames();stopFrames=null;
+            const original=sequence.slice(),target=signature(fresh[0]);
+            // Persist the original reproducer before attempting reduction.
+            const replay={schema:1,test,seed:cfg.seed,rules:cfg.rules,target,actions:original};
+            fs.writeFileSync(path.join(cfg.output,`${test.id}-replay.json`),JSON.stringify(replay,null,2));
+            const reduced=await minimize(test,original,target);
+            fs.writeFileSync(path.join(cfg.output,`${test.id}-minimal.json`),JSON.stringify({...replay,...reduced},null,2));
+            record.replay=`${test.id}-replay.json`;record.minimal=`${test.id}-minimal.json`;break;
+          }
+        }
+        record.steps=sequence;
+        if(cfg.replay && !record.candidates.some(h=>signature(h)===cfg.replay.target)) {
+          const hits=await runProbes(test); record.candidates=hits.filter(h=>signature(h)===cfg.replay.target);
+          if(!record.candidates.length) throw Error(`Replay target did not reproduce: ${cfg.replay.target}`);
+        }
+      } else {
+        for(const a of caseActions(test)) {await action(a);sequence.push(a);await settle();}
+        await verifyState(test);record.state=state;
+        if(cfg.mode!=='snapshot') record.candidates=await runProbes(test);
+      }
+      if(!record.screenshot) Object.assign(record,await capture(test,test.id));
+    } catch(e) {
+      record.status='failed';record.error=String(e.stack||e);
+      if(page && !page.isClosed()) try {Object.assign(record,await capture(test,test.id));} catch {}
+    } finally {
+      if(stopFrames) await stopFrames();
+      record.actions=sequence;record.endedEpochMs=Date.now();records.push(record);save();
+      process.stdout.write(`${test.id}: ${record.status}, ${record.candidates.length} candidates\n`);
+    }
+    checkTime();
+  }
+} catch(e) {errors.push({message:String(e.stack||e)});} finally {
+  if(context) await context.close();await browser.close();save();
+}
+if(errors.length || records.some(r=>r.status==='failed') || records.length!==cfg.cases.length) process.exitCode=2;

--- a/scripts/ui-audit/probes.mjs
+++ b/scripts/ui-audit/probes.mjs
@@ -1,0 +1,100 @@
+// Browser-side candidate oracles. A hit requires screenshot inspection, not automatic bug classification.
+export function probe({state = {}, direction = 'ltr'} = {}) {
+  const hits = [];
+  const id = el => {
+    if (el === document.documentElement) return 'html';
+    if (el === document.body) return 'body';
+    if (el.id) return `#${CSS.escape(el.id)}`;
+    const parts = [];
+    for (let n = el; n && n !== document.body; n = n.parentElement) {
+      if (n.id) { parts.unshift(`#${CSS.escape(n.id)}`); break; }
+      parts.unshift(`${n.localName}:nth-child(${[...n.parentElement.children].indexOf(n) + 1})`);
+    }
+    return parts.join(' > ');
+  };
+  const add = (rule, el, detail) => hits.push({rule, selector: id(el), detail});
+  const styled = el => {
+    for (let n = el; n; n = n.parentElement) {
+      const s = getComputedStyle(n);
+      if (s.display === 'none' || s.visibility !== 'visible' || Number(s.opacity) === 0 ||
+          (n.matches('details:not([open])') && el !== n && !n.querySelector('summary')?.contains(el))) return false;
+    }
+    return true;
+  };
+  const inViewport = el => {
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && r.right > 0 && r.bottom > 0 && r.left < innerWidth && r.top < innerHeight;
+  };
+  const exposed = el => {
+    if (!styled(el) || !inViewport(el)) return false;
+    const r = el.getBoundingClientRect();
+    const x = Math.max(0, Math.min(innerWidth - 1, r.x + r.width / 2));
+    const y = Math.max(0, Math.min(innerHeight - 1, r.y + r.height / 2));
+    const top = document.elementFromPoint(x, y);
+    return top === el || el.contains(top);
+  };
+  if (Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) > innerWidth + 1) add('horizontal-overflow', document.documentElement,
+    {scrollWidth: document.documentElement.scrollWidth, viewport: innerWidth});
+  if (document.documentElement.dir !== direction) add('document-direction', document.documentElement,
+    {expected: direction, actual: document.documentElement.dir});
+  for (const el of document.querySelectorAll('[hidden]')) {
+    if (styled(el) && inViewport(el)) add('hidden-paints', el, {});
+  }
+  const controls = [...document.querySelectorAll('button,input:not([type=hidden]),select,textarea,a[href],[tabindex],summary')];
+  for (const el of controls) {
+    if (!styled(el)) continue;
+    const r = el.getBoundingClientRect();
+    // Styled custom inputs intentionally retain an invisible native input; report as candidates.
+    if (!r.width || !r.height) add('zero-size-control', el, {width:r.width, height:r.height});
+    if (!exposed(el)) continue;
+    if (el.tabIndex > 0) add('positive-tab-order', el, {tabIndex:el.tabIndex});
+    if (el.closest('[aria-hidden=true]')) add('focus-in-aria-hidden', el, {});
+    if (el.scrollWidth > el.clientWidth + 2 && getComputedStyle(el).textOverflow !== 'ellipsis' &&
+        !el.matches('input,textarea,select')) add('control-text-overflow', el,
+      {scrollWidth:el.scrollWidth, clientWidth:el.clientWidth});
+  }
+  const visibleControls = controls.filter(el => styled(el) && inViewport(el) && !el.closest('[inert]'));
+  for (let i = 0; i < visibleControls.length; i++) for (let j = i + 1; j < visibleControls.length; j++) {
+    const a = visibleControls[i], b = visibleControls[j];
+    if (a.contains(b) || b.contains(a)) continue;
+    const x = a.getBoundingClientRect(), y = b.getBoundingClientRect();
+    const w = Math.min(x.right,y.right)-Math.max(x.left,y.left), h = Math.min(x.bottom,y.bottom)-Math.max(x.top,y.top);
+    // Ignore controls in different overlays, deliberate label/input relationships, and tiny edge contacts.
+    if (w > 3 && h > 3 && w*h > Math.min(x.width*x.height,y.width*y.height)*.25 &&
+        a.closest('[role=dialog],.modal-backdrop,#survey,.loupe-container') === b.closest('[role=dialog],.modal-backdrop,#survey,.loupe-container') &&
+        (exposed(a) || exposed(b))) add('overlapping-controls', a, {other:id(b), width:w, height:h});
+  }
+  const rgb = s => { const m = s.match(/^rgba?\(([^)]+)\)$/); return m ? m[1].split(/[, /]+/).map(Number) : null; };
+  const lum = c => c.slice(0,3).map(v => v/255).map(v => v <= .04045 ? v/12.92 : ((v+.055)/1.055)**2.4)
+    .reduce((sum,v,i) => sum+v*[.2126,.7152,.0722][i],0);
+  for (const el of document.querySelectorAll('label,button,summary,p,h1,h2,h3,span,strong,small')) {
+    if (!exposed(el) || ![...el.childNodes].some(n => n.nodeType === 3 && n.textContent.trim())) continue;
+    const s = getComputedStyle(el), r = el.getBoundingClientRect();
+    if (el.scrollWidth > el.clientWidth + 2 && s.textOverflow !== 'ellipsis' &&
+        ['hidden','clip'].includes(s.overflowX)) add('clipped-text', el, {text:el.textContent.trim().slice(0,100)});
+    // Only solid, opaque foreground/background pairs: no guessed contrast over photos or gradients.
+    const fg = rgb(s.color); let bg = null, uncertain = false;
+    for (let n = el; n; n = n.parentElement) {
+      const ns = getComputedStyle(n), color = rgb(ns.backgroundColor);
+      if (ns.backgroundImage !== 'none' || Number(ns.opacity) !== 1) { uncertain = true; break; }
+      if (color && (color[3] ?? 1) === 1) { bg = color; break; }
+      if (color && color[3] > 0) { uncertain = true; break; }
+    }
+    if (fg && bg && !uncertain && (fg[3] ?? 1) === 1 && !el.closest(':disabled')) {
+      const ratio = (Math.max(lum(fg),lum(bg))+.05)/(Math.min(lum(fg),lum(bg))+.05);
+      const large = parseFloat(s.fontSize) >= 24 || (parseFloat(s.fontSize) >= 18.66 && parseInt(s.fontWeight) >= 700);
+      if (ratio < (large ? 3 : 4.5)) add('text-contrast', el, {ratio:+ratio.toFixed(2), floor:large?3:4.5});
+    }
+    if (r.bottom > innerHeight + 1 && !el.closest('.modal-backdrop') && exposed(el) &&
+        ![...function*(){for(let n=el.parentElement;n;n=n.parentElement)yield n;}()].some(n =>
+          /auto|scroll/.test(getComputedStyle(n).overflowY))) add('viewport-clipping', el, {bottom:r.bottom});
+  }
+  const cv = document.querySelector('#cv'), wrap = document.querySelector('#zoomwrap');
+  if (state.zoomMode === 'fit' && state.viewMode === 'detail' && state.render?.state === 'ready' &&
+      cv && wrap && exposed(cv) && !state.activeTool) {
+    const a = cv.getBoundingClientRect(), b = wrap.getBoundingClientRect();
+    if (a.left < b.left-2 || a.right > b.right+2 || a.top < b.top-2 || a.bottom > b.bottom+2)
+      add('fit-geometry', cv, {photo:a.toJSON(), viewport:b.toJSON()});
+  }
+  return hits;
+}

--- a/scripts/ui-audit/run.py
+++ b/scripts/ui-audit/run.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Optional, bounded headless UI audits. Never imported by the normal test gate."""
+from __future__ import annotations
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+
+ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+MASK_VERSION = 1
+
+
+def write(path, value):
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + '\n')
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def matrix(profile, locales=None, viewports=None, states=None):
+    manifest = json.loads((ROOT / 'web/locales/manifest.json').read_text())['locales']
+    selected = locales or ([x['code'] for x in manifest] if profile == 'full' else ['en', 'ar', 'de', 'ru'])
+    directions = {x['code']: x['dir'] for x in manifest}
+    if set(selected) - directions.keys(): raise ValueError('Unknown locale')
+    panes = re.findall(r'<section\b[^>]*class="panel-pane[^"\n]*"[^>]*id="(\w+)Pane"', (ROOT / 'web/index.html').read_text())
+    if not panes: raise ValueError('No application panes discovered')
+    ports = viewports or (['1280x720','1440x900','1728x1117'] if profile == 'full' else ['1280x720'])
+    definitions = [{'name':f'pane-{p}-{z}', 'pane':p, 'zoom':z, 'fixture':'photos', 'view':'detail'}
+                   for p in panes for z in (['fit','actual','in','out'] if profile == 'full' else ['fit'])]
+    definitions += [{'name':v,'view':v,'fixture':'photos'} for v in
+                    ['grid','detail','compare','survey','loupe','help','settings','no-results','long-name']]
+    definitions += [{'name':v,'view':v,'fixture':v} for v in ['empty','first-run','missing']]
+    if states:
+        names = set(states)
+        if names - {d['name'] for d in definitions}: raise ValueError(f'Unknown state: {names - {d["name"] for d in definitions}}')
+        definitions = [d for d in definitions if d['name'] in names]
+    cases = []
+    for locale in selected:
+        for viewport in ports:
+            if not re.fullmatch(r'\d{3,4}x\d{3,4}', viewport): raise ValueError('Viewport must be WIDTHxHEIGHT')
+            w,h=map(int,viewport.split('x'))
+            for d in definitions:
+                cases.append({**d,'id':f'{locale}-{viewport}-{d["name"]}', 'locale':locale,
+                              'direction':directions[locale],'viewport':{'width':w,'height':h}})
+    return cases, panes
+
+
+def compare(actual, expected, diff, threshold=16, fraction=.001):
+    import numpy as np
+    from PIL import Image
+    a=np.asarray(Image.open(actual).convert('RGB')).astype('int16')
+    b=np.asarray(Image.open(expected).convert('RGB')).astype('int16')
+    if a.shape != b.shape: return {'status':'different-size','actual':list(a.shape),'expected':list(b.shape)}
+    changed=np.max(np.abs(a-b),axis=2)>threshold
+    ratio=float(changed.mean())
+    view=(a*.25).astype('uint8');view[changed]=[255,30,90]
+    Image.fromarray(view).save(diff)
+    return {'status':'changed' if ratio>fraction else 'matched','changedFraction':ratio,
+            'pixelThreshold':threshold,'allowedFraction':fraction,'diff':diff.name}
+
+
+def stop(process):
+    if process is None: return
+    if os.name == 'posix':
+        try: os.killpg(process.pid,signal.SIGTERM)
+        except ProcessLookupError: return
+        try: process.wait(timeout=3)
+        except subprocess.TimeoutExpired: pass
+        try: os.killpg(process.pid,signal.SIGKILL)
+        except ProcessLookupError: pass
+    elif process.poll() is None: process.kill()
+    process.wait(timeout=5)
+
+
+def frames_analysis(folder):
+    import numpy as np
+    from PIL import Image
+    spec=importlib.util.spec_from_file_location('native_review',ROOT/'scripts/visual-review/run.py')
+    module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module)
+    result=[]
+    for file in folder.glob('*-frames.json'):
+        capture=json.loads(file.read_text());records=capture['frames']
+        frames=[np.asarray(Image.open(folder/r['file']).convert('L').resize((80,46))) for r in records]
+        candidates=module.transient_candidates(frames,fps=1)
+        for hit in candidates:
+            i=int(hit.pop('seconds'));hit.update(timestamp=records[i]['timestamp'],
+                evidence=[r['file'] for r in records[i-1:i+2]])
+        result.append({'capture':file.name,'frames':len(frames),'capped':capture['capped'],'candidates':candidates,
+                       'limitation':'Actual CDP frames and timestamps; not guaranteed cadence or native Metal proof.'})
+    write(folder/'frame-analysis.json',result)
+    return result
+
+
+def report(folder, result):
+    lines=['# LightTable on-demand UI audit', '',
+           f'Status: **{result["status"]}**. Visual review: **not-reviewed**.', '',
+           'Open every candidate screenshot before classification. Browser evidence does not verify Metal or macOS input.', '',
+           '[Review ledger](review.json) · [Machine-readable result](result.json) · [Provenance](provenance.json)', '',
+           '| State | Execution | Candidates | Evidence | Baseline |', '|---|---|---:|---|---|']
+    for r in result['records']:
+        screenshot=r.get('screenshot')
+        evidence=f'[screenshot]({screenshot})' if screenshot else 'NOT DONE'
+        if r.get('minimal'): evidence+=f' · [replay]({r["minimal"]})'
+        lines.append(f'| {r["id"]} | {r["status"]} | {len(r.get("candidates",[]))+len(r.get("initialCandidates",[]))} | {evidence} | {r.get("baseline",{}).get("status","not compared")} |')
+    (folder/'README.md').write_text('\n'.join(lines)+'\n')
+
+
+def approve(source, destination, reviewer):
+    review=json.loads((source/'review.json').read_text());result=json.loads((source/'result.json').read_text())
+    provenance=json.loads((source/'provenance.json').read_text())
+    if provenance['mode']!='snapshot' or result['executionStatus']!='passed': raise ValueError('Only complete snapshot runs can become baselines')
+    if not reviewer or review.get('reviewStatus')!='reviewed': raise ValueError('An explicit reviewer and reviewed ledger are required')
+    required={r[k] for r in result['records'] for k in ['screenshot','masked']}
+    if not required.issubset(set(review.get('inspectedEvidence',[]))): raise ValueError('Ledger must list every original and masked screenshot in inspectedEvidence')
+    if any(f.get('classification') in ['confirmed-bug','suspected-bug'] for f in review.get('findings',[])):
+        raise ValueError('Resolve bug findings before baseline approval')
+    destination.mkdir(parents=True,exist_ok=False)
+    for name in required: shutil.copy2(source/name,destination/name)
+    write(destination/'baseline.json',{'schema':1,'approvedBy':reviewer,'approvedAt':time.time(),
+          'comparison':provenance['comparison'],'source':str(source),'images':{r['id']:{'file':r['masked'],'sha256':digest(source/r['masked'])} for r in result['records']}})
+
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('mode',nargs='?',choices=['snapshot','invariants','explore'],default='invariants')
+    p.add_argument('--profile',choices=['quick','full'],default='quick')
+    p.add_argument('--locales',nargs='+');p.add_argument('--viewports',nargs='+');p.add_argument('--states',nargs='+')
+    p.add_argument('--list',action='store_true');p.add_argument('--output',type=Path)
+    p.add_argument('--rules',nargs='+',choices=['horizontal-overflow','document-direction','hidden-paints','zero-size-control','positive-tab-order','focus-in-aria-hidden','control-text-overflow','overlapping-controls','clipped-text','text-contrast','viewport-clipping','fit-geometry'])
+    p.add_argument('--timeout',type=int,default=600);p.add_argument('--steps',type=int,default=40)
+    p.add_argument('--seed',type=int,default=20260909);p.add_argument('--minimize-attempts',type=int,default=12)
+    p.add_argument('--max-frames',type=int,default=600);p.add_argument('--baseline',type=Path)
+    p.add_argument('--replay',type=Path);p.add_argument('--approve-from',type=Path);p.add_argument('--reviewer')
+    args=p.parse_args()
+    if args.approve_from:
+        if not args.baseline: p.error('--approve-from requires --baseline (new directory)')
+        approve(args.approve_from.resolve(),args.baseline.resolve(),args.reviewer);return 0
+    if not 1<=args.timeout<=14400 or not 1<=args.steps<=10000 or not 0<=args.minimize_attempts<=100 or not 1<=args.max_frames<=10000:
+        p.error('Bounds: timeout 1..14400 seconds, steps 1..10000, minimize-attempts 0..100, max-frames 1..10000')
+    cases,panes=matrix(args.profile,args.locales,args.viewports,args.states)
+    replay=json.loads(args.replay.read_text()) if args.replay else None
+    if replay: args.mode='explore';args.seed=replay.get('seed',args.seed);cases=[replay['test']]
+    elif args.mode=='explore': cases=[c for c in cases if c['name']=='detail']
+    if not cases: p.error('No selected cases; explore requires the detail state')
+    if args.list: print(json.dumps({'count':len(cases),'panes':panes,'cases':cases},indent=2));return 0
+    folder=(args.output or ROOT/'output/ui-audits'/time.strftime('%Y%m%d-%H%M%S')).resolve()
+    folder.mkdir(parents=True,exist_ok=False)
+    started=time.monotonic();deadline=started+args.timeout
+    result={'schema':1,'status':'NOT DONE','executionStatus':'failed','records':[],'errors':[],'expectedCases':len(cases)}
+    provenance={'schema':1,'mode':args.mode,'seed':args.seed,'cases':cases,'bounds':vars(args)|{'output':str(folder)}}
+    provenance['bounds']={k:str(v) if isinstance(v,Path) else v for k,v in provenance['bounds'].items()}
+    try:
+        baseline=json.loads((args.baseline/'baseline.json').read_text()) if args.baseline else None
+        from bench.benchmark import server_environment,find_playwright_module,find_playwright_browser
+        from PIL import Image
+        import preset_library
+        try: preset_library.builtin_presets()
+        except Exception as error: raise RuntimeError(f'Application dependency preflight failed: {error}. Follow CONTRIBUTING.md source setup.') from error
+        module=find_playwright_module();node=shutil.which('node')
+        if not module or not node: raise RuntimeError('Requires Node and Playwright; see scripts/ui-audit/README.md')
+        browser=os.environ.get('LIGHTTABLE_BROWSER_EXECUTABLE') or find_playwright_browser()
+        provenance.update(revision=subprocess.check_output(['git','rev-parse','HEAD'],cwd=ROOT,text=True).strip(),
+          dirty=bool(subprocess.check_output(['git','status','--porcelain'],cwd=ROOT,text=True)),
+          sourceHashes={str(f.relative_to(ROOT)):digest(f) for f in [*sorted((ROOT/'web').rglob('*')), *sorted(HERE.glob('*'))] if f.is_file() and '__pycache__' not in f.parts},
+          comparison={'platform':platform.platform(),'machine':platform.machine(),'maskVersion':MASK_VERSION,'deviceScaleFactor':1,
+            'fixtureHashes':{f.name:digest(f) for f in sorted((ROOT/'tests/fixtures/photos').glob('*.jpg'))}})
+        write(folder/'provenance.json',provenance)
+        for fixture in dict.fromkeys(c['fixture'] for c in cases):
+            server=worker=None
+            try:
+                remaining=deadline-time.monotonic()
+                if remaining<=0: raise TimeoutError('Audit wall-clock limit reached')
+                state_dir=folder/f'runtime-{fixture}';photos=state_dir/'photos';photos.mkdir(parents=True)
+                if fixture in ['photos','missing']:
+                    for source in sorted((ROOT/'tests/fixtures/photos').glob('*.jpg')):
+                        with Image.open(source) as im:
+                            im.thumbnail((1200,1200));im.save(photos/source.name)
+                    shutil.copy2(photos/'field.jpg',photos/('Long-'+('filename-Deutsch-Русский-العربية-'*3)+'.jpg'))
+                with socket.socket() as sock: sock.bind(('127.0.0.1',0));port=sock.getsockname()[1]
+                env=server_environment(photos,port,state_dir/'cache')
+                owned={'LIGHTTABLE_DIR','LIGHTTABLE_PORT','LIGHTTABLE_CACHE_DIR','LIGHTTABLE_PREFS_FILE','LIGHTTABLE_CATALOG_FILE','LIGHTTABLE_CATALOG_MIRROR'}
+                env={k:v for k,v in env.items() if not k.startswith('LIGHTTABLE_') or k in owned}
+                for key,value in {'LIGHTTABLE_HEADLESS':'1','LIGHTTABLE_PRESETS_FILE':str(state_dir/'presets.json'),
+                    'LIGHTTABLE_INSTANCE_DIR':str(state_dir/'instances'),'LIGHTTABLE_AI_DIR':str(state_dir/'ai'),
+                    'LIGHTTABLE_PROFILE_ROOT':str(state_dir/'profiles'),'LIGHTTABLE_SERVER_LOG':str(state_dir/'server.log'),
+                    'MPLCONFIGDIR':str(state_dir/'mpl')}.items(): env[key]=value
+                base=f'http://127.0.0.1:{port}'
+                with (state_dir/'stdout.log').open('w') as log:
+                    server=subprocess.Popen([sys.executable,str(ROOT/'server.py')],cwd=ROOT,env=env,
+                                            stdout=log,stderr=subprocess.STDOUT,start_new_session=True)
+                until=min(deadline,time.monotonic()+60)
+                while time.monotonic()<until:
+                    if server.poll() is not None: raise RuntimeError(f'Isolated server exited: {state_dir}/stdout.log')
+                    try:
+                        with urllib.request.urlopen(base+'/api/images',timeout=2) as r: payload=json.load(r)
+                        if len(payload.get('images',[]))==len(list(photos.glob('*.jpg'))): break
+                    except (OSError,ValueError): pass
+                    time.sleep(.1)
+                else: raise TimeoutError('Isolated server startup timed out')
+                if fixture=='missing':
+                    for f in photos.glob('*.jpg'): f.rename(f.with_suffix('.missing'))
+                config={'module':str(module),'browser':str(browser) if browser else None,'baseUrl':base,
+                  'output':str(folder),'result':str(folder/f'{fixture}-results.json'),'fixture':fixture,
+                  'mode':args.mode,'cases':[c for c in cases if c['fixture']==fixture],'panes':panes,
+                  'timeout':max(1,deadline-time.monotonic()),'steps':args.steps,'seed':args.seed,
+                  'minimizeAttempts':args.minimize_attempts,'maxFrames':args.max_frames,'replay':replay,
+                  'rules':replay.get('rules') if replay else args.rules}
+                config_file=folder/f'{fixture}-config.json';write(config_file,config)
+                with (folder/f'{fixture}-browser.log').open('w') as log:
+                    worker=subprocess.Popen([node,str(HERE/'browser.mjs'),str(config_file)],cwd=ROOT,
+                                            stdout=log,stderr=subprocess.STDOUT,start_new_session=True)
+                    worker.wait(timeout=max(.1,deadline-time.monotonic()))
+                if worker.returncode: result['errors'].append(f'{fixture} browser exited {worker.returncode}; see browser log')
+            finally:
+                stop(worker);stop(server)
+                file=folder/f'{fixture}-results.json'
+                if file.exists():
+                    partial=json.loads(file.read_text());result['records']+=partial['records'];result['errors']+=partial['errors']
+                    provenance['comparison']['browserVersion']=partial['browserVersion']
+            print(f'{fixture}: {len(result["records"])}/{len(cases)} states recorded',flush=True)
+        for r in result['records']:
+            if args.mode!='snapshot': continue
+            key=(baseline or {}).get('images',{}).get(r['id'])
+            if baseline and baseline['comparison']!=provenance['comparison']: r['baseline']={'status':'incompatible'}
+            elif key and digest(args.baseline/key['file'])!=key['sha256']: r['baseline']={'status':'corrupt-baseline'}
+            elif key and r.get('masked'): r['baseline']=compare(folder/r['masked'],args.baseline/key['file'],folder/f'{r["id"]}-diff.png')
+            else: r['baseline']={'status':'needs-approval'}
+        result['frameAnalysis']=frames_analysis(folder)
+        if any(f['frames']==0 for f in result['frameAnalysis']): result['errors'].append('No screencast frames captured')
+        complete=len(result['records'])==len(cases) and not result['errors'] and all(r['status']=='passed' for r in result['records'])
+        result['executionStatus']='passed' if complete else 'failed'
+        candidates=any(r.get('candidates') or r.get('initialCandidates') or r.get('baseline',{}).get('status','matched')!='matched' for r in result['records']) or any(f['candidates'] or f['capped'] for f in result['frameAnalysis'])
+        result['status']=('REVIEW REQUIRED' if candidates else 'CHECKS PASSED — visual review pending') if complete else 'NOT DONE'
+    except (Exception,KeyboardInterrupt) as error: result['errors'].append(str(error))
+    finally:
+        result['durationSeconds']=round(time.monotonic()-started,2)
+        write(folder/'provenance.json',provenance);write(folder/'result.json',result)
+        write(folder/'review.json',{'reviewStatus':'not-reviewed','inspectedEvidence':[],'findings':[]})
+        report(folder,result)
+    print(f'{result["status"]}: {folder}/README.md')
+    return 2 if result['executionStatus']!='passed' else (1 if result['status']=='REVIEW REQUIRED' else 0)
+
+if __name__=='__main__':
+    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    raise SystemExit(main())

--- a/scripts/ui-audit/test_probes.mjs
+++ b/scripts/ui-audit/test_probes.mjs
@@ -1,0 +1,28 @@
+// Synthetic DOM tests validate the oracles only; never presented as LightTable visual proof.
+import assert from 'node:assert/strict';
+import {pathToFileURL} from 'node:url';
+import {probe} from './probes.mjs';
+const {chromium}=await import(pathToFileURL(process.env.LIGHTTABLE_PLAYWRIGHT_MODULE).href);
+const browser=await chromium.launch({headless:true,executablePath:process.env.LIGHTTABLE_BROWSER_EXECUTABLE||undefined});
+try {
+  const page=await browser.newPage({viewport:{width:500,height:400}});
+  await page.setContent(`<!doctype html><html dir="ltr"><style>body{margin:0;background:white;color:black}button{font:16px Arial}</style>
+    <button id="clean">Readable</button><div hidden><button id="hidden">Invisible</button></div>
+    <details><summary>Closed</summary><button id="closed">Invisible</button></details></html>`);
+  let hits=await page.evaluate(probe,{});
+  assert.equal(hits.length,0,JSON.stringify(hits));
+  await page.setContent(`<!doctype html><html dir="ltr"><style>body{margin:0;background:white;color:black}button{font:16px Arial}
+    #badHidden[hidden]{display:block!important}#clip{width:30px;overflow:hidden;white-space:nowrap}
+    #a,#b{position:absolute;left:100px;top:100px;width:80px;height:40px}
+    #low{color:rgb(220,220,220)}#wide{width:700px;height:10px}#zero{width:0;height:0;padding:0;border:0}</style>
+    <button id="badHidden" hidden>Painted hidden</button><button id="clip">A long label here</button>
+    <button id="a">Overlap A</button><button id="b">Overlap B</button><span id="low">Low contrast</span>
+    <button id="tab" tabindex="2">Tab order</button><div id="wide"></div><button id="zero"></button></html>`);
+  hits=await page.evaluate(probe,{direction:'rtl'});
+  for(const rule of ['horizontal-overflow','hidden-paints','overlapping-controls','control-text-overflow','text-contrast','positive-tab-order','zero-size-control','document-direction'])
+    assert(hits.some(h=>h.rule===rule),`Missing ${rule}: ${JSON.stringify(hits)}`);
+  await page.setContent('<!doctype html><html dir="ltr"><div id="zoomwrap" style="width:200px;height:200px"><canvas id="cv" style="width:300px;height:300px"></canvas></div></html>');
+  hits=await page.evaluate(probe,{state:{zoomMode:'fit',viewMode:'detail',render:{state:'ready'}}});
+  assert(hits.some(h=>h.rule==='fit-geometry'));
+  console.log('Probe self-checks passed (clean DOM, eight defects, Fit geometry).');
+} finally {await browser.close();}

--- a/scripts/ui-audit/test_runner.py
+++ b/scripts/ui-audit/test_runner.py
@@ -1,0 +1,61 @@
+"""Harness self-checks, run explicitly; these do not audit application visuals."""
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+import run as audit
+
+
+class RunnerTests(unittest.TestCase):
+    def test_full_matrix_uses_every_shipped_locale_pane_zoom_and_viewport(self):
+        cases, panes = audit.matrix('full')
+        manifest = json.loads((audit.ROOT/'web/locales/manifest.json').read_text())
+        self.assertEqual({c['locale'] for c in cases}, {l['code'] for l in manifest['locales']})
+        self.assertEqual(len({c['id'] for c in cases}), len(cases))
+        for p in panes:
+            self.assertEqual({c['zoom'] for c in cases if c.get('pane') == p}, {'fit','actual','in','out'})
+        self.assertEqual({(c['viewport']['width'],c['viewport']['height']) for c in cases}, {(1280,720),(1440,900),(1728,1117)})
+        self.assertTrue(all(c['direction']=='rtl' for c in cases if c['locale']=='ar'))
+
+    def test_unknown_state_and_locale_fail(self):
+        with self.assertRaises(ValueError): audit.matrix('quick',states=['typo'])
+        with self.assertRaises(ValueError): audit.matrix('quick',locales=['typo'])
+
+    def test_pixel_comparison_detects_shift_and_wrong_size(self):
+        from PIL import Image, ImageDraw
+        with tempfile.TemporaryDirectory() as t:
+            d=Path(t);a=Image.new('RGB',(100,100),'white');ImageDraw.Draw(a).rectangle((5,5,30,30),fill='black');a.save(d/'a.png')
+            self.assertEqual(audit.compare(d/'a.png',d/'a.png',d/'diff.png')['status'],'matched')
+            b=Image.new('RGB',(100,100),'white');ImageDraw.Draw(b).rectangle((15,5,40,30),fill='black');b.save(d/'b.png')
+            self.assertEqual(audit.compare(d/'a.png',d/'b.png',d/'diff.png')['status'],'changed')
+            b.resize((90,100)).save(d/'b.png')
+            self.assertEqual(audit.compare(d/'a.png',d/'b.png',d/'diff.png')['status'],'different-size')
+
+    def test_baselines_require_review_and_do_not_overwrite(self):
+        with tempfile.TemporaryDirectory() as t:
+            d=Path(t);source=d/'run';source.mkdir();dest=d/'baseline'
+            audit.write(source/'review.json', {'reviewStatus':'not-reviewed','inspectedEvidence':[]})
+            audit.write(source/'result.json', {'executionStatus':'passed','records':[{'id':'case','screenshot':'a.png','masked':'b.png'}]})
+            audit.write(source/'provenance.json', {'mode':'snapshot','comparison':{}})
+            (source/'a.png').write_bytes(b'original');(source/'b.png').write_bytes(b'masked')
+            with self.assertRaises(ValueError): audit.approve(source,dest,'test reviewer')
+            audit.write(source/'review.json', {'reviewStatus':'reviewed','inspectedEvidence':['a.png']})
+            with self.assertRaises(ValueError): audit.approve(source,dest,'test reviewer')
+            audit.write(source/'review.json', {'reviewStatus':'reviewed','inspectedEvidence':['a.png','b.png']})
+            audit.approve(source,dest,'test reviewer')
+            self.assertEqual(json.loads((dest/'baseline.json').read_text())['images']['case']['sha256'],audit.digest(source/'b.png'))
+            with self.assertRaises(FileExistsError): audit.approve(source,dest,'test reviewer')
+
+    def test_transients_reuse_native_detector_and_real_timestamps(self):
+        from PIL import Image
+        with tempfile.TemporaryDirectory() as t:
+            d=Path(t);frames=[]
+            for i,c in enumerate(['black','white','black']):
+                Image.new('RGB',(80,46),c).save(d/f'{i}.jpg');frames.append({'file':f'{i}.jpg','timestamp':100+i*.04})
+            audit.write(d/'example-frames.json',{'frames':frames,'capped':False})
+            result=audit.frames_analysis(d)
+            self.assertEqual(result[0]['candidates'][0]['timestamp'],100.04)
+            self.assertEqual(result[0]['candidates'][0]['evidence'],['0.jpg','1.jpg','2.jpg'])
+
+if __name__=='__main__': unittest.main()


### PR DESCRIPTION
Adds an explicitly on-demand headless UI audit suite for snapshots, layout invariants, and seeded exploration. Runs use isolated disposable libraries, save screenshots and transition frames, produce bounded minimized replays, and require explicit review before approving baselines.

The suite and its self-checks are not wired into commit checks, CI triggers, build scripts, or mnb. Documentation links live in CONTRIBUTING.md and JOURNEY-TESTING.md.

Validation: five Python harness tests and browser oracle checks passed; exercised 80 unique UI states across English, Arabic, German and Russian through targeted runs, plus 60 detail snapshot combinations across all 20 locales and three viewports. The missing-original wait correction passed a four-locale recheck. Repeated masked snapshots matched exactly. Seeded exploration, saved replay, frame capture and intentional timeout cleanup were verified. Candidate visual findings remain unreviewed and no baselines were approved.

Refreshed against current main and reran the five harness tests successfully. This PR contains only the UI audit suite and its two documentation links; the same suite is also present in pending integration PR #75.
