### PR TITLE
Sign Windows releases with Azure Artifact Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,9 @@ jobs:
   windows:
     needs: prepare
     if: needs.prepare.outputs.windows == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/windows-build.yml
     with:
       version: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -157,12 +157,27 @@ jobs:
     needs: installer-check
     runs-on: windows-2022
     timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write
+    # windows-release permits only main and v* tags; windows-ci has no Azure trust.
+    environment: ${{ inputs.require_signing && 'windows-release' || 'windows-ci' }}
     env:
       UV_CACHE_DIR: ${{ github.workspace }}\.build\uv-cache
+      AZURE_SIGNING_ENDPOINT: ${{ inputs.require_signing && vars.AZURE_SIGNING_ENDPOINT || '' }}
+      AZURE_SIGNING_ACCOUNT: ${{ inputs.require_signing && vars.AZURE_SIGNING_ACCOUNT || '' }}
+      AZURE_SIGNING_PROFILE: ${{ inputs.require_signing && vars.AZURE_SIGNING_PROFILE || '' }}
+      AZURE_TENANT_ID: ${{ inputs.require_signing && vars.AZURE_TENANT_ID || '' }}
+      AZURE_CLIENT_ID: ${{ inputs.require_signing && vars.AZURE_CLIENT_ID || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_ref || github.sha }}
+
+      - name: Install pinned Azure signing dependencies
+        if: inputs.require_signing && vars.AZURE_SIGNING_ENDPOINT != ''
+        shell: pwsh
+        run: ./scripts/windows/install-signing-tools.ps1
 
       - name: Validate Windows signing configuration
         shell: pwsh
@@ -173,6 +188,9 @@ jobs:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           ./scripts/windows/sign-release.ps1 -CheckOnly -RequireSigning:($env:REQUIRE_SIGNING -eq 'true') | Out-Null
+          if ($env:REQUIRE_SIGNING -eq 'true' -and [string]::IsNullOrWhiteSpace($env:SPARKLE_PRIVATE_KEY)) {
+            throw "Windows release updates require SPARKLE_PRIVATE_KEY."
+          }
 
       - name: Restore build caches
         uses: actions/cache@v4
@@ -220,6 +238,14 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ./scripts/windows/build-release.ps1 -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
 
+      - name: Verify signatures in the completed artifacts
+        if: inputs.require_signing
+        shell: pwsh
+        run: |
+          $Archive = Get-ChildItem ./dist/LightTable-*-windows-x64.zip | Select-Object -First 1
+          $Installer = Get-ChildItem ./dist/LightTable-*-windows-x64-setup.exe | Select-Object -First 1
+          ./scripts/windows/verify-release-signatures.ps1 -Archive $Archive.FullName -Installer $Installer.FullName -Report ./dist/windows-signatures.json
+
       - name: Upload portable build and installer
         # Preserve a completed package for diagnosis/rechecks even if native
         # acceptance fails. The package job still fails and blocks release.yml.
@@ -230,6 +256,7 @@ jobs:
             dist/LightTable-*-windows-x64.zip
             dist/LightTable-*-windows-x64-setup.exe
             dist/appcast-windows-x64.xml
+            dist/windows-signatures.json
           if-no-files-found: error
 
       - name: Require native edit, export and restart

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -147,26 +147,63 @@ through `--stack-dumper`; diagnostics never turn a failed journey into a pass.
 Completed packages are retained even when native acceptance fails; that failure
 still blocks the full build job and release publication.
 
-For Authenticode signing, configure repository secrets
+For Azure Artifact Signing, configure the GitHub environment `windows-release`
+with deployment rules allowing branch `main` and tags `v*`. Give a dedicated
+Microsoft Entra application **Artifact Signing Certificate Profile Signer** at
+the certificate-profile scope only. Its federated credential must use:
+
+- Issuer: `https://token.actions.githubusercontent.com`
+- Subject: `repo:reville/lighttable-digital-darkroom:environment:windows-release`
+- Audience: `api://AzureADTokenExchange`
+
+Set these environment variables in GitHub's **Settings > Environments >
+windows-release > Environment variables**:
+
+| Variable | Value |
+| --- | --- |
+| `AZURE_SIGNING_ENDPOINT` | `https://eus.codesigning.azure.net/` |
+| `AZURE_SIGNING_ACCOUNT` | `lighttable-signing` |
+| `AZURE_SIGNING_PROFILE` | `lighttable-windows` |
+| `AZURE_TENANT_ID` | The signing account's Microsoft Entra tenant ID |
+| `AZURE_CLIENT_ID` | The dedicated application's client ID |
+
+Signed jobs request `id-token: write`; reusable callers must also grant that
+permission. The signing helper fetches a fresh GitHub OIDC assertion at each
+signing stage and uses Azure's `WorkloadIdentityCredential`. Temporary assertions
+are deleted after signing. No Azure client secret or private signing key is
+stored in GitHub. The Microsoft signing client and SDK packages are version- and
+checksum-pinned. The Windows runner needs .NET 8 or later. Ordinary CI uses the
+separate `windows-ci` environment, which has no Azure federated trust.
+
+Alternatively, for PFX-based Authenticode signing, configure repository secrets
 `WINDOWS_CERTIFICATE_BASE64` (a base64-encoded PFX containing a valid code-signing
 certificate and private key) and `WINDOWS_CERTIFICATE_PASSWORD`. The installed
 Windows SDK must provide `signtool.exe`. A reusable-workflow caller must pass
-these secrets explicitly or use `secrets: inherit`.
+these secrets explicitly or use `secrets: inherit`. Configure only one signing
+backend; mixed or partial settings fail the build.
 
 `build-release.ps1 -RequireSigning` checks the signing configuration before any
 downloads or compilation and refuses missing or partial credentials. Without
 credentials, ordinary CI builds remain unsigned. With credentials, the build
-signs the desktop executable, both render-engine executables, and the final
+signs the desktop executable, WinSparkle DLL, both render-engine executables, and the final
 NSIS installer; verification precedes smoke testing and final archiving. The
 temporary PFX is deleted in a `finally` block and no certificate is installed
 in the Windows certificate store. `build-manifest.json` records whether the
 package was signed.
 
 The signing helper uses SHA-256 file and RFC 3161 timestamp digests with the
-DigiCert timestamp service, then requires `signtool verify /pa /all /tw` to
+Microsoft timestamp service for Azure or DigiCert for PFX, then requires `signtool verify /pa /all /tw` to
 pass. The flags follow [Microsoft's SignTool documentation](https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool).
+Signed CI builds also extract the completed ZIP and independently verify every
+signed application binary and the installer, including timestamp presence.
+`windows-signatures.json` records the source revision, file hashes, publishers,
+and timestamp authorities alongside the build artifacts.
 Configuring this workflow does not itself obtain a certificate or prove a
 successful signed release.
+
+To produce a signed candidate without publishing a release, dispatch
+`windows-build.yml` on `main` with `version=0.5.0` and `require_signing=true`.
+Inspect the signature report and native acceptance evidence before publishing.
 
 Windows support is an additional host around the shared render core, not a
 replacement for the macOS implementation.

--- a/release/README.md
+++ b/release/README.md
@@ -134,11 +134,17 @@ the public key embedded in `app/Info.plist`.
 
 Ordinary CI builds remain unsigned so runtime and installation checks can run
 without release credentials. Public release builds set `require_signing: true`
-and fail before building if signing is not configured. Set repository secrets
-`WINDOWS_CERTIFICATE_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD` for the authorized
-Authenticode certificate export. The Windows SDK SignTool signs and timestamps
+and fail before building if signing is not configured. Configure Azure Artifact
+Signing through the protected `windows-release` environment and a GitHub OIDC
+federated identity scoped to the Windows certificate profile; see
+[Windows signing setup](../WINDOWS.md). PFX signing remains supported through
+`WINDOWS_CERTIFICATE_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD`, but the two
+backends cannot be configured together. The Windows SDK SignTool signs and timestamps
 the app and engine executables before packaging, then signs the final installer.
 The npm installer independently rejects an invalid or unsigned Windows installer.
+Signed build artifacts include `windows-signatures.json`, recording independently
+verified signatures from the finished ZIP and installer. Dispatch the Windows
+build workflow with `require_signing=true` to test a candidate without publishing.
 
 ## Windows and Linux update feeds
 

--- a/scripts/windows/install-signing-tools.ps1
+++ b/scripts/windows/install-signing-tools.ps1
@@ -1,0 +1,33 @@
+# Pinned Microsoft NuGet packages. These tools never contain signing credentials.
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+if ($env:OS -ne "Windows_NT") { throw "The signing tools require Windows." }
+$Destination = Join-Path $env:RUNNER_TEMP "lighttable-signing-tools"
+$Packages = @(
+    @{
+        Name = "microsoft.artifactsigning.client"; Version = "1.0.128"; Folder = "client"
+        Sha256 = "74bd7d27e6ce1051409c38d9b46bc8df0400ecd643d51ffbf2ac00869061e40b"
+    },
+    @{
+        Name = "microsoft.windows.sdk.buildtools"; Version = "10.0.26100.8249"; Folder = "sdk"
+        Sha256 = "1628c77d21ed187c4db998b37b18e267a7f092ae755589e21110c14260b14960"
+    }
+)
+New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+foreach ($Package in $Packages) {
+    $Archive = Join-Path $Destination "$($Package.Folder).zip"
+    $Uri = "https://api.nuget.org/v3-flatcontainer/$($Package.Name)/$($Package.Version)/$($Package.Name).$($Package.Version).nupkg"
+    Invoke-WebRequest -Uri $Uri -OutFile $Archive
+    if ((Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant() -ne $Package.Sha256) {
+        throw "Signing dependency checksum mismatch: $($Package.Name)."
+    }
+    Expand-Archive -LiteralPath $Archive -DestinationPath (Join-Path $Destination $Package.Folder) -Force
+    Remove-Item -LiteralPath $Archive -Force
+}
+$SignTool = Join-Path $Destination "sdk/bin/10.0.26100.0/x64/signtool.exe"
+$Dlib = Join-Path $Destination "client/bin/x64/Azure.CodeSigning.Dlib.dll"
+foreach ($File in @($SignTool, $Dlib)) {
+    if (-not (Test-Path -LiteralPath $File -PathType Leaf)) { throw "Missing signing dependency: $File" }
+}
+"AZURE_SIGNING_SIGNTOOL=$SignTool" | Out-File -LiteralPath $env:GITHUB_ENV -Append -Encoding utf8
+"AZURE_SIGNING_DLIB=$Dlib" | Out-File -LiteralPath $env:GITHUB_ENV -Append -Encoding utf8

--- a/scripts/windows/sign-azure.ps1
+++ b/scripts/windows/sign-azure.ps1
@@ -1,0 +1,88 @@
+param([string[]]$Files = @(), [switch]$CheckOnly)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$Endpoint = $null
+if (-not [Uri]::TryCreate($env:AZURE_SIGNING_ENDPOINT, [UriKind]::Absolute, [ref]$Endpoint) -or
+    $Endpoint.Scheme -ne "https" -or $Endpoint.Host -notmatch '^[a-z0-9-]+\.codesigning\.azure\.net$' -or
+    $Endpoint.UserInfo -or $Endpoint.Query -or $Endpoint.Fragment -or $Endpoint.AbsolutePath -ne "/") {
+    throw "Azure Artifact Signing requires an HTTPS regional codesigning.azure.net endpoint."
+}
+foreach ($Setting in @("AZURE_TENANT_ID", "AZURE_CLIENT_ID")) {
+    $Identifier = [Guid]::Empty
+    if (-not [Guid]::TryParse([Environment]::GetEnvironmentVariable($Setting), [ref]$Identifier)) {
+        throw "Azure Artifact Signing requires a valid $Setting GUID."
+    }
+}
+if ($env:GITHUB_ACTIONS -ne "true" -or $env:GITHUB_REPOSITORY -ne "reville/lighttable-digital-darkroom" -or
+    $env:GITHUB_EVENT_NAME -eq "pull_request" -or
+    ($env:GITHUB_REF -ne "refs/heads/main" -and $env:GITHUB_REF -notmatch '^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$')) {
+    throw "Azure signing is restricted to this repository's main branch and version tags in GitHub Actions."
+}
+foreach ($Setting in @("ACTIONS_ID_TOKEN_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")) {
+    if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($Setting))) {
+        throw "Azure signing requires GitHub OIDC with id-token: write."
+    }
+}
+if ($env:OS -ne "Windows_NT") { throw "Azure Artifact Signing requires Windows." }
+foreach ($Setting in @("AZURE_SIGNING_SIGNTOOL", "AZURE_SIGNING_DLIB")) {
+    $Dependency = [Environment]::GetEnvironmentVariable($Setting)
+    if ([string]::IsNullOrWhiteSpace($Dependency) -or -not (Test-Path -LiteralPath $Dependency -PathType Leaf)) {
+        throw "Run install-signing-tools.ps1 before Azure signing; missing $Setting."
+    }
+}
+if ($CheckOnly) { return $true }
+if ($Files.Count -eq 0) { throw "At least one executable is required for Authenticode signing." }
+$Executables = @(foreach ($File in $Files) {
+    $Executable = (Resolve-Path -LiteralPath $File).Path
+    if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll")) {
+        throw "The Windows release signing list must contain only executables or DLLs."
+    }
+    $Executable
+})
+$SigningDirectory = Join-Path ([IO.Path]::GetTempPath()) ("lighttable-signing-" + [Guid]::NewGuid())
+$PreviousTokenFile = $env:AZURE_FEDERATED_TOKEN_FILE
+try {
+    New-Item -ItemType Directory -Path $SigningDirectory | Out-Null
+    # Fetch a fresh GitHub assertion at each signing stage, after compilation.
+    # Azure.Identity exchanges it using WorkloadIdentityCredential; no client secret
+    # or Azure private signing key is stored in GitHub or on the build runner.
+    try {
+        $Response = Invoke-RestMethod -Uri ($env:ACTIONS_ID_TOKEN_REQUEST_URL + "&audience=api://AzureADTokenExchange") `
+            -Headers @{ Authorization = "bearer $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN" } -TimeoutSec 30
+        if ([string]::IsNullOrWhiteSpace($Response.value)) { throw "Missing assertion" }
+        $env:AZURE_FEDERATED_TOKEN_FILE = Join-Path $SigningDirectory "oidc.jwt"
+        [IO.File]::WriteAllText($env:AZURE_FEDERATED_TOKEN_FILE, $Response.value)
+    } catch {
+        # Do not echo HTTP diagnostics, which can include credential material.
+        throw "Could not obtain the GitHub OIDC assertion for Azure signing."
+    }
+    $MetadataPath = Join-Path $SigningDirectory "metadata.json"
+    @{
+        Endpoint = $env:AZURE_SIGNING_ENDPOINT
+        CodeSigningAccountName = $env:AZURE_SIGNING_ACCOUNT
+        CertificateProfileName = $env:AZURE_SIGNING_PROFILE
+        CorrelationId = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+        ExcludeCredentials = @(
+            "EnvironmentCredential", "ManagedIdentityCredential", "SharedTokenCacheCredential",
+            "VisualStudioCredential", "VisualStudioCodeCredential", "AzureCliCredential",
+            "AzurePowerShellCredential", "AzureDeveloperCliCredential", "InteractiveBrowserCredential"
+        )
+    } | ConvertTo-Json | Set-Content -LiteralPath $MetadataPath -Encoding utf8
+    foreach ($Executable in $Executables) {
+        & $env:AZURE_SIGNING_SIGNTOOL sign /q /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 `
+            /dlib $env:AZURE_SIGNING_DLIB /dmdf $MetadataPath $Executable
+        if ($LASTEXITCODE -ne 0) { throw "Azure signing or timestamping failed." }
+        & $env:AZURE_SIGNING_SIGNTOOL verify /q /pa /all /tw $Executable
+        if ($LASTEXITCODE -ne 0) { throw "Windows executable Authenticode verification failed." }
+        $Signature = Get-AuthenticodeSignature -LiteralPath $Executable
+        if ($Signature.Status -ne "Valid" -or $null -eq $Signature.TimeStamperCertificate) {
+            throw "Azure signing requires a valid, timestamped Authenticode signature."
+        }
+        Write-Host "Verified Authenticode signature: $([IO.Path]::GetFileName($Executable)); publisher: $($Signature.SignerCertificate.Subject)"
+    }
+} finally {
+    $env:AZURE_FEDERATED_TOKEN_FILE = $PreviousTokenFile
+    $Response = $null
+    if (Test-Path -LiteralPath $SigningDirectory) { Remove-Item -LiteralPath $SigningDirectory -Recurse -Force }
+}

--- a/scripts/windows/sign-release.ps1
+++ b/scripts/windows/sign-release.ps1
@@ -9,6 +9,20 @@ Set-StrictMode -Version Latest
 
 $HasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_BASE64)
 $HasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+$AzureSettings = @("AZURE_SIGNING_ENDPOINT", "AZURE_SIGNING_ACCOUNT", "AZURE_SIGNING_PROFILE", "AZURE_TENANT_ID", "AZURE_CLIENT_ID")
+$AzureConfigured = @($AzureSettings | Where-Object {
+    -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+})
+if ($AzureConfigured.Count -gt 0) {
+    if ($HasCertificate -or $HasPassword) { throw "Configure Azure Artifact Signing or a PFX, never both." }
+    foreach ($Setting in $AzureSettings) {
+        if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($Setting))) {
+            throw "Azure Artifact Signing requires $Setting."
+        }
+    }
+    & (Join-Path $PSScriptRoot "sign-azure.ps1") -Files $Files -CheckOnly:$CheckOnly
+    return
+}
 if (-not $HasCertificate -and -not $HasPassword -and -not $RequireSigning) {
     if ($CheckOnly) { return $false }
     Write-Host "Authenticode is not configured; this is an unsigned CI build."

--- a/scripts/windows/verify-release-signatures.ps1
+++ b/scripts/windows/verify-release-signatures.ps1
@@ -1,0 +1,43 @@
+param(
+    [Parameter(Mandatory)][string]$Archive,
+    [Parameter(Mandatory)][string]$Installer,
+    [Parameter(Mandatory)][string]$Report
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$Directory = Join-Path ([IO.Path]::GetTempPath()) ("lighttable-signature-check-" + [Guid]::NewGuid())
+try {
+    Expand-Archive -LiteralPath $Archive -DestinationPath $Directory
+    $Bundle = Join-Path $Directory "LightTable"
+    $Manifest = Get-Content -LiteralPath (Join-Path $Bundle "build-manifest.json") -Raw | ConvertFrom-Json
+    if (-not $Manifest.authenticode_signed) { throw "The archive is not marked as signed." }
+    $ExpectedRevision = (git rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0 -or $Manifest.source_revision -ne $ExpectedRevision) {
+        throw "The archive source revision does not match the checked-out build."
+    }
+    $Paths = @("LightTable.exe", "WinSparkle.dll", "Resources/engine/lighttable-engine.exe", "Resources/engine/spektrafilm-rs.exe")
+    $Files = @($Paths | ForEach-Object { Join-Path $Bundle $_ }) + @((Resolve-Path -LiteralPath $Installer).Path)
+    $Evidence = @(foreach ($File in $Files) {
+        $Signature = Get-AuthenticodeSignature -LiteralPath $File
+        if ($Signature.Status -ne "Valid" -or $null -eq $Signature.TimeStamperCertificate) {
+            throw "Invalid or missing timestamped Authenticode signature: $([IO.Path]::GetFileName($File))"
+        }
+        @{
+            file = [IO.Path]::GetFileName($File)
+            sha256 = (Get-FileHash -LiteralPath $File -Algorithm SHA256).Hash.ToLowerInvariant()
+            status = [string]$Signature.Status
+            publisher = $Signature.SignerCertificate.Subject
+            certificate_thumbprint = $Signature.SignerCertificate.Thumbprint
+            timestamp_authority = $Signature.TimeStamperCertificate.Subject
+        }
+    })
+    @{
+        source_revision = $ExpectedRevision
+        version = $Manifest.version
+        archive_sha256 = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
+        signatures = $Evidence
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $Report -Encoding utf8
+    Write-Host "Verified all $($Evidence.Count) application and installer signatures in the completed artifacts."
+} finally {
+    if (Test-Path -LiteralPath $Directory) { Remove-Item -LiteralPath $Directory -Recurse -Force }
+}

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -339,13 +339,15 @@ class WindowsRuntimeLaunchContractTests(unittest.TestCase):
 
 @unittest.skipUnless(shutil.which("pwsh") or shutil.which("powershell"), "PowerShell is required")
 class WindowsSigningGateTests(unittest.TestCase):
-    def invoke(self, script, *arguments, certificate=None, password=None):
+    def invoke(self, script, *arguments, certificate=None, password=None, azure=None):
         environment = {key: value for key, value in os.environ.items()
-                       if key not in ("WINDOWS_CERTIFICATE_BASE64", "WINDOWS_CERTIFICATE_PASSWORD")}
+                       if key not in ("WINDOWS_CERTIFICATE_BASE64", "WINDOWS_CERTIFICATE_PASSWORD")
+                       and not key.startswith(("AZURE_", "ACTIONS_ID_TOKEN_", "GITHUB_"))}
         if certificate is not None:
             environment["WINDOWS_CERTIFICATE_BASE64"] = certificate
         if password is not None:
             environment["WINDOWS_CERTIFICATE_PASSWORD"] = password
+        environment.update(azure or {})
         return subprocess.run(
             [shutil.which("pwsh") or shutil.which("powershell"), "-NoLogo", "-NoProfile",
              "-NonInteractive", "-File", str(ROOT / "scripts/windows" / script), *arguments],
@@ -374,6 +376,55 @@ class WindowsSigningGateTests(unittest.TestCase):
                 self.assertIn("Windows signing requires both", result.stderr)
                 for value in configuration.values():
                     self.assertNotIn(value, result.stdout + result.stderr)
+
+    AZURE = {
+        "AZURE_SIGNING_ENDPOINT": "https://eus.codesigning.azure.net/",
+        "AZURE_SIGNING_ACCOUNT": "fixture-account",
+        "AZURE_SIGNING_PROFILE": "fixture-profile",
+        "AZURE_TENANT_ID": "00000000-0000-0000-0000-000000000001",
+        "AZURE_CLIENT_ID": "00000000-0000-0000-0000-000000000002",
+    }
+
+    def test_partial_azure_configuration_fails_closed_without_leaking_values(self):
+        for missing in self.AZURE:
+            with self.subTest(missing=missing):
+                config = {key: value for key, value in self.AZURE.items() if key != missing}
+                result = self.invoke("sign-release.ps1", "-CheckOnly", azure=config)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"requires {missing}", result.stderr)
+                self.assertNotIn("fixture-account", result.stderr)
+
+    def test_azure_and_pfx_configuration_is_rejected(self):
+        result = self.invoke("sign-release.ps1", "-CheckOnly", azure=self.AZURE,
+                             certificate="synthetic-test-certificate")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("never both", result.stderr)
+
+    def test_azure_rejects_an_untrusted_endpoint_before_authentication(self):
+        for endpoint in ("http://eus.codesigning.azure.net/", "https://example.com/",
+                         "https://eus.codesigning.azure.net.evil.example/",
+                         "https://eus.codesigning.azure.net/?token=synthetic"):
+            result = self.invoke("sign-release.ps1", "-CheckOnly",
+                                 azure={**self.AZURE, "AZURE_SIGNING_ENDPOINT": endpoint})
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("HTTPS regional", result.stderr)
+
+    def test_azure_rejects_untrusted_build_contexts(self):
+        trusted = {**self.AZURE, "GITHUB_ACTIONS": "true",
+                   "GITHUB_REPOSITORY": "reville/lighttable-digital-darkroom",
+                   "GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_REF": "refs/heads/main"}
+        for override in ({"GITHUB_REF": "refs/heads/topic"},
+                         {"GITHUB_REF": "refs/tags/arbitrary"},
+                         {"GITHUB_EVENT_NAME": "pull_request"},
+                         {"GITHUB_REPOSITORY": "someone-else/fork"},
+                         {"GITHUB_ACTIONS": "false"}):
+            result = self.invoke("sign-release.ps1", "-CheckOnly", azure={**trusted, **override})
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("restricted to this repository", result.stderr)
+        for ref in ("refs/heads/main", "refs/tags/v0.5.0", "refs/tags/v0.5.0-rc.1"):
+            result = self.invoke("sign-release.ps1", "-CheckOnly", azure={**trusted, "GITHUB_REF": ref})
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("requires GitHub OIDC", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Windows releases can now use Azure Artifact Signing to sign the application binaries and NSIS installer, then verify timestamped signatures again from the finished ZIP and installer. GitHub OIDC provides a fresh assertion at each signing stage, avoiding stored Azure client secrets and token expiry during compilation. Microsoft signing dependencies are version- and checksum-pinned; partial or mixed Azure/PFX configuration fails closed.

Signed builds use the protected `windows-release` environment and require main or a version tag. Ordinary CI stays unsigned in `windows-ci`. The existing PFX path remains supported, and the reusable release caller grants the required OIDC permission. Build artifacts include a signature report with source revision, hashes, publishers, and timestamp authorities. Setup and candidate-build instructions are documented.

Validation: all 26 Windows packaging/signing tests passed locally with PowerShell 7.6.6; all Windows PowerShell scripts parsed successfully; actionlint passed for both affected workflows. Windows CI and a production-signed candidate will provide runtime and real-signature validation after merge; this change does not publish a release.
