### PR TITLE
Keep Windows signing builds independent of routine CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -45,7 +45,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_run_id || 'build' }}
+  # A routine main build must not cancel a production-signed candidate.
+  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_run_id || 'build' }}-${{ inputs.require_signing && 'signed' || 'unsigned' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
A push to main and a manually dispatched signed Windows candidate currently share a concurrency group, so routine CI can cancel release validation. Include signing mode in that group so signed candidates finish independently while repeated runs of the same mode still cancel stale work.

Validation: actionlint and git diff --check passed. This only changes workflow concurrency; the signing implementation passed all checks in #81.
