### PR TITLE
Verify production signing before compiling Windows releases

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -192,6 +192,7 @@ jobs:
           if ($env:REQUIRE_SIGNING -eq 'true' -and [string]::IsNullOrWhiteSpace($env:SPARKLE_PRIVATE_KEY)) {
             throw "Windows release updates require SPARKLE_PRIVATE_KEY."
           }
+          if ($env:REQUIRE_SIGNING -eq 'true') { ./scripts/windows/signing-smoke.ps1 }
 
       - name: Restore build caches
         uses: actions/cache@v4

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -153,7 +153,7 @@ Microsoft Entra application **Artifact Signing Certificate Profile Signer** at
 the certificate-profile scope only. Its federated credential must use:
 
 - Issuer: `https://token.actions.githubusercontent.com`
-- Subject: `repo:reville/lighttable-digital-darkroom:environment:windows-release`
+- Subject: `repo:reville@279601/lighttable-digital-darkroom@1358417583:environment:windows-release`
 - Audience: `api://AzureADTokenExchange`
 
 Set these environment variables in GitHub's **Settings > Environments >
@@ -166,6 +166,10 @@ windows-release > Environment variables**:
 | `AZURE_SIGNING_PROFILE` | `lighttable-windows` |
 | `AZURE_TENANT_ID` | The signing account's Microsoft Entra tenant ID |
 | `AZURE_CLIENT_ID` | The dedicated application's client ID |
+
+The subject includes immutable owner and repository IDs. Match the subject
+GitHub actually issues; do not assume a name-only subject from the API's
+`use_immutable_subject` flag.
 
 Signed jobs request `id-token: write`; reusable callers must also grant that
 permission. The signing helper fetches a fresh GitHub OIDC assertion at each
@@ -190,6 +194,10 @@ NSIS installer; verification precedes smoke testing and final archiving. The
 temporary PFX is deleted in a `finally` block and no certificate is installed
 in the Windows certificate store. `build-manifest.json` records whether the
 package was signed.
+
+Before compiling the application, a required signing run signs and verifies a
+temporary executable. This exercises federation, signer permissions, and the
+timestamp service early. The fixture is deleted and is never run or shipped.
 
 The signing helper uses SHA-256 file and RFC 3161 timestamp digests with the
 Microsoft timestamp service for Azure or DigiCert for PFX, then requires `signtool verify /pa /all /tw` to

--- a/scripts/windows/sign-azure.ps1
+++ b/scripts/windows/sign-azure.ps1
@@ -70,9 +70,15 @@ try {
         )
     } | ConvertTo-Json | Set-Content -LiteralPath $MetadataPath -Encoding utf8
     foreach ($Executable in $Executables) {
+        # The Microsoft client can include HTTP response headers in failure
+        # diagnostics. Keep its output private and expose only an AADSTS code.
+        $SignLog = Join-Path $SigningDirectory "signing.log"
         & $env:AZURE_SIGNING_SIGNTOOL sign /q /fd SHA256 /tr http://timestamp.acs.microsoft.com /td SHA256 `
-            /dlib $env:AZURE_SIGNING_DLIB /dmdf $MetadataPath $Executable
-        if ($LASTEXITCODE -ne 0) { throw "Azure signing or timestamping failed." }
+            /dlib $env:AZURE_SIGNING_DLIB /dmdf $MetadataPath $Executable *> $SignLog
+        if ($LASTEXITCODE -ne 0) {
+            $FailureCode = [regex]::Match((Get-Content -LiteralPath $SignLog -Raw), 'AADSTS[0-9]+').Value
+            throw "Azure signing or timestamping failed. $FailureCode Check the federated identity and certificate-profile signer role."
+        }
         & $env:AZURE_SIGNING_SIGNTOOL verify /q /pa /all /tw $Executable
         if ($LASTEXITCODE -ne 0) { throw "Windows executable Authenticode verification failed." }
         $Signature = Get-AuthenticodeSignature -LiteralPath $Executable

--- a/scripts/windows/signing-smoke.ps1
+++ b/scripts/windows/signing-smoke.ps1
@@ -1,0 +1,19 @@
+# Exercise the real signing identity before a long release build. The fixture
+# is never executed or shipped, and all temporary files are removed afterward.
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$Directory = Join-Path ([IO.Path]::GetTempPath()) ("lighttable-signing-smoke-" + [Guid]::NewGuid())
+try {
+    New-Item -ItemType Directory -Path $Directory | Out-Null
+    $Compiler = Join-Path $env:WINDIR "Microsoft.NET/Framework64/v4.0.30319/csc.exe"
+    if (-not (Test-Path -LiteralPath $Compiler -PathType Leaf)) { throw "The signing smoke test requires the Windows .NET Framework compiler." }
+    $Source = Join-Path $Directory "signing-smoke.cs"
+    $Executable = Join-Path $Directory "signing-smoke.exe"
+    'class SigningSmoke { static int Main() { return 0; } }' | Set-Content -LiteralPath $Source -Encoding ascii
+    & $Compiler /nologo /target:exe "/out:$Executable" $Source
+    if ($LASTEXITCODE -ne 0) { throw "The signing smoke fixture failed to compile." }
+    & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files $Executable
+    Write-Host "Production signing and timestamp verification passed before compilation."
+} finally {
+    if (Test-Path -LiteralPath $Directory) { Remove-Item -LiteralPath $Directory -Recurse -Force }
+}

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -426,6 +426,45 @@ class WindowsSigningGateTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("requires GitHub OIDC", result.stderr)
 
+    def test_azure_failure_redacts_sdk_headers_and_removes_temporary_credentials(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            folder = Path(temporary)
+            signer = folder / "fake-signtool.ps1"
+            signer.write_text(
+                'Write-Output "Set-Cookie: private-cookie-for-test"\n'
+                'Write-Output "AADSTS700213 private-assertion-for-test"\nexit 1\n')
+            dlib = folder / "fake.dll"
+            executable = folder / "fixture.exe"
+            dlib.touch()
+            executable.touch()
+            environment = {key: value for key, value in os.environ.items()
+                           if key not in ("WINDOWS_CERTIFICATE_BASE64", "WINDOWS_CERTIFICATE_PASSWORD")
+                           and not key.startswith(("AZURE_", "ACTIONS_ID_TOKEN_", "GITHUB_"))}
+            environment.update({
+                **self.AZURE, "OS": "Windows_NT", "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "reville/lighttable-digital-darkroom",
+                "GITHUB_REF": "refs/heads/main", "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_RUN_ID": "123", "GITHUB_RUN_ATTEMPT": "1",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://example.invalid/?fixture=true",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "private-request-token-for-test",
+                "AZURE_SIGNING_SIGNTOOL": str(signer), "AZURE_SIGNING_DLIB": str(dlib),
+                "TEMP": temporary, "TMP": temporary, "TMPDIR": temporary,
+            })
+            quote = lambda value: "'" + str(value).replace("'", "''") + "'"
+            command = (
+                "function Invoke-RestMethod { @{ value = 'private-assertion-for-test' } }; "
+                f"& {quote(ROOT / 'scripts/windows/sign-release.ps1')} -RequireSigning -Files {quote(executable)}"
+            )
+            result = subprocess.run(
+                [shutil.which("pwsh") or shutil.which("powershell"), "-NoLogo", "-NoProfile",
+                 "-NonInteractive", "-Command", command], env=environment,
+                capture_output=True, text=True, timeout=30)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("AADSTS700213", result.stderr)
+            for secret in ("private-cookie-for-test", "private-assertion-for-test", "private-request-token-for-test"):
+                self.assertNotIn(secret, result.stdout + result.stderr)
+            self.assertEqual(list(folder.glob("lighttable-signing-*")), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A signed candidate reached compilation successfully but Azure rejected GitHub's immutable repository subject. Document the exact issued subject and exercise real signing, timestamps, and certificate-profile permissions on a disposable executable before the long application build. The fixture is never run or shipped.

Capture Microsoft's verbose signing diagnostics privately and expose only its AADSTS error code on failure, since its exception output can contain HTTP headers. Temporary logs and assertions are removed in the existing cleanup block.

Validation: 27 packaging/signing tests pass, including failure-log redaction and credential cleanup; all Windows PowerShell scripts parse; actionlint passes. Azure's existing federated credential has been corrected to the issued immutable subject. The next signed candidate will validate the real preflight and finished artifacts.
