### PR TITLE
Verify signatures at the shipped Windows engine paths

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -218,6 +218,7 @@ jobs:
           choco install nsis --no-progress -y
 
       - name: Build and smoke-test package
+        id: build-package
         shell: pwsh
         env:
           PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
@@ -250,7 +251,9 @@ jobs:
 
       - name: Upload portable build and installer
         # Preserve a completed package for diagnosis/rechecks even if native
-        # acceptance fails. The package job still fails and blocks release.yml.
+        # acceptance or signature verification fails. The job still fails and
+        # blocks release.yml; retained artifacts are not approval to publish.
+        if: ${{ !cancelled() && steps.build-package.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: LightTable-windows-x64

--- a/scripts/windows/verify-release-signatures.ps1
+++ b/scripts/windows/verify-release-signatures.ps1
@@ -15,7 +15,7 @@ try {
     if ($LASTEXITCODE -ne 0 -or $Manifest.source_revision -ne $ExpectedRevision) {
         throw "The archive source revision does not match the checked-out build."
     }
-    $Paths = @("LightTable.exe", "WinSparkle.dll", "Resources/engine/lighttable-engine.exe", "Resources/engine/spektrafilm-rs.exe")
+    $Paths = @("LightTable.exe", "WinSparkle.dll", "Resources/LightTable/engine/lighttable-engine.exe", "Resources/LightTable/engine/spektrafilm-rs.exe")
     $Files = @($Paths | ForEach-Object { Join-Path $Bundle $_ }) + @((Resolve-Path -LiteralPath $Installer).Path)
     $Evidence = @(foreach ($File in $Files) {
         $Signature = Get-AuthenticodeSignature -LiteralPath $File

--- a/tests/test_windows_packaging.py
+++ b/tests/test_windows_packaging.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import unittest
 from unittest import mock
+import zipfile
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -464,6 +465,62 @@ class WindowsSigningGateTests(unittest.TestCase):
             for secret in ("private-cookie-for-test", "private-assertion-for-test", "private-request-token-for-test"):
                 self.assertNotIn(secret, result.stdout + result.stderr)
             self.assertEqual(list(folder.glob("lighttable-signing-*")), [])
+
+
+@unittest.skipUnless(shutil.which("pwsh") or shutil.which("powershell"), "PowerShell is required")
+class WindowsSignatureReportTests(unittest.TestCase):
+    def test_finished_package_layout_source_identity_and_timestamps(self):
+        revision = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+        # This is the shipped runtime layout: Python resources are nested under
+        # Resources/LightTable, independently of the verifier's implementation.
+        payload = (
+            "LightTable.exe", "WinSparkle.dll",
+            "Resources/LightTable/engine/lighttable-engine.exe",
+            "Resources/LightTable/engine/spektrafilm-rs.exe",
+        )
+        for case in ("valid", "wrong-source", "missing-timestamp"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temporary:
+                folder = Path(temporary)
+                archive = folder / "LightTable.zip"
+                installer = folder / "LightTable-0.5.0-windows-x64-setup.exe"
+                report = folder / "signatures.json"
+                installer.write_bytes(b"installer fixture")
+                with zipfile.ZipFile(archive, "w") as bundle:
+                    for path in payload:
+                        bundle.writestr("LightTable/" + path, b"executable fixture")
+                    bundle.writestr("LightTable/build-manifest.json", json.dumps({
+                        "version": "0.5.0", "authenticode_signed": True,
+                        "source_revision": "0" * 40 if case == "wrong-source" else revision,
+                    }))
+                quote = lambda value: "'" + str(value).replace("'", "''") + "'"
+                # Stub only the native certificate API; use real ZIP extraction,
+                # files, hashes, manifest loading, and source-revision checks.
+                timestamp = "$null" if case == "missing-timestamp" else "@{ Subject = 'fixture timestamp authority' }"
+                command = (
+                    "function Get-AuthenticodeSignature { param($LiteralPath) "
+                    "if (-not (Test-Path -LiteralPath $LiteralPath -PathType Leaf)) { throw 'Packaged executable not found' }; "
+                    "[pscustomobject]@{ Status = 'Valid'; SignerCertificate = @{ Subject = 'fixture publisher'; Thumbprint = 'abc' }; "
+                    f"TimeStamperCertificate = {timestamp} }} }}; "
+                    f"& {quote(ROOT / 'scripts/windows/verify-release-signatures.ps1')} "
+                    f"-Archive {quote(archive)} -Installer {quote(installer)} -Report {quote(report)}"
+                )
+                result = subprocess.run(
+                    [shutil.which("pwsh") or shutil.which("powershell"), "-NoLogo", "-NoProfile",
+                     "-NonInteractive", "-Command", command], cwd=ROOT,
+                    capture_output=True, text=True, timeout=30)
+                if case != "valid":
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("source revision" if case == "wrong-source" else "timestamped Authenticode", result.stderr)
+                    self.assertFalse(report.exists())
+                    continue
+                self.assertEqual(result.returncode, 0, result.stderr)
+                evidence = json.loads(report.read_text(encoding="utf-8-sig"))
+                self.assertEqual(evidence["source_revision"], revision)
+                self.assertEqual(evidence["version"], "0.5.0")
+                self.assertEqual({item["file"] for item in evidence["signatures"]},
+                                 {Path(path).name for path in payload} | {installer.name})
+                for item in evidence["signatures"]:
+                    self.assertRegex(item["sha256"], r"^[0-9a-f]{64}$")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The completed-package verifier looked for engine executables in `Resources/engine`, but the shipped runtime stores them in `Resources/LightTable/engine`. Correct those paths and test against an independently constructed package fixture using real extraction, hashes, and source-revision checks. The test also requires rejection of missing timestamps and mismatched source revisions.

Preserve a completed package as a diagnostic artifact if the independent verification step fails. The failed job still blocks release publication.

Validation: all 28 Windows packaging/signing tests pass locally with PowerShell, and actionlint and diff checks pass. The live signed build has already verified the application binaries and installer with the production certificate; a clean run will validate the corrected final report and native acceptance.
