### PR TITLE
Fix Windows startup reporting and Linux release CI dependencies

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -53,6 +53,9 @@ jobs:
 
       - name: Install Linux build dependencies
         run: |
+          # The hosted image may retain Chrome's updater source. This WebKit
+          # build does not use it, and stale Chrome metadata can break apt update.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config cmake gfortran libssl-dev libopenblas-dev \

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -128,6 +128,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_durable_io.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_startup_reporting.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_desktop_smoke.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_packaging.py -v
@@ -230,6 +232,8 @@ jobs:
           python -m unittest discover -s tests -p test_process_liveness.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_durable_io.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_startup_reporting.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_desktop_smoke.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/recovery.py
+++ b/recovery.py
@@ -55,11 +55,19 @@ def _stamp() -> str:
 
 def _write_json(path: Path, value: Any) -> bool:
     """Best-effort durable write; recovery bookkeeping must never raise."""
-    try:
-        durable_io.atomic_write_json(path, value, keep_backup=False)
-        return True
-    except OSError:
-        return False
+    for attempt in range(6):
+        try:
+            durable_io.atomic_write_json(path, value, keep_backup=False)
+            return True
+        except OSError as error:
+            # A launcher polling the phase file, or a Windows virus scanner,
+            # can briefly deny replacement. Losing the final ready record
+            # leaves a healthy server looking stuck at its previous phase.
+            # Keep permanent failures best-effort, with at most 310 ms of delay.
+            if getattr(error, "winerror", None) not in (5, 32, 33) or attempt == 5:
+                return False
+            time.sleep(0.01 * 2 ** attempt)
+    return False
 
 
 # ----------------------------------------------------------------- startup --

--- a/tests/test_startup_reporting.py
+++ b/tests/test_startup_reporting.py
@@ -1,0 +1,100 @@
+"""Keep the launcher's final startup record readable under Windows file sharing."""
+import ctypes
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import durable_io
+import recovery
+
+
+class StartupPublicationTests(unittest.TestCase):
+    def test_transient_windows_lock_does_not_lose_ready(self):
+        for code in (5, 32, 33):
+            with self.subTest(winerror=code), tempfile.TemporaryDirectory() as temporary:
+                path = Path(temporary) / "startup.json"
+                reporter = recovery.StartupReporter(path)
+                reporter.phase("listening")
+                original_write = durable_io.atomic_write_json
+                failure = PermissionError("temporary Windows file lock")
+                failure.winerror = code
+                attempts = 0
+
+                def write(*args, **kwargs):
+                    nonlocal attempts
+                    attempts += 1
+                    if attempts < 3:
+                        raise failure
+                    return original_write(*args, **kwargs)
+
+                with mock.patch.object(durable_io, "atomic_write_json", side_effect=write), \
+                        mock.patch.object(recovery.time, "sleep") as sleep:
+                    reporter.ready(8321)
+                record = json.loads(path.read_text())
+                self.assertEqual((record["phase"], record["port"]), ("ready", 8321))
+                self.assertEqual(attempts, 3)
+                self.assertTrue(sleep.called)
+
+    def test_permanent_failure_stays_bounded_and_keeps_previous_report(self):
+        for code in (None, 5, 32):
+            with self.subTest(winerror=code), tempfile.TemporaryDirectory() as temporary:
+                path = Path(temporary) / "startup.json"
+                path.write_text('{"phase":"listening"}')
+                failure = OSError("write unavailable")
+                if code is not None:
+                    failure.winerror = code
+                with mock.patch.object(durable_io, "atomic_write_json", side_effect=failure) as write, \
+                        mock.patch.object(recovery.time, "sleep") as sleep:
+                    self.assertFalse(recovery._write_json(path, {"phase": "ready"}))
+                self.assertEqual(json.loads(path.read_text())["phase"], "listening")
+                if code is None:
+                    self.assertEqual(write.call_count, 1)
+                    sleep.assert_not_called()
+                else:
+                    self.assertGreater(write.call_count, 1)
+                    self.assertLessEqual(write.call_count, 10)
+                    self.assertLessEqual(sum(call.args[0] for call in sleep.call_args_list), 0.5)
+
+    @unittest.skipUnless(os.name == "nt", "requires real Windows sharing semantics")
+    def test_ready_survives_a_native_reader_without_delete_sharing(self):
+        from ctypes import wintypes
+
+        kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel.CreateFileW.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD,
+                                      wintypes.LPVOID, wintypes.DWORD, wintypes.DWORD,
+                                      wintypes.HANDLE]
+        kernel.CreateFileW.restype = wintypes.HANDLE
+        kernel.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel.CloseHandle.restype = wintypes.BOOL
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "startup.json"
+            reporter = recovery.StartupReporter(path)
+            reporter.phase("listening")
+            # Match a polling reader that permits reads/writes but not deletion.
+            handle = kernel.CreateFileW(str(path), 0x80000000, 0x3, None, 3, 0x80, None)
+            self.assertNotEqual(handle, ctypes.c_void_p(-1).value)
+            try:
+                with self.assertRaises(OSError) as caught:
+                    durable_io.atomic_write_json(path, {"phase": "ready"}, keep_backup=False)
+                self.assertIn(caught.exception.winerror, (5, 32, 33))
+
+                def release_reader(_delay):
+                    nonlocal handle
+                    if handle is not None:
+                        self.assertTrue(kernel.CloseHandle(handle))
+                        handle = None
+
+                with mock.patch.object(recovery.time, "sleep", side_effect=release_reader):
+                    reporter.ready(8321)
+                record = json.loads(path.read_text())
+                self.assertEqual((record["phase"], record["port"]), ("ready", 8321))
+            finally:
+                if handle is not None:
+                    kernel.CloseHandle(handle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A packaged Windows server can start listening but leave its launcher waiting forever if a transient Windows file lock prevents the final ready report from replacing the previous startup phase. Recovery JSON writes now retry Windows sharing/access errors for a bounded 310 ms, preserving the existing best-effort behavior for permanent failures. A native Windows regression holds the report open without delete sharing, demonstrates the replacement failure, then verifies that releasing the reader during retry publishes ready successfully.

Linux CI also failed twice before building because Google's unused Chrome apt source returned mismatched index hashes. Remove that source from the ephemeral runner before installing the Ubuntu build dependencies; package verification remains enabled.

Validation: Windows CI passed all three startup-reporting tests, including a real Win32 reader that denies delete sharing, plus the packaging and installer checks. Linux package CI passed on the combined change. The full unit suite and independent film, export, WebGL, and application pixel gates passed. Local startup-publication and durable-I/O tests pass; actionlint passes; Help content is current. A signed candidate will exercise the complete package and native acceptance checks after merge.
