### PR TITLE
Enable native trackpad pinch zoom in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ skipped, and labels converted settings as approximate:
 different render engines produce different results. See
 [preset interchange](PRESET-INTERCHANGE.md) for compatibility details.
 
-In Detail, switching photos keeps the current zoom level and restores each
+In Detail, pinch on the trackpad over the photo to zoom around the pointer.
+Switching photos keeps the current zoom level and restores each
 photo’s pan position for the current window session. New photos start centered.
 
 ### A full editing workflow

--- a/app/main.swift
+++ b/app/main.swift
@@ -43,6 +43,43 @@ final class LightTableWebView: WKWebView {
     private var topBarRect: CGRect?
     private var topBarControlRects: [CGRect] = []
     private var windowChromeDragBlocked = false
+    private var magnificationMonitor: Any?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let magnificationMonitor { NSEvent.removeMonitor(magnificationMonitor) }
+        magnificationMonitor = nil
+        guard window != nil else { return }
+        // WebKit's content descendants can consume magnification without
+        // emitting DOM gesture events. Route it before responder dispatch,
+        // and consume the native event so WebKit cannot deliver it twice.
+        magnificationMonitor = NSEvent.addLocalMonitorForEvents(matching: .magnify) { [weak self] event in
+            self?.forwardEditorMagnification(event) == true ? nil : event
+        }
+    }
+
+    deinit {
+        if let magnificationMonitor { NSEvent.removeMonitor(magnificationMonitor) }
+    }
+
+    @discardableResult
+    func forwardEditorMagnification(_ event: NSEvent) -> Bool {
+        guard event.type == .magnify, let window, event.window === window,
+              !isHiddenOrHasHiddenAncestor else { return false }
+        let point = convert(event.locationInWindow, from: nil)
+        guard bounds.contains(point) else { return false }
+        let factor = 1 + event.magnification
+        guard factor.isFinite, factor > 0 else { return true }
+        let payload: [String: Double] = [
+            "factor": Double(factor),
+            "x": Double(point.x - bounds.minX),
+            "y": Double(isFlipped ? point.y - bounds.minY : bounds.maxY - point.y),
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else { return true }
+        evaluateJavaScript("window.dispatchEvent(new CustomEvent('lighttable-magnify', {detail: \(json)}))", completionHandler: nil)
+        return true
+    }
 
     func updateWindowChromeLayout(_ body: [String: Any]) {
         guard let topBar = Self.rect(body["topBar"]),

--- a/docs/help/library.json
+++ b/docs/help/library.json
@@ -484,6 +484,10 @@
         "anchor": "export function createZoomMotion("
       },
       {
+        "path": "app/main.swift",
+        "anchor": "func forwardEditorMagnification(_ event: NSEvent) -> Bool {"
+      },
+      {
         "path": "web/photo-pan.js",
         "anchor": "export function createPhotoPanMemory()"
       }

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -3,14 +3,14 @@
     "about-lighttable": {
       "content": "f176c760d71f2141d024f089715f371828dcb3916a9a86bdfbea36dbae67ce87",
       "sources": {
-        "README.md": "8a0c6b223cb61c3c9e35d9fb66478eb46010a046b28ff077dbc92985967097c6",
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23"
+        "README.md": "2a87312ba5e435ca24fbdba6ab42ba87409c79a6865a2d5e04ca74490b62b15b",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628"
       }
     },
     "add-photos": {
       "content": "ed9c4ac18836826ad67c0ad52e2689c5d46d696548161570ecb8374c777632fa",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/first-run.js": "d3e3cc68759c3c7634b44c9edf562b2ae163120ae6255c38941222fa33eeebda",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
@@ -21,7 +21,7 @@
       "sources": {
         "film_lab_ai/culling.py": "08cb4e9ebda9ca5285422eab7c0be5938dd0a63c7bfefa3a22218ea3ed93773b",
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/cull-batch.js": "f22524c715dcccbf0f0870cc464d5f45f328bcb20bb2e6793285dbe7a7ba9b87",
         "web/cull-similarity.js": "55d00a5f2a99b89f0ce1b140271af396872cbc9510e37404474be4b6ad4b6d13",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
@@ -31,8 +31,8 @@
     "browse-folders": {
       "content": "83110cc81ab7af3bec5273ae311e070f452a2972b13822f1164cfde7699d13ac",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
@@ -49,7 +49,7 @@
       "content": "9300fd7e981c26e4f2997363e9327fe23bbf8df404cfd80db32dee5cb865abd1",
       "sources": {
         "app/DiagnosticReports.swift": "f658b768399f0b1da70cd1158812c4bd726cafd032155398b266434882054c02",
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "catalog_scan.py": "a4f36ffa249b431642ae6b8af927da3a359ae5c7354f0ab0140491bdfe1759e1",
         "fatal_diagnostics.py": "56b1deacd97f83a19f3d41e0d77ac46e3f3d6b75cb815c043fafec5f443ef2f9",
         "file_identity.py": "e6516b82a587821c2dcb4d7d015847884e72c10f74cb28ce5b18cb60dd9a1c2b",
@@ -63,14 +63,14 @@
     "collections": {
       "content": "95bc3775974e6454f3d55661cf2db268196f4d73750fb1ba7f796bb23379cd36",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -84,16 +84,16 @@
     "editing-color-mixer-point-color": {
       "content": "9cfba81ef549fe43a8d1e2dc1ed7c7cc660202b4f2a640506af71f8e59fb0d7e",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "editing-copy-paste-match-exposure": {
       "content": "6ad6b7b568ad9a1f3ae86662e7e835b617eb23a6bfb8d415cabb15e1418c00d5",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "server.py": "e82bd1fe458e2779a09594c5b63fccacbaec6337b4565589ef45340615f9adbc",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
@@ -108,16 +108,16 @@
     "editing-curves": {
       "content": "a2280ce4abd9f79d1c1e6d0673c3d2ef6015fb01a14e4385e3c8621bd6b13a54",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "editing-detail-effects-enhance": {
       "content": "49911d9d38fd2ceaf03c72fb033100ed2b6683610df8c2d67b8139dce6bd03e8",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "enhance_workflow.py": "b2b3fe529770388b3c4bf04345bf995a6d9a70ef866a5e917313f8b3de72506a",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/enhance-panel.js": "6efc59ea9686bf72062453c76d61a9a09ad86511b4d9737e8ba95409fd95daa7",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
@@ -126,14 +126,14 @@
       "content": "e65c38833c6557b83b0e471394ed3d4fda54c7e44a5a7f4cba7a7e25fd04df71",
       "sources": {
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "editing-history-snapshots": {
       "content": "86dc3f8196fa62cc452db8d0cf86e40f2fe2450a1c8166cfe812177272853273",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/history-panel.js": "5f7a77338be697479c921dc76a9668e7846c50e75cab47bfd634dfe924faec25",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
@@ -141,7 +141,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
@@ -149,7 +149,7 @@
       "content": "b93d29b8af3e46c1f77976f9fec3732bb152c6b506e7bfe1f681d8b6381d4644",
       "sources": {
         "semantic_masks.py": "d48eb799d0c3188d4dc48a573d193eec94fc087b4eb9fba9560ed41b8de585f7",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
@@ -157,7 +157,7 @@
       "content": "9e545e5ed89a7b168be2b0a8eabfea5cec8e882c010910a4615ae425f61bbd5b",
       "sources": {
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/editor-panels.js": "cbb1e16f590167c8f948629f3a851866a94e641daf0bc9af9694cb893d937446",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/mask-curve.js": "4db1ce1aa1d7c959762be56651cc5f7076bd363540309aef6aba3ba5a1bcf281",
@@ -169,7 +169,7 @@
     "editing-masks-ranges-refinements": {
       "content": "69559a947ccd17ddcf891ab7791585d708eaa3b452ac32e1fe6fee456fe90167",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254"
       }
@@ -177,22 +177,22 @@
     "editing-photo-merge": {
       "content": "5030e3092b04c12520f62d83ac0dd9b1f5b09b50e8af8cd1693f190bc63b47c1",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
         "server.py": "e82bd1fe458e2779a09594c5b63fccacbaec6337b4565589ef45340615f9adbc",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "editing-presets": {
       "content": "8deccb179e402b4f907687ea12cd7650abaad71b59d14b2901ae26e9812894ec",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "preset_io.py": "ad379b80b1b534c5afde2b54587892440c1be80d314b8a60b6532793a763b97e",
         "preset_library.py": "fb8d27cde136b026d25fe512a281a0d8f6d80a97b9bcbdca667e229162c26358",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "server.py": "e82bd1fe458e2779a09594c5b63fccacbaec6337b4565589ef45340615f9adbc",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
         "web/preset-browser.css": "607baaf24f673069d59e069381edb5fe64b138f4a9769addbc7d53c51e334768",
@@ -204,7 +204,7 @@
       "content": "3d70eb73feed29823cf507dacaaefa5e836efbeda3815657693341cdb79c297d",
       "sources": {
         "app/NativePreview.metal": "45aa8ae595982903f61554d60f6da370d0e77e905fad335f7ba9e250f0daaa02",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
@@ -213,21 +213,21 @@
     "editing-save-recovery": {
       "content": "5ea77476828b252a78757b30d827464a516994d3c1cf84a3a6041bec601e2b2d",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/edit-save-queue.js": "0d56b96358f6de5ade38c3dd554260f876a746145a89476c0a68e3c16620a574"
       }
     },
     "editing-tone": {
       "content": "2e83d0be17ae55ef2edbd5cb335d18e9d96de22d032056f3dc9027bbe48fc35d",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "editing-white-balance": {
       "content": "f6b3b37c291e9d60356355f3668f15990e40995bedc9062c9a67a3da9425e271",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
@@ -235,7 +235,7 @@
       "content": "007309327e1d2aa65e1c38fea9ce0347ee5b343c9a12b881419000c5ccd44999",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
@@ -243,7 +243,7 @@
       "content": "5945724f1f5a9ad80dabdbb9b1943978a77aa5a373366307f8acc38aabd165f0",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
@@ -258,14 +258,14 @@
       "content": "dbb37c4fdeb501f59294843e33d6aea92727bd952e76e11978a4a14af5535086",
       "sources": {
         "server.py": "e82bd1fe458e2779a09594c5b63fccacbaec6337b4565589ef45340615f9adbc",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "external-editor": {
       "content": "905a7f2d9fc297adb88b6aa0c2f0f5bf7b21513ca1db891c3b7a3bf137aac2de",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
@@ -273,7 +273,7 @@
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
@@ -282,7 +282,7 @@
       "content": "2ea19e843ce9c9a59afd0e8d2e0a3dd7927a6e7a413dc92a9b64c23f328516b6",
       "sources": {
         "film_tuning.py": "133a5e3200b69b2aa3b92f8bb471c93af449b5036bb8dfdd6610292175693860",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/style.css": "f9757f8e1e6c1430d379d532a3c4350b93c9851d298452ef447337291e148065"
@@ -299,7 +299,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
@@ -307,7 +307,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
@@ -315,14 +315,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -348,8 +348,8 @@
     "keyboard-midi": {
       "content": "afa81f9e0bf349d0df5d83bf5a2b09497fd62c2c0ecc69fa629d2fa04382fdf0",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/midi.js": "a74a05ad2303790b15efaf9953afcf60f20ccfabf4d4f8bde7ae2eb99c834175"
       }
@@ -357,9 +357,9 @@
     "metadata-and-keywords": {
       "content": "4070dd0015da08ec42ca3dbf872e0d0e24c046eb2f938cf594101846244587ec",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "keyword_workflow.py": "5c545bd45205bf294d15cddbaf43f27a39ad5c30b69e7f98fab579d2b61a73a4",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/keyword-batch.js": "e38195a5528e40635522473776ba9b0a2052f11a78ac77fb7cfe81fa3cc8a88e",
         "web/metadata-panel.js": "d6be67c2b0b58d543fabee1349bab40bbe40afffb5fe2ecd4414d7c996f69cda"
       }
@@ -384,7 +384,7 @@
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
         "server.py": "e82bd1fe458e2779a09594c5b63fccacbaec6337b4565589ef45340615f9adbc",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/preview-detail.js": "8601034c83de06c042fdd5528d7fde5ff69db567bdac7225f3b133b739836acc",
@@ -401,7 +401,7 @@
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
         "film_lab_ai/service.py": "fd684477d966d1014c1b72cb843871379db98b41fb800ec9f98a8d75c1eea842",
         "media_availability.py": "cfdfc4495f979f9c6b11686a9bb3610a1c894059eecf896bbcd8730582363272",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
         "web/style.css": "f9757f8e1e6c1430d379d532a3c4350b93c9851d298452ef447337291e148065"
@@ -410,7 +410,7 @@
     "raw-jpeg-pairs": {
       "content": "63ef5d08a8d6515e2677eb9344c41edafd7d2b2266703648040f4080033691b2",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -428,7 +428,7 @@
       "sources": {
         "catalog_scan.py": "a4f36ffa249b431642ae6b8af927da3a359ae5c7354f0ab0140491bdfe1759e1",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/library-filters.js": "eea02c5ed7b026e4be6ec7983b1af5af9f66b917c274be54e3b04744b57a4b00",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
@@ -452,7 +452,7 @@
     "settings-language": {
       "content": "94778fce4730a2170969e2c8021322069e60563dc48890e749ff36fbfbc55f6f",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/i18n.js": "48ec7b56c856a8db9bcd47315a6c697582a0207a1656d42ed43260c3627b7388",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/locale-bootstrap.js": "06fc13de85d1b216f01742ae5667c03b18a4fd413913281bb87aa7866b287845",
@@ -463,7 +463,7 @@
     "shortcut-schemes": {
       "content": "e6cf59f5fde950bf351b74084189c3d6fb585b9ef8f86c78a01c82db94da584d",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
@@ -472,7 +472,7 @@
       "content": "9b7e47fe1ac1a2ae85a54070f12b51d8876a2d4497b5f3dc3c0857cca2e1da6b",
       "sources": {
         "catalog.py": "e1cb4c80f7ba1265ac02c48656b365c48109fa3f4560d7dd5647e4bd29b008e2",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
       }
     },
@@ -480,30 +480,31 @@
       "content": "667d42680ff9d3d60918660cb348f4d0add54a7577d29d9db4a20a48495425f0",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a"
       }
     },
     "survey-photos": {
       "content": "1769c5e6c33849b62cd8407e16ceb7ae8f211b4a61d15f73fb7ca1a7933a3c15",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/survey.js": "79fd7a71ef314f25e5a6452f9def6d5edeac62799fd1305631f1607724363cc3"
       }
     },
     "trash-rejected": {
       "content": "f52bb62055da510b5960532a68f9c82786187593aaa50a1172a5f2173f8d2fbd",
       "sources": {
-        "app/main.swift": "26c2bbeeb38f20b3bbe5e3338e8889c206fc3fbfb272cb65fa9355ca0cffda23",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "server.py": "e82bd1fe458e2779a09594c5b63fccacbaec6337b4565589ef45340615f9adbc",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
     "views-and-selection": {
-      "content": "5671b035e23cb8bb257863e9ec19b58cad37c37393946f51b4c4e8203313133e",
+      "content": "b29d13cf48372d452f1b70d9f45883e7d3ad32ed7a23f1dd2754744d62382641",
       "sources": {
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95",
+        "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "ba50e6295cad3ce2c19a5b010f67bd16946e4b894e748fca5b773a3ea1f0df9a",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
@@ -515,7 +516,7 @@
       "content": "de9620831ddcd8ecee7ce1f29fa1442122cfe5fa8183c0650ee8b3b34210d498",
       "sources": {
         "library_workflow.py": "b07bc79b58666fe92ce189ac4132a6904457e166f73c155f3f636fc683966e3c",
-        "web/app.js": "48231649295d3f20b7bb66a14e4159ddcd0e15913866067de081786a749aed95"
+        "web/app.js": "8d9a6e64fa39354ddc543261f084196628de3b89ef22f6381f347a4f8890b12f"
       }
     },
     "xmp-interchange": {

--- a/tests/native-pinch.test.mjs
+++ b/tests/native-pinch.test.mjs
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const source = fs.readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+const handlers = source.slice(source.indexOf('  let wheelFrame = 0;'),
+  source.indexOf('  let gStart = 1;'));
+const zoom = ['zoomAt', 'zoomReset'].map(name =>
+  source.match(new RegExp(`function ${name}\\(.*?\\n\\}`, 's'))[0]).join('\n');
+
+function scene({sourceWidth = 6000} = {}) {
+  const S = {viewMode: 'detail', zoom: 1, zoomMode: 'fit', panX: 0, panY: 0};
+  const listeners = {}, frames = [], paints = [];
+  const image = {name: 'photo'};
+  let target = 'photo', modal = false, current = image, speedChanges = 0;
+  const rect = () => ({left: 500 + S.panX - 400 * S.zoom,
+    top: 400 + S.panY - 300 * S.zoom, width: 800 * S.zoom, height: 600 * S.zoom});
+  const cv = {width: 800, height: 600, getBoundingClientRect: rect};
+  const wrap = {contains: hit => hit === 'photo',
+    addEventListener: (type, fn) => {listeners[type] = fn;}};
+  const document = {querySelector: () => modal, elementFromPoint: () => target};
+  const noop = () => {};
+  new Function('S', '$', 'displaySourcePixelWidth', 'clamp', 'zoomMotion', 'zoomView',
+    'presentZoomChange', 'rememberPhotoPan', 'wrap', 'window', 'document', 'cur',
+    'requestAnimationFrame', 'stopZoomMotion', 'applyView', 'adjustSpeed', `${zoom}\n${handlers}`)(
+      S, () => cv, () => sourceWidth, (v, a, b) => Math.min(b, Math.max(a, v)),
+      {cancel: noop}, () => ({zoom: S.zoom, panX: S.panX, panY: S.panY}),
+      () => paints.push(S.zoom), noop, wrap, {addEventListener: wrap.addEventListener},
+      document, () => current, fn => {frames.push(fn); return frames.length;},
+      noop, noop, () => {speedChanges++;});
+  return {S, paints, frames, rect,
+    pinch(factor, x = 650, y = 450) {listeners['lighttable-magnify']({detail: {factor, x, y}});},
+    wheel(event) {listeners.wheel({preventDefault: noop, clientX: 650, clientY: 450, ...event});},
+    flush() {for (const fn of frames.splice(0)) fn();},
+    target(value) {target = value;}, modal(value) {modal = value;},
+    current(value) {current = value;}, speedChanges: () => speedChanges,
+  };
+}
+
+test('native pinch coalesces incremental magnification and preserves the photo under the pointer', () => {
+  const view = scene();
+  const before = view.rect();
+  const anchor = [(650 - before.left) / before.width, (450 - before.top) / before.height];
+  view.pinch(1.1); view.pinch(1.2); view.pinch(1.25);
+  assert.equal(view.frames.length, 1);
+  assert.equal(view.S.zoom, 1);
+  view.flush();
+  assert.ok(Math.abs(view.S.zoom - 1.65) < 1e-10);
+  assert.equal(view.paints.length, 1);
+  const after = view.rect();
+  assert.ok(Math.abs(after.left + after.width * anchor[0] - 650) < 1e-10);
+  assert.ok(Math.abs(after.top + after.height * anchor[1] - 450) < 1e-10);
+  view.pinch(1 / 1.65); view.flush();
+  assert.equal(view.S.zoomMode, 'fit');
+  assert.deepEqual([view.S.zoom, view.S.panX, view.S.panY], [1, 0, 0]);
+});
+
+test('native pinch uses the existing zoom limits, including actual pixels below Fit', () => {
+  const view = scene();
+  view.pinch(100); view.flush();
+  assert.equal(view.S.zoom, 32);
+  view.pinch(0.001); view.flush();
+  assert.equal(view.S.zoom, 1);
+  const small = scene({sourceWidth: 200});
+  small.pinch(0.25); small.flush();
+  assert.equal(small.S.zoom, 0.25);
+  assert.equal(small.S.zoomMode, '100');
+  small.pinch(0.5); small.flush();
+  assert.equal(small.S.zoom, 0.25);
+});
+
+test('pinch cannot zoom through dialogs, sidebars, a grid, or an in-progress edit', () => {
+  const view = scene();
+  view.target('sidebar'); view.pinch(2);
+  view.target('photo'); view.modal(true); view.pinch(2);
+  view.modal(false); view.S.viewMode = 'square'; view.pinch(2);
+  view.S.viewMode = 'detail'; view.current(null); view.pinch(2);
+  view.current({name: 'photo'}); view.S.editGesture = {}; view.pinch(2);
+  view.S.editGesture = null; view.S.cropTransition = {}; view.pinch(2);
+  assert.equal(view.frames.length, 0);
+  assert.equal(view.S.zoom, 1);
+});
+
+test('invalid or empty native magnification is ignored', () => {
+  const view = scene();
+  for (const factor of [NaN, Infinity, -1, 0, 1, undefined]) view.pinch(factor);
+  view.pinch(2, NaN, 450); view.pinch(2, 650, Infinity);
+  assert.equal(view.frames.length, 0);
+});
+
+test('native pinch stays a zoom gesture when a Speed Key is held', () => {
+  const view = scene();
+  view.S.speed = {key: 'e'};
+  view.pinch(2); view.flush();
+  assert.equal(view.S.zoom, 2);
+  assert.equal(view.speedChanges(), 0);
+  view.wheel({deltaY: 1});
+  assert.equal(view.speedChanges(), 1);
+});
+
+test('browser trackpad wheel zoom and ordinary two-finger panning still work', () => {
+  const view = scene();
+  view.wheel({ctrlKey: true, deltaY: -Math.log(2) * 100}); view.flush();
+  assert.equal(view.S.zoom, 2);
+  const pan = [view.S.panX, view.S.panY];
+  view.wheel({deltaX: 15, deltaY: -10}); view.flush();
+  assert.deepEqual([view.S.panX, view.S.panY], [pan[0] - 15, pan[1] + 10]);
+});

--- a/tests/test_native_pinch.py
+++ b/tests/test_native_pinch.py
@@ -1,0 +1,125 @@
+"""Check the production native pinch bridge without displaying a window."""
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(sys.platform == "darwin", "requires AppKit and WebKit")
+class NativePinchTests(unittest.TestCase):
+    def test_magnification_reaches_javascript_without_scaling_webkit(self):
+        swiftc = shutil.which("swiftc")
+        if not swiftc:
+            self.skipTest("swiftc is unavailable")
+        source = (ROOT / "app/main.swift").read_text()
+        chrome = source[source.index("private enum WindowChrome"):
+                        source.index("// MARK: - Locations")]
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            main = directory / "main.swift"
+            executable = directory / "pinch-test"
+            main.write_text(HARNESS.replace("CHROME_SOURCE", chrome))
+            for command in (
+                [swiftc, "-swift-version", "5", "-module-cache-path",
+                 str(directory / "modules"), str(main), "-o", str(executable)],
+                [str(executable)],
+            ):
+                result = subprocess.run(command, capture_output=True, text=True, timeout=90)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("PASS: native pinch delivery", result.stdout)
+            print(result.stdout.strip())
+
+
+HARNESS = r'''
+import AppKit
+import WebKit
+
+CHROME_SOURCE
+
+func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() { print("FAIL: \(message)"); exit(1) }
+}
+func wait(_ condition: () -> Bool) {
+    let deadline = Date().addingTimeInterval(10)
+    while !condition() && Date() < deadline {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+    }
+    require(condition(), "timed out waiting for WebKit")
+}
+final class Messages: NSObject, WKScriptMessageHandler {
+    var ready = false
+    var pinches: [[String: Double]] = []
+    func userContentController(_ controller: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        if message.body as? String == "ready" { ready = true }
+        if let payload = message.body as? [String: Double] { pinches.append(payload) }
+    }
+}
+// Synthetic values enter the production NSEvent -> DOM boundary. No global
+// event injection, activation, or physical trackpad claim is involved.
+final class MagnifyEvent: NSEvent {
+    var owner: NSWindow?
+    var location = NSPoint.zero
+    var amount: CGFloat = 0
+    override var type: NSEvent.EventType { .magnify }
+    override var window: NSWindow? { owner }
+    override var locationInWindow: NSPoint { location }
+    override var magnification: CGFloat { amount }
+}
+let foreground = NSWorkspace.shared.frontmostApplication?.processIdentifier
+let application = NSApplication.shared
+application.setActivationPolicy(.prohibited)
+let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 1000, height: 800),
+    styleMask: [.titled], backing: .buffered, defer: false)
+let root = NSView(frame: NSRect(x: 0, y: 0, width: 1000, height: 800))
+let config = WKWebViewConfiguration()
+config.websiteDataStore = .nonPersistent()
+let messages = Messages()
+config.userContentController.add(messages, name: "pinch")
+let web = LightTableWebView(frame: NSRect(x: 30, y: 40, width: 900, height: 700), configuration: config)
+web.allowsMagnification = false
+root.addSubview(web)
+window.contentView = root
+web.loadHTMLString("""
+<html><body><script>
+window.addEventListener('lighttable-magnify', e => window.webkit.messageHandlers.pinch.postMessage(e.detail));
+window.webkit.messageHandlers.pinch.postMessage('ready');
+</script></body></html>
+""", baseURL: nil)
+wait { messages.ready }
+let event = MagnifyEvent()
+event.owner = window
+event.location = web.convert(NSPoint(x: 350, y: web.isFlipped ? 250 : 450), to: nil)
+event.amount = 0.2
+require(web.forwardEditorMagnification(event), "own-window pinch must be consumed")
+wait { messages.pinches.count == 1 }
+let payload = messages.pinches[0]
+require(abs((payload["factor"] ?? 0) - 1.2) < 0.000001, "magnification is an incremental scale")
+require(payload["x"] == 350 && payload["y"] == 250, "window coordinates must become DOM coordinates")
+event.amount = -0.25
+require(web.forwardEditorMagnification(event), "reverse pinch must be consumed")
+wait { messages.pinches.count == 2 }
+require(messages.pinches[1]["factor"] == 0.75, "pinch-in must shrink the photo")
+require(web.magnification == 1 && web.pageZoom == 1, "WebKit UI scale must stay unchanged")
+
+event.owner = nil
+require(!web.forwardEditorMagnification(event), "other windows must keep their events")
+event.owner = window
+event.location = NSPoint(x: -100, y: -100)
+require(!web.forwardEditorMagnification(event), "outside points must keep their events")
+event.location = web.convert(NSPoint(x: 350, y: 250), to: nil)
+web.isHidden = true
+require(!web.forwardEditorMagnification(event), "hidden views must not receive pinch")
+web.isHidden = false
+event.amount = .nan
+require(web.forwardEditorMagnification(event), "invalid pinch is consumed without emitting JSON")
+web.removeFromSuperview()
+require(!web.forwardEditorMagnification(event), "detached views must not receive pinch")
+require(!window.isVisible && !application.isActive, "test must never show or activate the window")
+require(NSWorkspace.shared.frontmostApplication?.processIdentifier == foreground, "foreground app must be unchanged")
+print("PASS: native pinch delivery, coordinates, direction, window scope, unchanged UI scale; no activation")
+'''

--- a/web/app.js
+++ b/web/app.js
@@ -9124,6 +9124,17 @@ function finishSpeedKey(key) {
     }
     wheelScale = 1; wheelPanX = 0; wheelPanY = 0;
   };
+  window.addEventListener('lighttable-magnify', ({detail}) => {
+    if (S.viewMode !== 'detail' || !cur() || S.editGesture || S.cropTransition ||
+        document.querySelector('.modal-backdrop.on')) return;
+    const {factor, x, y} = detail || {};
+    if (!Number.isFinite(factor) || factor <= 0 || factor === 1 ||
+        !Number.isFinite(x) || !Number.isFinite(y) ||
+        !wrap.contains(document.elementFromPoint(x, y))) return;
+    wheelScale *= factor;
+    wheelPoint = [x, y];
+    if (!wheelFrame) wheelFrame = requestAnimationFrame(flushWheel);
+  });
   wrap.addEventListener('wheel', (e) => {
     if (S.speed) {
       e.preventDefault();


### PR DESCRIPTION
Trackpad pinches in the macOS editor now reach the photo zoom handler even when WebKit consumes native magnification events. Zoom stays anchored under the pointer, while sidebars, dialogs, and the overall UI keep their normal size.

The native route consumes each event once, coalesces zoom updates, and respects the existing zoom limits. Browser pinch and two-finger panning retain their existing behavior. README and Help source tracking are updated.

Validation: 363 JavaScript tests passed; native event-delivery and window-routing tests passed; the full Swift shell type-check passed; Help and all localization checks passed. Physical trackpad visual verification has not yet been completed.
