### PR TITLE
Polish UI controls and prepare signed Windows Store candidates

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,6 +10,11 @@ on:
         description: Package version (leave blank for a CI build)
         required: false
         type: string
+      store_candidate:
+        description: Build a Chonkers LLC Microsoft Store EXE candidate (requires a stable version and release signing)
+        required: false
+        default: false
+        type: boolean
       require_signing:
         description: Require valid Authenticode signatures for release artifacts
         required: false
@@ -28,6 +33,11 @@ on:
         description: Exact source commit selected by the release workflow
         required: false
         type: string
+      store_candidate:
+        description: Build a Chonkers LLC Microsoft Store EXE candidate (requires a stable version and release signing)
+        required: false
+        default: false
+        type: boolean
       require_signing:
         description: Require valid Authenticode signatures for release artifacts
         required: false
@@ -46,12 +56,12 @@ permissions:
 
 concurrency:
   # A routine main build must not cancel a production-signed candidate.
-  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_run_id || 'build' }}-${{ inputs.require_signing && 'signed' || 'unsigned' }}
+  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_run_id || 'build' }}-${{ (inputs.require_signing || inputs.store_candidate) && 'signed' || 'unsigned' }}-${{ inputs.store_candidate && 'store' || 'direct' }}
   cancel-in-progress: true
 
 jobs:
   native-recheck:
-    if: github.event_name == 'workflow_dispatch' && inputs.build_run_id != ''
+    if: github.event_name == 'workflow_dispatch' && inputs.build_run_id != '' && !inputs.store_candidate
     permissions:
       contents: read
       actions: read
@@ -60,7 +70,7 @@ jobs:
       build_run_id: ${{ inputs.build_run_id }}
 
   installer-check:
-    if: github.event_name != 'workflow_dispatch' || !inputs.build_run_id
+    if: github.event_name != 'workflow_dispatch' || !inputs.build_run_id || inputs.store_candidate
     runs-on: windows-2022
     timeout-minutes: 10
     steps:
@@ -136,6 +146,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_updater.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_windows_store_packaging.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_webview2_runtime.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -156,7 +168,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   package:
-    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || !inputs.build_run_id)
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || !inputs.build_run_id || inputs.store_candidate)
     needs: installer-check
     runs-on: windows-2022
     timeout-minutes: 90
@@ -164,28 +176,42 @@ jobs:
       contents: read
       id-token: write
     # windows-release permits only main and v* tags; windows-ci has no Azure trust.
-    environment: ${{ inputs.require_signing && 'windows-release' || 'windows-ci' }}
+    environment: ${{ (inputs.require_signing || inputs.store_candidate) && 'windows-release' || 'windows-ci' }}
     env:
       UV_CACHE_DIR: ${{ github.workspace }}\.build\uv-cache
-      AZURE_SIGNING_ENDPOINT: ${{ inputs.require_signing && vars.AZURE_SIGNING_ENDPOINT || '' }}
-      AZURE_SIGNING_ACCOUNT: ${{ inputs.require_signing && vars.AZURE_SIGNING_ACCOUNT || '' }}
-      AZURE_SIGNING_PROFILE: ${{ inputs.require_signing && vars.AZURE_SIGNING_PROFILE || '' }}
-      AZURE_TENANT_ID: ${{ inputs.require_signing && vars.AZURE_TENANT_ID || '' }}
-      AZURE_CLIENT_ID: ${{ inputs.require_signing && vars.AZURE_CLIENT_ID || '' }}
+      PACKAGE_OUTPUT: ${{ inputs.store_candidate && 'dist/store-candidate' || 'dist' }}
+      AZURE_SIGNING_ENDPOINT: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_ENDPOINT || '' }}
+      AZURE_SIGNING_ACCOUNT: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_ACCOUNT || '' }}
+      AZURE_SIGNING_PROFILE: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_PROFILE || '' }}
+      AZURE_TENANT_ID: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_TENANT_ID || '' }}
+      AZURE_CLIENT_ID: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_CLIENT_ID || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_ref || github.sha }}
 
+      - name: Validate Store candidate selection
+        if: inputs.store_candidate
+        shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          RECHECK_RUN: ${{ inputs.build_run_id }}
+        run: |
+          if ($env:PACKAGE_VERSION -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') { throw "Store candidates require an explicit stable version." }
+          if ($env:RECHECK_RUN) { throw "Store candidate builds cannot be combined with native recheck mode." }
+          if ($env:GITHUB_REF -ne 'refs/heads/main' -and $env:GITHUB_REF -notmatch '^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$') {
+            throw "Store candidates must build from main or a release version tag."
+          }
+
       - name: Install pinned Azure signing dependencies
-        if: inputs.require_signing && vars.AZURE_SIGNING_ENDPOINT != ''
+        if: (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_ENDPOINT != ''
         shell: pwsh
         run: ./scripts/windows/install-signing-tools.ps1
 
       - name: Validate Windows signing configuration
         shell: pwsh
         env:
-          REQUIRE_SIGNING: ${{ inputs.require_signing && 'true' || 'false' }}
+          REQUIRE_SIGNING: ${{ (inputs.require_signing || inputs.store_candidate) && 'true' || 'false' }}
           WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
@@ -195,6 +221,11 @@ jobs:
             throw "Windows release updates require SPARKLE_PRIVATE_KEY."
           }
           if ($env:REQUIRE_SIGNING -eq 'true') { ./scripts/windows/signing-smoke.ps1 }
+
+      - name: Stage the pinned offline WebView2 prerequisite
+        if: inputs.store_candidate
+        shell: pwsh
+        run: ./scripts/windows/stage-store-webview2.ps1 -OutputDirectory ./.build/store-inputs
 
       - name: Restore build caches
         uses: actions/cache@v4
@@ -223,8 +254,9 @@ jobs:
         id: build-package
         shell: pwsh
         env:
+          STORE_CANDIDATE: ${{ inputs.store_candidate && 'true' || 'false' }}
           PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
-          REQUIRE_SIGNING: ${{ inputs.require_signing && 'true' || 'false' }}
+          REQUIRE_SIGNING: ${{ (inputs.require_signing || inputs.store_candidate) && 'true' || 'false' }}
           WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
@@ -241,17 +273,35 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_updater.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_windows_store_packaging.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_webview2_runtime.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          ./scripts/windows/build-release.ps1 -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
+          $StoreOptions = @{}
+          if ($env:STORE_CANDIDATE -eq 'true') {
+            $InputRecord = Get-Content ./packaging/webview2-store-input.json -Raw | ConvertFrom-Json
+            $StoreOptions = @{
+              StoreCandidate = $true
+              OfflineWebView2Installer = (Join-Path ./.build/store-inputs $InputRecord.filename)
+              OfflineWebView2Sha256 = $InputRecord.sha256
+            }
+          }
+          ./scripts/windows/build-release.ps1 @StoreOptions -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
 
       - name: Verify signatures in the completed artifacts
-        if: inputs.require_signing
+        if: inputs.require_signing || inputs.store_candidate
         shell: pwsh
         run: |
-          $Archive = Get-ChildItem ./dist/LightTable-*-windows-x64.zip | Select-Object -First 1
-          $Installer = Get-ChildItem ./dist/LightTable-*-windows-x64-setup.exe | Select-Object -First 1
-          ./scripts/windows/verify-release-signatures.ps1 -Archive $Archive.FullName -Installer $Installer.FullName -Report ./dist/windows-signatures.json
+          $Archive = Get-ChildItem "$env:PACKAGE_OUTPUT/LightTable-*-windows-x64.zip" | Select-Object -First 1
+          $Installer = Get-ChildItem "$env:PACKAGE_OUTPUT/LightTable-*-windows-x64-setup.exe" | Select-Object -First 1
+          ./scripts/windows/verify-release-signatures.ps1 -Archive $Archive.FullName -Installer $Installer.FullName -Report "$env:PACKAGE_OUTPUT/windows-signatures.json"
+
+      - name: Record Store candidate checksums and build inputs
+        if: inputs.store_candidate
+        shell: pwsh
+        run: |
+          python ./scripts/windows/write-store-receipt.py $env:PACKAGE_OUTPUT ./packaging/webview2-store-input.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload portable build and installer
         # Preserve a completed package for diagnosis/rechecks even if native
@@ -262,17 +312,19 @@ jobs:
         with:
           name: LightTable-windows-x64
           path: |
-            dist/LightTable-*-windows-x64.zip
-            dist/LightTable-*-windows-x64-setup.exe
-            dist/appcast-windows-x64.xml
-            dist/windows-signatures.json
+            ${{ env.PACKAGE_OUTPUT }}/LightTable-*-windows-x64.zip
+            ${{ env.PACKAGE_OUTPUT }}/LightTable-*-windows-x64-setup.exe
+            ${{ env.PACKAGE_OUTPUT }}/appcast-windows-x64.xml
+            ${{ env.PACKAGE_OUTPUT }}/windows-signatures.json
+            ${{ env.PACKAGE_OUTPUT }}/windows-store-pe-signatures.json
+            ${{ env.PACKAGE_OUTPUT }}/store-candidate-receipt.json
           if-no-files-found: error
 
       - name: Require native edit, export and restart
         timeout-minutes: 10
         shell: pwsh
         run: |
-          $Archive = Get-ChildItem ./dist/LightTable-*-windows-x64.zip | Select-Object -First 1
+          $Archive = Get-ChildItem "$env:PACKAGE_OUTPUT/LightTable-*-windows-x64.zip" | Select-Object -First 1
           Expand-Archive -LiteralPath $Archive.FullName -DestinationPath ./.build/native-candidate
           $Bundle = (Resolve-Path ./.build/native-candidate/LightTable).Path
           & "$Bundle/Python/python.exe" -B ./scripts/windows/desktop-smoke.py $Bundle --timeout 240 --report-dir ./.build/windows-desktop-evidence

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The photograph stays large while the library, film controls, and editor share
 one quiet workspace. Catalog originals in place, keep edits separate, and use
 ratings, flags, collections, stacks, and virtual copies to organize your work.
 Film can be switched off for conventional RAW development.
-Use **Copy…** and **Paste** below the photo in Detail view to choose adjustment
+Use **Copy Settings...** and **Paste** below the photo in Detail view to choose adjustment
 groups and transfer them to other selected photos.
 
 ### Find and curate a shoot

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -339,3 +339,68 @@ preview surface is not enabled in the Windows shell. Measure decode, GPU work,
 webview upload, and presentation separately before choosing whether a native
 DirectX viewport is needed. Apple-only AI providers and HEIF export also remain
 separate feature-porting work.
+
+## Microsoft Store EXE candidate
+
+Store preparation uses the existing per-user NSIS installer. It is an opt-in
+build mode; direct downloads keep their current defaults. It does not reserve
+a Store name, enroll a publisher, upload anything, or prove certification.
+
+On a Windows build runner with the existing release-signing prerequisites,
+provide the **x64 Evergreen Standalone Installer** from
+[Microsoft WebView2 downloads](https://developer.microsoft.com/microsoft-edge/webview2/)
+and record its SHA256 when acquiring it. Do not use the small online bootstrapper.
+The build checks that pinned hash and a trusted Microsoft signature before any
+compilation. Offline setup never falls back to downloading a prerequisite.
+
+```powershell
+./scripts/windows/build-release.ps1 -Version 0.5.0 -StoreCandidate `
+  -OfflineWebView2Installer C:\release-inputs\MicrosoftEdgeWebView2RuntimeInstallerX64.exe `
+  -OfflineWebView2Sha256 '<recorded 64-character SHA256>'
+```
+
+Use a selected stable release number in place of the example. Outputs are under
+`dist/store-candidate/`; do not overwrite an already submitted version. The
+existing Azure signing configuration runs only on approved main/version-tag
+GitHub Actions contexts. The command also requires the existing update-signing
+key. This mode does not change credentials, certificates, or Azure identity.
+
+Candidate builds:
+
+- Embed the standalone WebView2 prerequisite and invoke it silently when needed.
+- Scan the native payload by PE header, including Python `.pyd` modules. Sign
+  unsigned EXE/DLL/PYD files with the configured release signer and preserve
+  valid vendor signatures. Reject invalid signatures or unsupported unsigned PE
+  suffixes rather than silently ignoring them.
+- Sign NSIS's generated uninstaller before embedding it, then audit every PE in
+  the installed payload. `windows-store-pe-signatures.json` records each path,
+  SHA256, signature status, and publisher. A failure blocks the candidate.
+- Set candidate installer CompanyName and installed-app publisher metadata to
+  `Chonkers LLC`. Direct-release metadata remains unchanged. Metadata does not
+  change the certificate's legal identity: review the actual signing identity
+  with the Chonkers LLC Partner Center account before submission.
+
+Partner Center installation arguments: `/S` (case-sensitive). Silent uninstall
+uses `/S`. The installer is per-user and currently leaves its own update service
+in control, as with other EXE installations; it is not an MSIX package.
+
+### Evidence still required before initial submission
+
+The existing successful Windows release run predates this candidate mode. Run
+it on Windows and retain the installed-payload signature report, installer
+hash, build manifest, native startup/edit/export/restart evidence, and install,
+repair, uninstall results. Separately exercise installation on clean Windows
+10/11 x64 with WebView2 absent and network disabled, then launch and export.
+An ordinary CI image with WebView2 already present cannot prove this case.
+Check that `/S` shows no setup UI and no app is launched by setup. Confirm all
+supported OS/device claims and that uninstall preserves photos and catalogs.
+
+Host the final signed EXE at a permanent **versioned HTTPS URL** only after
+release approval. Record its SHA256 and never replace bytes at that URL.
+Complete publisher verification, name reservation, Store listing assets,
+privacy/support links, age rating, and certification notes in Partner Center.
+No Store release is prepared merely because the four original application
+signatures or the standard Windows workflow passed.
+
+Sources: [Store EXE package requirements](https://learn.microsoft.com/windows/apps/publish/publish-your-app/msi/app-package-requirements)
+and [Microsoft's offline WebView2 deployment](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution#offline-deployment).

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -404,3 +404,38 @@ signatures or the standard Windows workflow passed.
 
 Sources: [Store EXE package requirements](https://learn.microsoft.com/windows/apps/publish/publish-your-app/msi/app-package-requirements)
 and [Microsoft's offline WebView2 deployment](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution#offline-deployment).
+
+### Dispatch the initial candidate after the preparation branch is merged
+
+The checked-in `packaging/webview2-store-input.json` pins the acquired Microsoft
+x64 standalone download (258,614,480 bytes; SHA256
+`e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831`).
+The workflow downloads only that Microsoft CDN URL without redirects and checks
+its byte length, SHA256, and trusted Microsoft signature on Windows. If the CDN
+no longer serves those exact bytes, acquire and review a new input explicitly;
+never replace the checksum automatically.
+
+```sh
+gh workflow run windows-build.yml --repo reville/lighttable-digital-darkroom \
+  --ref main -f version=0.5.0 -F store_candidate=true -F require_signing=true
+```
+
+This command is an instruction for a future authorized run, not evidence that a
+run occurred. Store mode implies required signing even when the separate signing
+input is false, uses the existing `windows-release` environment, accepts only
+main/version-tag dispatches, and cannot be combined with native-recheck mode.
+The direct-download workflow defaults and artifact name remain unchanged.
+
+The `LightTable-windows-x64` workflow artifact contains the candidate ZIP and
+EXE, signature reports, signed appcast, and `store-candidate-receipt.json`.
+The receipt cross-checks the source commit, final installer hash, archive hash,
+prerequisite hash, and installed PE report including the uninstaller. Native
+edit/export/restart still gates the job and uploads separate
+`Windows-native-acceptance` evidence. The receipt explicitly leaves clean-machine
+offline acceptance unconfirmed until that independent Windows test is done.
+
+For the selected initial release `0.5.0`, the proposed public EXE URL is
+`https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-windows-x64-setup.exe`.
+This is a proposed location, not a live download. Publish only the exact verified
+candidate bytes after all release and Store gates pass; do not replace bytes at
+that URL after submission.

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -3,7 +3,7 @@
     "about-lighttable": {
       "content": "f176c760d71f2141d024f089715f371828dcb3916a9a86bdfbea36dbae67ce87",
       "sources": {
-        "README.md": "4a409a5cb4610dc9e7dbeef949febd65e3356f6a394ee6143248e95160cfc3e8",
+        "README.md": "18a1f419f3473504c3a2c0492a7dda8aebf603d38c9b66c599fc9b337d53183b",
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628"
       }
     },
@@ -12,7 +12,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/first-run.js": "d3e3cc68759c3c7634b44c9edf562b2ae163120ae6255c38941222fa33eeebda",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
@@ -21,10 +21,10 @@
       "sources": {
         "film_lab_ai/culling.py": "08cb4e9ebda9ca5285422eab7c0be5938dd0a63c7bfefa3a22218ea3ed93773b",
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/cull-batch.js": "f22524c715dcccbf0f0870cc464d5f45f328bcb20bb2e6793285dbe7a7ba9b87",
         "web/cull-similarity.js": "55d00a5f2a99b89f0ce1b140271af396872cbc9510e37404474be4b6ad4b6d13",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786"
       }
     },
@@ -32,16 +32,16 @@
       "content": "83110cc81ab7af3bec5273ae311e070f452a2972b13822f1164cfde7699d13ac",
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "capture-time": {
       "content": "ff0cc83fb27f3147353a662717ee91ca10017e8e663c4877e3a05dd017f44683",
       "sources": {
         "web/capture-time.js": "c8d62263728ab5a6a867392bc8b1a2bbe6a0a057cf903b8aeefa992f2b275487",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "xmp_sidecar.py": "7222b2987fb7f7e002e5be54fc32a6a63cdfb6abca586a9540c6764c040966af"
       }
     },
@@ -55,7 +55,7 @@
         "file_identity.py": "8810c0d7818352baaa5db681f6c5a895514d94a93fea47e4bb3e1e4b9bd6f8ce",
         "platform_paths.py": "ecb078415022d6886d6e2810cf4effa1529ada485ae145d42ecc0f5967971711",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/recovery.js": "fa5646aae6fdc5bc95dd317f08c9c3f78985a1c36d89785152d9cc55df1f0921",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72"
       }
@@ -63,14 +63,14 @@
     "collections": {
       "content": "95bc3775974e6454f3d55661cf2db268196f4d73750fb1ba7f796bb23379cd36",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -78,14 +78,14 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "9cfba81ef549fe43a8d1e2dc1ed7c7cc660202b4f2a640506af71f8e59fb0d7e",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-copy-paste-match-exposure": {
@@ -93,23 +93,23 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-crop-geometry": {
       "content": "8540d6a3489f09244e5bb0f7b885bcf5bfd981b965c71dd1f3e2f317223462bc",
       "sources": {
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-curves": {
       "content": "a2280ce4abd9f79d1c1e6d0673c3d2ef6015fb01a14e4385e3c8621bd6b13a54",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-detail-effects-enhance": {
@@ -117,49 +117,49 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "enhance_workflow.py": "b2b3fe529770388b3c4bf04345bf995a6d9a70ef866a5e917313f8b3de72506a",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/enhance-panel.js": "6efc59ea9686bf72062453c76d61a9a09ad86511b4d9737e8ba95409fd95daa7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-effects": {
       "content": "e65c38833c6557b83b0e471394ed3d4fda54c7e44a5a7f4cba7a7e25fd04df71",
       "sources": {
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-history-snapshots": {
       "content": "86dc3f8196fa62cc452db8d0cf86e40f2fe2450a1c8166cfe812177272853273",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/history-panel.js": "5f7a77338be697479c921dc76a9668e7846c50e75cab47bfd634dfe924faec25",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-masks-ai": {
       "content": "b93d29b8af3e46c1f77976f9fec3732bb152c6b506e7bfe1f681d8b6381d4644",
       "sources": {
         "semantic_masks.py": "d48eb799d0c3188d4dc48a573d193eec94fc087b4eb9fba9560ed41b8de585f7",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-masks-brush-gradients": {
       "content": "9e545e5ed89a7b168be2b0a8eabfea5cec8e882c010910a4615ae425f61bbd5b",
       "sources": {
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/editor-panels.js": "cbb1e16f590167c8f948629f3a851866a94e641daf0bc9af9694cb893d937446",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/mask-curve.js": "4db1ce1aa1d7c959762be56651cc5f7076bd363540309aef6aba3ba5a1bcf281",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254",
         "web/mask-shape.js": "890bfb7652c2424bb4444c1c51495887bb2d1605495a11a71d7205985fa0de65",
@@ -169,8 +169,8 @@
     "editing-masks-ranges-refinements": {
       "content": "69559a947ccd17ddcf891ab7791585d708eaa3b452ac32e1fe6fee456fe90167",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254"
       }
     },
@@ -180,8 +180,8 @@
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-presets": {
@@ -192,8 +192,8 @@
         "preset_library.py": "fb8d27cde136b026d25fe512a281a0d8f6d80a97b9bcbdca667e229162c26358",
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
         "web/preset-browser.css": "607baaf24f673069d59e069381edb5fe64b138f4a9769addbc7d53c51e334768",
         "web/preset-browser.js": "9c2c3b0f606d505616bab7903e5857f1b8cef1dc9bffe9baab908ac238741833",
@@ -204,125 +204,125 @@
       "content": "3d70eb73feed29823cf507dacaaefa5e836efbeda3815657693341cdb79c297d",
       "sources": {
         "app/NativePreview.metal": "45aa8ae595982903f61554d60f6da370d0e77e905fad335f7ba9e250f0daaa02",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
     },
     "editing-save-recovery": {
       "content": "5ea77476828b252a78757b30d827464a516994d3c1cf84a3a6041bec601e2b2d",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/edit-save-queue.js": "0d56b96358f6de5ade38c3dd554260f876a746145a89476c0a68e3c16620a574"
       }
     },
     "editing-tone": {
       "content": "2e83d0be17ae55ef2edbd5cb335d18e9d96de22d032056f3dc9027bbe48fc35d",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "editing-white-balance": {
       "content": "f6b3b37c291e9d60356355f3668f15990e40995bedc9062c9a67a3da9425e271",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "export-filenames-and-folders": {
       "content": "007309327e1d2aa65e1c38fea9ce0347ee5b343c9a12b881419000c5ccd44999",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "export-format-color-space": {
       "content": "5945724f1f5a9ad80dabdbb9b1943978a77aa5a373366307f8acc38aabd165f0",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "export-metadata-sidecars": {
       "content": "ff38b09d22440c0f8c975dc0e18bbb848413afd9ff205ab956f89d3335f3ce9d",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "export-photos": {
       "content": "dbb37c4fdeb501f59294843e33d6aea92727bd952e76e11978a4a14af5535086",
       "sources": {
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "external-editor": {
       "content": "905a7f2d9fc297adb88b6aa0c2f0f5bf7b21513ca1db891c3b7a3bf137aac2de",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "film-getting-started": {
       "content": "2ea19e843ce9c9a59afd0e8d2e0a3dd7927a6e7a413dc92a9b64c23f328516b6",
       "sources": {
         "film_tuning.py": "133a5e3200b69b2aa3b92f8bb471c93af449b5036bb8dfdd6610292175693860",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
+        "web/style.css": "141d21b6ef3746b2ea45053f8eb6d94ae682e95c3c71ce760f91a03b25baca8f"
       }
     },
     "film-grain-and-format": {
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "film-halation-diffusion-scan": {
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "film-negative-paper-and-slides": {
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "flags-and-ratings": {
       "content": "024887b0aec3ba1497cd788acb58f45a60e2b5abfaa0a458fea2428083904d05",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -333,7 +333,7 @@
         "ingest_workflow.py": "bd0365f4184536485ef7e7ebc1506df5e302e2859bfa3678bde76dba5ad48518",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "import-lightroom-catalog": {
@@ -342,15 +342,15 @@
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "keyboard-midi": {
       "content": "afa81f9e0bf349d0df5d83bf5a2b09497fd62c2c0ecc69fa629d2fa04382fdf0",
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/midi.js": "a74a05ad2303790b15efaf9953afcf60f20ccfabf4d4f8bde7ae2eb99c834175"
       }
     },
@@ -359,7 +359,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "keyword_workflow.py": "5c545bd45205bf294d15cddbaf43f27a39ad5c30b69e7f98fab579d2b61a73a4",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/keyword-batch.js": "e38195a5528e40635522473776ba9b0a2052f11a78ac77fb7cfe81fa3cc8a88e",
         "web/metadata-panel.js": "d6be67c2b0b58d543fabee1349bab40bbe40afffb5fe2ecd4414d7c996f69cda"
       }
@@ -385,14 +385,14 @@
         "media_availability.py": "c450d7734d3e39f2c9bb6c5e39c855374ee4e03d6947c299315f558072aca25e",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/preview-detail.js": "8601034c83de06c042fdd5528d7fde5ff69db567bdac7225f3b133b739836acc",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d",
+        "web/style.css": "141d21b6ef3746b2ea45053f8eb6d94ae682e95c3c71ce760f91a03b25baca8f",
         "web/thumbnail-errors.js": "0009004ecc17943d34546c797234770a498ae9671b92c94eb309de1af58ef78e",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
@@ -403,17 +403,17 @@
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
         "film_lab_ai/service.py": "fd684477d966d1014c1b72cb843871379db98b41fb800ec9f98a8d75c1eea842",
         "media_availability.py": "c450d7734d3e39f2c9bb6c5e39c855374ee4e03d6947c299315f558072aca25e",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d"
+        "web/style.css": "141d21b6ef3746b2ea45053f8eb6d94ae682e95c3c71ce760f91a03b25baca8f"
       }
     },
     "raw-jpeg-pairs": {
       "content": "63ef5d08a8d6515e2677eb9344c41edafd7d2b2266703648040f4080033691b2",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -430,8 +430,8 @@
       "sources": {
         "catalog_scan.py": "694ded2af507f35ef95dcb358632fc0d8b3b8deb63d77029617b9e94b2abde18",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/library-filters.js": "1d05785c353a9d6d1324fba2961d4c3bb0e3c7f794bb4bdc35bf968c236e972d",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8",
         "web/photo-display-status.js": "33a66b26b9c7a8f9fed4c2151cf7c069b6c02adf89f094ce1885d557db458956"
@@ -445,7 +445,7 @@
         "server_updates.py": "e3b348cc4412d656a51e8410b07ec78d0ddf404eb6a5e506468d233d1cf17b6d",
         "web/desktop-theme.js": "29f65082cfffad6e59023c6dacc22f0af95b4226955df79c8afcb936219ecc3f",
         "web/desktop-updates.js": "b5da55533a5dbfc8d9652361ca4a6a4b31b388510214971619d03f81ff7588f9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/linux-layout.css": "885ae0e7ad37cd2af4feb2d94739c405a498dcd62ee95bf38cf5ff7d39a57ae5",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154",
@@ -457,7 +457,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/i18n.js": "48ec7b56c856a8db9bcd47315a6c697582a0207a1656d42ed43260c3627b7388",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/locale-bootstrap.js": "06fc13de85d1b216f01742ae5667c03b18a4fd413913281bb87aa7866b287845",
         "web/locales/manifest.json": "50952ea4e6e3b6028aeda3f9d36310905ecbe82e4825577b6912c0836a4e4c9c",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72"
@@ -466,8 +466,8 @@
     "shortcut-schemes": {
       "content": "e6cf59f5fde950bf351b74084189c3d6fb585b9ef8f86c78a01c82db94da584d",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -475,7 +475,7 @@
       "content": "9b7e47fe1ac1a2ae85a54070f12b51d8876a2d4497b5f3dc3c0857cca2e1da6b",
       "sources": {
         "catalog.py": "e1cb4c80f7ba1265ac02c48656b365c48109fa3f4560d7dd5647e4bd29b008e2",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
       }
     },
@@ -483,14 +483,14 @@
       "content": "667d42680ff9d3d60918660cb348f4d0add54a7577d29d9db4a20a48495425f0",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e"
       }
     },
     "survey-photos": {
       "content": "1769c5e6c33849b62cd8407e16ceb7ae8f211b4a61d15f73fb7ca1a7933a3c15",
       "sources": {
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/survey.js": "79fd7a71ef314f25e5a6452f9def6d5edeac62799fd1305631f1607724363cc3"
       }
     },
@@ -499,7 +499,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
@@ -507,11 +507,11 @@
       "content": "b29d13cf48372d452f1b70d9f45883e7d3ad32ed7a23f1dd2754744d62382641",
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "b2c48b2863abe8d0d1a208b357c48e43da6bb2cdfabc55dfdceb99008db3995e",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d",
+        "web/style.css": "141d21b6ef3746b2ea45053f8eb6d94ae682e95c3c71ce760f91a03b25baca8f",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },
@@ -519,7 +519,7 @@
       "content": "de9620831ddcd8ecee7ce1f29fa1442122cfe5fa8183c0650ee8b3b34210d498",
       "sources": {
         "library_workflow.py": "b07bc79b58666fe92ce189ac4132a6904457e166f73c155f3f636fc683966e3c",
-        "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9"
+        "web/app.js": "4f5d08a1be4945992537709f6bf03befb9b0cc5a1b623887bcadf17708e32380"
       }
     },
     "xmp-interchange": {

--- a/docs/localization/source.json
+++ b/docs/localization/source.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "pluralsDigest": "48cbd3ff74f519cc3776cc3d829ff2c99c4f684f8c4a8c0631d2c20d1c50b6b6",
   "pluralPairs": [
     {
@@ -755,7 +755,6 @@
     "Choose a person",
     "Choose a photo folder",
     "Choose a photo to edit",
-    "Choose a photo to rate or flag",
     "Choose a preset to see its source and conversion coverage.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.",
@@ -1001,6 +1000,7 @@
     "Copies every readable row into a fresh file. Readable now: {value}. Keeps edits made after the last backup; rows on damaged pages are lost.",
     "Copy",
     "Copy Edit Settings",
+    "Copy Settings...",
     "Copy and Paste are below the photo in Detail view.",
     "Copy and Paste transfer the groups you explicitly select. Settings in unchecked groups stay as they are on each destination. This is an explicit copy/paste workflow: later edits to the source do not automatically synchronize to the destinations.",
     "Copy and verify it into the library",
@@ -2809,7 +2809,6 @@
     "Select a photo to copy its settings",
     "Select a photo to edit",
     "Select a photo to preview",
-    "Select a photo to rate or flag",
     "Select a photo, or a set in a grid, and open Info.",
     "Select a photo.",
     "Select a range of distances from the camera; refine the far and near limits",

--- a/docs/localization/web-dynamic-source.json
+++ b/docs/localization/web-dynamic-source.json
@@ -848,7 +848,6 @@
   "Select a photo to copy its settings",
   "Select a photo to edit",
   "Select a photo to preview",
-  "Select a photo to rate or flag",
   "Select a photo.",
   "Select an active reference photo first",
   "Select at least two distinct originals",

--- a/packaging/webview2-store-input.json
+++ b/packaging/webview2-store-input.json
@@ -1,0 +1,10 @@
+{
+  "filename": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+  "bytes": 258614480,
+  "sha256": "e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831",
+  "acquired_at": "2026-09-09",
+  "source_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/a8f5ad97-0b01-41e5-9245-e8fc9ba9b311/MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+  "microsoft_redirect": "https://go.microsoft.com/fwlink/?LinkId=2124701",
+  "authenticode_verified_on_windows": false,
+  "status": "Downloaded from Microsoft; checksum recorded and PE header checked. Trusted signature and actual offline behavior still require Windows validation."
+}

--- a/scripts/windows/build-release.ps1
+++ b/scripts/windows/build-release.ps1
@@ -4,11 +4,40 @@ param(
     [string]$OutputDirectory = "dist",
     [switch]$PortableOnly,
     [switch]$RuntimeSmokeOnly,
-    [switch]$RequireSigning
+    [switch]$RequireSigning,
+    [switch]$StoreCandidate,
+    [string]$OfflineWebView2Installer = "",
+    [string]$OfflineWebView2Sha256 = ""
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# A Store candidate embeds its prerequisite and signs the entire native payload.
+# Certification still requires a clean offline Windows acceptance run.
+if ($StoreCandidate) {
+    if ($PortableOnly -or $RuntimeSmokeOnly) { throw "StoreCandidate requires an installer build." }
+    if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') { throw "StoreCandidate requires a stable numeric version." }
+    $RequireSigning = $true
+    if ([string]::IsNullOrWhiteSpace($OfflineWebView2Installer)) {
+        throw "StoreCandidate requires the x64 WebView2 Evergreen Standalone Installer."
+    }
+}
+if ($OfflineWebView2Installer -or $OfflineWebView2Sha256) {
+    if ($OfflineWebView2Sha256 -notmatch '^[a-fA-F0-9]{64}$' -or
+        -not (Test-Path -LiteralPath $OfflineWebView2Installer -PathType Leaf)) {
+        throw "Supply an existing offline WebView2 installer and its pinned SHA256."
+    }
+    $OfflineWebView2Installer = (Resolve-Path -LiteralPath $OfflineWebView2Installer).Path
+    if ((Get-FileHash -LiteralPath $OfflineWebView2Installer -Algorithm SHA256).Hash -ne $OfflineWebView2Sha256) {
+        throw "Offline WebView2 installer SHA256 mismatch."
+    }
+    $WebViewSignature = Get-AuthenticodeSignature -LiteralPath $OfflineWebView2Installer
+    if ($WebViewSignature.Status -ne 'Valid' -or $null -eq $WebViewSignature.SignerCertificate -or
+        $WebViewSignature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)') {
+        throw "The offline WebView2 installer must have a valid Microsoft signature."
+    }
+}
 
 # Public releases must fail before downloads or compilation when signing is
 # unavailable. CI builds can run without a certificate unless explicitly gated.
@@ -36,6 +65,7 @@ $Output = if ([IO.Path]::IsPathRooted($OutputDirectory)) {
 } else {
     Join-Path $Project $OutputDirectory
 }
+if ($StoreCandidate) { $Output = Join-Path $Output "store-candidate" }
 $BuildRoot = Join-Path ([IO.Path]::GetTempPath()) ("lighttable-windows-" + [Guid]::NewGuid())
 $Payload = Join-Path $BuildRoot "LightTable"
 $Resources = Join-Path $Payload "Resources\LightTable"
@@ -206,6 +236,9 @@ try {
         (Join-Path $Project "windows-shell\target\$Target\release\lighttable-desktop-shell.exe") `
         (Join-Path $Payload "LightTable.exe")
 
+    if ($StoreCandidate) {
+        & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $Payload -SignMissing
+    }
     if ($SigningEnabled) {
         & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files @(
             (Join-Path $Payload "LightTable.exe"),
@@ -233,6 +266,8 @@ try {
         python_version = $PythonVersion
         vc_runtime_version = $VCRuntimeVersion
         authenticode_signed = [bool]$SigningEnabled
+        store_candidate = [bool]$StoreCandidate
+        webview2_offline_sha256 = $OfflineWebView2Sha256.ToLowerInvariant()
     } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $Payload "build-manifest.json") -Encoding utf8
 
     if (-not $PortableOnly) {
@@ -240,7 +275,17 @@ try {
         $UninstallManifest = Join-Path $BuildRoot "uninstall-files.nsh"
         & $PythonExe -B (Join-Path $Project "scripts\windows\make-uninstall-manifest.py") $Payload $UninstallManifest
         if ($LASTEXITCODE -ne 0) { throw "Could not generate the safe uninstall file list" }
-        & $MakeNsis.Source `
+        $InstallerOptions = @()
+        if ($OfflineWebView2Installer) {
+            $InstallerOptions += "/DOFFLINE_WEBVIEW2_INSTALLER=$OfflineWebView2Installer"
+        }
+        if ($StoreCandidate) {
+            $InstallerOptions += "/DSIGN_UNINSTALLER_SCRIPT=$(Join-Path $PSScriptRoot 'sign-uninstaller.ps1')"
+            $InstallerOptions += "/DPUBLISHER=Chonkers LLC"
+            $InstallerOptions += "/DSTORE_NUMERIC_VERSION=$Version.0"
+            $InstallerOptions += "/DSIGNING_POWERSHELL=$((Get-Process -Id $PID).Path)"
+        }
+        & $MakeNsis.Source @InstallerOptions `
             "/WX" `
             "/DVERSION=$Version" `
             "/DPAYLOAD=$Payload" `
@@ -251,7 +296,8 @@ try {
         if ($SigningEnabled) {
             & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files $Installer
         }
-        & (Join-Path $Project "scripts\windows\installer-smoke.ps1") -Installer $Installer -Version $Version
+        & (Join-Path $Project "scripts\windows\installer-smoke.ps1") -Installer $Installer -Version $Version `
+            -VerifyStoreSignatures:$StoreCandidate -ExpectedPublisher $(if ($StoreCandidate) { "Chonkers LLC" } else { "Nicholas Reville" }) -SignatureReport (Join-Path $Output "windows-store-pe-signatures.json")
         if ($RequireSigning) {
             # WinSparkle accepts both the current Sparkle 32-byte seed and its
             # older 96-byte private-key format. No key material is logged or

--- a/scripts/windows/ensure-webview2.ps1
+++ b/scripts/windows/ensure-webview2.ps1
@@ -1,4 +1,4 @@
-param([switch]$CheckOnly)
+param([switch]$CheckOnly, [string]$OfflineInstaller = "")
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
@@ -35,7 +35,7 @@ function Test-WebView2Runtime {
     return $false
 }
 
-function Install-WebView2Runtime {
+function Install-WebView2Runtime([string]$OfflineInstaller = "") {
     if (Test-WebView2Runtime) {
         Write-Host "Microsoft Edge WebView2 Runtime is already installed."
         return
@@ -46,9 +46,17 @@ function Install-WebView2Runtime {
     New-Item -ItemType Directory -Path $Temporary | Out-Null
     try {
         Write-Host "Installing Microsoft Edge WebView2 Runtime..."
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-        Invoke-WebRequest -UseBasicParsing -TimeoutSec 120 `
-            -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $Bootstrapper
+        if (-not [string]::IsNullOrWhiteSpace($OfflineInstaller)) {
+            # An explicit offline package must never fall back to the network.
+            if (-not (Test-Path -LiteralPath $OfflineInstaller -PathType Leaf)) {
+                throw "The bundled offline WebView2 installer is missing."
+            }
+            Copy-Item -LiteralPath $OfflineInstaller -Destination $Bootstrapper
+        } else {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+            Invoke-WebRequest -UseBasicParsing -TimeoutSec 120 `
+                -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $Bootstrapper
+        }
         $Signature = Get-AuthenticodeSignature -LiteralPath $Bootstrapper
         if ($Signature.Status -ne 'Valid' -or $null -eq $Signature.SignerCertificate -or
             $Signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)') {
@@ -85,7 +93,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             if (Test-WebView2Runtime) { exit 0 }
             exit 1
         }
-        Install-WebView2Runtime
+        Install-WebView2Runtime -OfflineInstaller $OfflineInstaller
     } catch {
         [Console]::Error.WriteLine("$($_.Exception.Message) Install Microsoft Edge WebView2 Runtime from https://developer.microsoft.com/microsoft-edge/webview2 and run LightTable setup again.")
         exit 1

--- a/scripts/windows/installer-smoke.ps1
+++ b/scripts/windows/installer-smoke.ps1
@@ -2,7 +2,10 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$Installer,
     [Parameter(Mandatory = $true)]
-    [string]$Version
+    [string]$Version,
+    [switch]$VerifyStoreSignatures,
+    [string]$SignatureReport = "",
+    [string]$ExpectedPublisher = "Nicholas Reville"
 )
 
 $ErrorActionPreference = "Stop"
@@ -20,9 +23,10 @@ function Get-RawUserPath {
 
 function Invoke-InstallerProcess([string]$Executable, [string]$Arguments) {
     $Process = Start-Process -FilePath $Executable -ArgumentList $Arguments -PassThru
-    if (-not $Process.WaitForExit(120000)) {
+    $Timeout = if ($VerifyStoreSignatures) { 600000 } else { 120000 }
+    if (-not $Process.WaitForExit($Timeout)) {
         $Process.Kill()
-        throw "Installer process exceeded the two-minute smoke-test limit"
+        throw "Installer process exceeded the bounded smoke-test limit"
     }
     if ($Process.ExitCode -ne 0) { throw "Installer process exited with $($Process.ExitCode)" }
 }
@@ -56,8 +60,11 @@ try {
     if (-not (Test-Path (Join-Path $InstallPath "WinSparkle.dll"))) {
         throw "The Windows update component was not installed"
     }
+    if ($VerifyStoreSignatures) {
+        & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $InstallPath -Report $SignatureReport
+    }
     $Installed = Get-ItemProperty $RegistryPath
-    if ($Installed.DisplayVersion -ne $Version -or $Installed.Publisher -ne "Nicholas Reville") {
+    if ($Installed.DisplayVersion -ne $Version -or $Installed.Publisher -ne $ExpectedPublisher) {
         throw "Installed package identity does not match the release"
     }
     if ($Installed.InstallLocation -ne $InstallPath -or $Installed.QuietUninstallString -notmatch ' /S$') {

--- a/scripts/windows/installer.nsi
+++ b/scripts/windows/installer.nsi
@@ -11,6 +11,10 @@
   !error "UNINSTALL_MANIFEST is required"
 !endif
 
+!ifndef PUBLISHER
+  !define PUBLISHER "Nicholas Reville"
+!endif
+
 !include "LogicLib.nsh"
 !include "FileFunc.nsh"
 !include "WinMessages.nsh"
@@ -21,11 +25,23 @@
 
 Unicode True
 Name "LightTable"
+!ifdef STORE_NUMERIC_VERSION
+VIProductVersion "${STORE_NUMERIC_VERSION}"
+VIAddVersionKey /LANG=1033 "ProductName" "LightTable"
+VIAddVersionKey /LANG=1033 "CompanyName" "${PUBLISHER}"
+VIAddVersionKey /LANG=1033 "FileDescription" "LightTable Setup"
+VIAddVersionKey /LANG=1033 "FileVersion" "${VERSION}"
+VIAddVersionKey /LANG=1033 "LegalCopyright" "Copyright ${PUBLISHER}"
+!endif
 OutFile "${OUTPUT}"
 InstallDir "$LOCALAPPDATA\Programs\LightTable"
 RequestExecutionLevel user
 SetCompressor /SOLID lzma
 Var UpdateOwner
+
+!ifdef SIGN_UNINSTALLER_SCRIPT
+  !uninstfinalize '"${SIGNING_POWERSHELL}" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${SIGN_UNINSTALLER_SCRIPT}" -RequireSigning -Files "%1"' = 0
+!endif
 
 Function .onInit
   ${IfNot} ${RunningX64}
@@ -71,10 +87,15 @@ Section "Install"
   File /oname=ensure-webview2.ps1 "ensure-webview2.ps1"
   DetailPrint "Checking Microsoft Edge WebView2 Runtime…"
   ClearErrors
+!ifdef OFFLINE_WEBVIEW2_INSTALLER
+  File /oname=WebView2Standalone.exe "${OFFLINE_WEBVIEW2_INSTALLER}"
+  ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "$PLUGINSDIR\ensure-webview2.ps1" -OfflineInstaller "$PLUGINSDIR\WebView2Standalone.exe"' $0
+!else
   ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "$PLUGINSDIR\ensure-webview2.ps1"' $0
+!endif
   ${If} ${Errors}
   ${OrIf} $0 != 0
-    MessageBox MB_OK|MB_ICONSTOP "Microsoft Edge WebView2 Runtime could not be installed. Connect to the internet and run setup again, or install the Runtime from https://developer.microsoft.com/microsoft-edge/webview2 first." /SD IDOK
+    MessageBox MB_OK|MB_ICONSTOP "Microsoft Edge WebView2 Runtime could not be installed. Run setup again, or install the Runtime from https://developer.microsoft.com/microsoft-edge/webview2 first." /SD IDOK
     SetErrorLevel 1
     Abort
   ${EndIf}
@@ -116,7 +137,7 @@ Section "Install"
   CreateShortcut "$SMPROGRAMS\LightTable\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "DisplayName" "LightTable"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "DisplayVersion" "${VERSION}"
-  WriteRegStr HKCU "${UNINSTALL_KEY}" "Publisher" "Nicholas Reville"
+  WriteRegStr HKCU "${UNINSTALL_KEY}" "Publisher" "${PUBLISHER}"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "URLInfoAbout" "https://github.com/reville/lighttable-digital-darkroom"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "InstallLocation" "$INSTDIR"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "DisplayIcon" "$INSTDIR\LightTable.exe"

--- a/scripts/windows/sign-azure.ps1
+++ b/scripts/windows/sign-azure.ps1
@@ -35,8 +35,8 @@ if ($CheckOnly) { return $true }
 if ($Files.Count -eq 0) { throw "At least one executable is required for Authenticode signing." }
 $Executables = @(foreach ($File in $Files) {
     $Executable = (Resolve-Path -LiteralPath $File).Path
-    if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll")) {
-        throw "The Windows release signing list must contain only executables or DLLs."
+    if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll", ".pyd")) {
+        throw "The Windows release signing list must contain only executables, DLLs, or Python native modules."
     }
     $Executable
 })

--- a/scripts/windows/sign-release.ps1
+++ b/scripts/windows/sign-release.ps1
@@ -68,8 +68,8 @@ try {
 
     foreach ($File in $Files) {
         $Executable = (Resolve-Path -LiteralPath $File).Path
-        if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll")) {
-            throw "The Windows release signing list must contain only executables or DLLs."
+        if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll", ".pyd")) {
+            throw "The Windows release signing list must contain only executables, DLLs, or Python native modules."
         }
         # Microsoft's SignTool syntax uses /fd for the file digest and /td with
         # /tr for an RFC 3161 timestamp. Pass arguments directly; never echo them.

--- a/scripts/windows/sign-uninstaller.ps1
+++ b/scripts/windows/sign-uninstaller.ps1
@@ -1,0 +1,16 @@
+param([Parameter(Mandatory)][string[]]$Files, [switch]$RequireSigning)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+if ($Files.Count -ne 1 -or -not $RequireSigning) { throw 'Exactly one uninstaller and required signing are expected.' }
+# NSIS supplies an extensionless temporary file. SignTool needs a PE filename,
+# and our release signer deliberately rejects arbitrary file types.
+$Directory = Join-Path ([IO.Path]::GetTempPath()) ('lighttable-uninstaller-sign-' + [Guid]::NewGuid())
+try {
+    New-Item -ItemType Directory -Path $Directory | Out-Null
+    $Executable = Join-Path $Directory 'Uninstall.exe'
+    Copy-Item -LiteralPath $Files[0] -Destination $Executable
+    & (Join-Path $PSScriptRoot 'sign-release.ps1') -RequireSigning -Files $Executable
+    Copy-Item -LiteralPath $Executable -Destination $Files[0] -Force
+} finally {
+    if (Test-Path -LiteralPath $Directory) { Remove-Item -LiteralPath $Directory -Recurse -Force }
+}

--- a/scripts/windows/stage-store-webview2.ps1
+++ b/scripts/windows/stage-store-webview2.ps1
@@ -1,0 +1,34 @@
+param(
+    [string]$Manifest = (Join-Path $PSScriptRoot '..\..\packaging\webview2-store-input.json'),
+    [Parameter(Mandatory)][string]$OutputDirectory
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$InputRecord = Get-Content -LiteralPath $Manifest -Raw | ConvertFrom-Json
+$Source = [Uri]$InputRecord.source_url
+if ($Source.Scheme -ne 'https' -or $Source.Host -ne 'msedge.sf.dl.delivery.mp.microsoft.com' -or
+    $Source.UserInfo -or $Source.Query -or $Source.Fragment -or
+    $InputRecord.filename -cne 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe' -or
+    $InputRecord.sha256 -notmatch '^[a-fA-F0-9]{64}$') {
+    throw 'Store WebView2 input must be the pinned Microsoft x64 standalone installer.'
+}
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+$Destination = Join-Path $OutputDirectory $InputRecord.filename
+# A failed or changed CDN download must never become a build input.
+$Temporary = Join-Path $OutputDirectory ('download-' + [Guid]::NewGuid() + '.exe')
+try {
+    Invoke-WebRequest -Uri $Source.AbsoluteUri -OutFile $Temporary -TimeoutSec 300 -MaximumRedirection 0
+    if ((Get-Item -LiteralPath $Temporary).Length -ne $InputRecord.bytes -or
+        (Get-FileHash -LiteralPath $Temporary -Algorithm SHA256).Hash -ne $InputRecord.sha256) {
+        throw 'Store WebView2 input size or SHA256 mismatch.'
+    }
+    $Signature = Get-AuthenticodeSignature -LiteralPath $Temporary
+    if ($Signature.Status -ne 'Valid' -or $null -eq $Signature.SignerCertificate -or
+        $Signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)') {
+        throw 'Store WebView2 input lacks a trusted Microsoft signature.'
+    }
+    Move-Item -LiteralPath $Temporary -Destination $Destination -Force
+    Write-Host 'Pinned x64 offline WebView2 input verified.'
+} finally {
+    if (Test-Path -LiteralPath $Temporary) { Remove-Item -LiteralPath $Temporary -Force }
+}

--- a/scripts/windows/store-pe-signatures.ps1
+++ b/scripts/windows/store-pe-signatures.ps1
@@ -24,8 +24,9 @@ function Test-PortableExecutable([string]$Path) {
 
 # Use PE headers rather than extensions: Python wheels carry native .pyd files,
 # and bundled native code can use other suffixes. Never erase a vendor signature.
-$Files = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force | Sort-Object FullName)
-$Evidence = @(foreach ($File in $Files) {
+$RelativePaths = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force -Name | Sort-Object)
+$Evidence = @(foreach ($RelativePath in $RelativePaths) {
+    $File = Get-Item -LiteralPath (Join-Path $Root $RelativePath)
     $IsPe = Test-PortableExecutable $File.FullName
     if (-not $IsPe) {
         if ($File.Extension.ToLowerInvariant() -in @('.exe', '.dll', '.pyd')) {
@@ -39,7 +40,9 @@ $Evidence = @(foreach ($File in $Files) {
         $Signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
     }
     @{
-        path = $File.FullName.Substring($Root.TrimEnd([IO.Path]::DirectorySeparatorChar).Length + 1)
+        # Enumeration supplies the relative path even when Windows expands an
+        # 8.3 temporary-directory alias in the file's absolute FullName.
+        path = $RelativePath
         sha256 = (Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
         status = [string]$Signature.Status
         publisher = if ($null -ne $Signature.SignerCertificate) { $Signature.SignerCertificate.Subject } else { $null }

--- a/scripts/windows/store-pe-signatures.ps1
+++ b/scripts/windows/store-pe-signatures.ps1
@@ -1,0 +1,60 @@
+param(
+    [Parameter(Mandatory)][string]$Payload,
+    [switch]$SignMissing,
+    [string]$Report = ""
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Root = (Resolve-Path -LiteralPath $Payload).Path
+
+function Test-PortableExecutable([string]$Path) {
+    $Stream = [IO.File]::OpenRead($Path)
+    $Reader = [IO.BinaryReader]::new($Stream)
+    try {
+        if ($Stream.Length -lt 64 -or $Reader.ReadUInt16() -ne 0x5A4D) { return $false }
+        $Stream.Position = 0x3C
+        $Offset = $Reader.ReadUInt32()
+        if ($Offset -lt 64 -or $Offset -gt $Stream.Length - 4) { return $false }
+        $Stream.Position = $Offset
+        return $Reader.ReadUInt32() -eq 0x00004550
+    } finally {
+        $Reader.Dispose()
+    }
+}
+
+# Use PE headers rather than extensions: Python wheels carry native .pyd files,
+# and bundled native code can use other suffixes. Never erase a vendor signature.
+$Files = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force | Sort-Object FullName)
+$Evidence = @(foreach ($File in $Files) {
+    $IsPe = Test-PortableExecutable $File.FullName
+    if (-not $IsPe) {
+        if ($File.Extension.ToLowerInvariant() -in @('.exe', '.dll', '.pyd')) {
+            throw "Malformed native binary in payload: $($File.FullName)"
+        }
+        continue
+    }
+    $Signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
+    if ($SignMissing -and $Signature.Status -eq 'NotSigned') {
+        & (Join-Path $PSScriptRoot 'sign-release.ps1') -RequireSigning -Files $File.FullName
+        $Signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
+    }
+    @{
+        path = $File.FullName.Substring($Root.TrimEnd([IO.Path]::DirectorySeparatorChar).Length + 1)
+        sha256 = (Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+        status = [string]$Signature.Status
+        publisher = if ($null -ne $Signature.SignerCertificate) { $Signature.SignerCertificate.Subject } else { $null }
+    }
+})
+if ($Evidence.Count -eq 0) { throw 'No Portable Executable files found in the payload.' }
+$Invalid = @($Evidence | Where-Object { $_.status -ne 'Valid' })
+if ($Report) {
+    @{
+        pe_count = $Evidence.Count
+        invalid_count = $Invalid.Count
+        signatures = $Evidence
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $Report -Encoding utf8
+}
+if ($Invalid.Count -gt 0) {
+    throw "Store PE signature check failed for $($Invalid.Count) files: $(($Invalid | ForEach-Object { $_.path + ' (' + $_.status + ')' }) -join ', ')"
+}
+Write-Host "Verified $($Evidence.Count) Portable Executable signatures."

--- a/scripts/windows/write-store-receipt.py
+++ b/scripts/windows/write-store-receipt.py
@@ -1,0 +1,72 @@
+"""Record exact candidate artifacts after signature checks; no publishing or certification claims."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_receipt(output: Path, input_manifest: Path, revision: str) -> Path:
+    archives = list(output.glob('LightTable-*-windows-x64.zip'))
+    installers = list(output.glob('LightTable-*-windows-x64-setup.exe'))
+    if len(archives) != 1 or len(installers) != 1:
+        raise ValueError('Store output must contain exactly one archive and one installer')
+    archive, installer = archives[0], installers[0]
+    with zipfile.ZipFile(archive) as bundle:
+        manifest = json.loads(bundle.read('LightTable/build-manifest.json').decode('utf-8-sig'))
+    prerequisite = json.loads(input_manifest.read_text(encoding='utf-8-sig'))
+    signatures_path = output / 'windows-signatures.json'
+    signatures = json.loads(signatures_path.read_text(encoding='utf-8-sig'))
+    pe_path = output / 'windows-store-pe-signatures.json'
+    pe = json.loads(pe_path.read_text(encoding='utf-8-sig'))
+    if (manifest.get('source_revision') != revision or not manifest.get('store_candidate')
+            or not manifest.get('authenticode_signed')
+            or manifest.get('webview2_offline_sha256') != prerequisite['sha256']
+            or signatures.get('source_revision') != revision
+            or signatures.get('archive_sha256') != sha256(archive)):
+        raise ValueError('Candidate source, signatures, or pinned prerequisite evidence does not match')
+    if (not pe.get('pe_count') or pe.get('invalid_count') != 0
+            or len(pe.get('signatures', [])) != pe['pe_count']
+            or any(item.get('status') != 'Valid' for item in pe['signatures'])
+            or not any(Path(item['path'].replace('\\', '/')).name.lower() == 'uninstall.exe'
+                       for item in pe['signatures'])):
+        raise ValueError('A passing installed-payload PE report including the uninstaller is required')
+    installer_hash = sha256(installer)
+    if not any(item.get('file') == installer.name and item.get('sha256') == installer_hash
+               and item.get('status') == 'Valid' for item in signatures.get('signatures', [])):
+        raise ValueError('Installer signature evidence does not match the final installer')
+    version = manifest['version']
+    if installer.name != f'LightTable-{version}-windows-x64-setup.exe':
+        raise ValueError('Installer filename and package version disagree')
+    receipt = {
+        'source_revision': revision,
+        'version': version,
+        'publisher_metadata': 'Chonkers LLC',
+        'webview2_input': prerequisite,
+        'artifacts': [{'file': item.name, 'bytes': item.stat().st_size, 'sha256': sha256(item)}
+                      for item in (archive, installer, signatures_path, pe_path)],
+        'installed_pe_count': pe['pe_count'],
+        'offline_clean_machine_acceptance': 'NOT DONE: separate Windows proof required',
+        'native_acceptance': 'See the Windows-native-acceptance artifact and final job result',
+        'store_submission': 'Not submitted',
+    }
+    destination = output / 'store-candidate-receipt.json'
+    destination.write_text(json.dumps(receipt, indent=2) + '\n')
+    return destination
+
+
+if __name__ == '__main__':
+    source = Path(__file__).resolve().parents[2]
+    revision = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=source, text=True).strip()
+    print(write_receipt(Path(sys.argv[1]), Path(sys.argv[2]), revision))

--- a/tests/test_windows_store_packaging.py
+++ b/tests/test_windows_store_packaging.py
@@ -36,6 +36,8 @@ class StorePackagingTests(unittest.TestCase):
                 payload.mkdir()
                 for name in ('LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'):
                     (payload / name).write_bytes(pe_fixture())
+                (payload / 'nested').mkdir()
+                (payload / 'nested' / 'module.pyd').write_bytes(pe_fixture())
                 (payload / 'readme.txt').write_text('not executable')
                 report = root / 'report.json'
                 # Substitute only certificate verification. Scan actual PE headers,
@@ -50,10 +52,11 @@ class StorePackagingTests(unittest.TestCase):
                 result = subprocess.run([POWERSHELL, '-NoProfile', '-Command', script], capture_output=True, text=True, timeout=30)
                 self.assertEqual(result.returncode != 0, invalid, result.stderr)
                 evidence = json.loads(report.read_text(encoding='utf-8-sig'))
-                self.assertEqual(evidence['pe_count'], 5)
+                self.assertEqual(evidence['pe_count'], 6)
                 self.assertEqual(evidence['invalid_count'], int(invalid))
-                self.assertEqual({row['path'] for row in evidence['signatures']},
-                                 {'LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'})
+                self.assertEqual({row['path'].replace('\\', '/') for row in evidence['signatures']},
+                                 {'LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe',
+                                  'nested/module.pyd'})
                 if invalid:
                     self.assertIn('native.pyd (NotSigned)', result.stderr)
 

--- a/tests/test_windows_store_packaging.py
+++ b/tests/test_windows_store_packaging.py
@@ -1,0 +1,99 @@
+"""Store preparation checks; native certificate and runtime proof still needs Windows."""
+import json
+from pathlib import Path
+import shutil
+import struct
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+POWERSHELL = shutil.which("pwsh") or shutil.which("powershell")
+
+
+def quote(path):
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def pe_fixture():
+    data = bytearray(128)
+    data[:2] = b'MZ'
+    struct.pack_into('<I', data, 0x3c, 64)
+    data[64:68] = b'PE\0\0'
+    return data
+
+
+@unittest.skipUnless(POWERSHELL, "PowerShell is required")
+class StorePackagingTests(unittest.TestCase):
+    def test_pe_audit_finds_python_modules_and_unusual_suffixes_and_reports_failures(self):
+        for invalid in (False, True):
+            with self.subTest(invalid=invalid), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                payload = root / 'payload with spaces'
+                payload.mkdir()
+                for name in ('LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'):
+                    (payload / name).write_bytes(pe_fixture())
+                (payload / 'readme.txt').write_text('not executable')
+                report = root / 'report.json'
+                # Substitute only certificate verification. Scan actual PE headers,
+                # walk the real filesystem and produce actual file hashes/report.
+                failure = "if ($LiteralPath.EndsWith('native.pyd')) { $status = 'NotSigned' };" if invalid else ''
+                script = (
+                    "function Get-AuthenticodeSignature { param($LiteralPath); $status = 'Valid'; "
+                    + failure + "[pscustomobject]@{ Status = $status; SignerCertificate = @{ Subject = 'fixture vendor' } } }; "
+                    + f"& {quote(ROOT / 'scripts/windows/store-pe-signatures.ps1')} "
+                    + f"-Payload {quote(payload)} -Report {quote(report)}"
+                )
+                result = subprocess.run([POWERSHELL, '-NoProfile', '-Command', script], capture_output=True, text=True, timeout=30)
+                self.assertEqual(result.returncode != 0, invalid, result.stderr)
+                evidence = json.loads(report.read_text(encoding='utf-8-sig'))
+                self.assertEqual(evidence['pe_count'], 5)
+                self.assertEqual(evidence['invalid_count'], int(invalid))
+                self.assertEqual({row['path'] for row in evidence['signatures']},
+                                 {'LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'})
+                if invalid:
+                    self.assertIn('native.pyd (NotSigned)', result.stderr)
+
+    def test_nsis_extensionless_uninstaller_is_signed_and_copied_back(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            script = root / 'sign-uninstaller.ps1'
+            shutil.copyfile(ROOT / 'scripts/windows/sign-uninstaller.ps1', script)
+            (root / 'sign-release.ps1').write_text(
+                'param([string[]]$Files,[switch]$RequireSigning)\n'
+                'if (-not $RequireSigning -or [IO.Path]::GetExtension($Files[0]) -ne ".exe") { throw "Incorrect signing input" }\n'
+                '[IO.File]::AppendAllText($Files[0], "signed-fixture")\n')
+            uninstaller = root / 'extensionless temp file'
+            uninstaller.write_text('native-fixture-')
+            result = subprocess.run([POWERSHELL, '-NoProfile', '-File', str(script),
+                                     '-RequireSigning', '-Files', str(uninstaller)],
+                                    capture_output=True, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(uninstaller.read_text(), 'native-fixture-signed-fixture')
+
+    def test_candidate_rejects_missing_offline_prerequisite_before_signing_or_output(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / 'not-created'
+            result = subprocess.run([POWERSHELL, '-NoProfile', '-File',
+                                     str(ROOT / 'scripts/windows/build-release.ps1'),
+                                     '-StoreCandidate', '-OutputDirectory', str(output)],
+                                    capture_output=True, text=True, timeout=30)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('Standalone Installer', result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_offline_hash_mismatch_stops_before_certificate_or_build_access(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = root / 'standalone.exe'
+            fixture.write_bytes(b'fixture')
+            result = subprocess.run([POWERSHELL, '-NoProfile', '-File',
+                                     str(ROOT / 'scripts/windows/build-release.ps1'), '-StoreCandidate',
+                                     '-OfflineWebView2Installer', str(fixture),
+                                     '-OfflineWebView2Sha256', '0' * 64], capture_output=True, text=True, timeout=30)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('SHA256 mismatch', result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_windows_store_packaging.py
+++ b/tests/test_windows_store_packaging.py
@@ -1,5 +1,8 @@
 """Store preparation checks; native certificate and runtime proof still needs Windows."""
 import json
+import hashlib
+import importlib.util
+import zipfile
 from pathlib import Path
 import shutil
 import struct
@@ -71,6 +74,29 @@ class StorePackagingTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(uninstaller.read_text(), 'native-fixture-signed-fixture')
 
+    def test_standalone_staging_checks_hash_and_microsoft_trust_before_promoting_input(self):
+        for case in ('valid', 'hash-mismatch', 'untrusted'):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                manifest = root / 'input.json'
+                manifest.write_text(json.dumps({
+                    'filename': 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe',
+                    'source_url': 'https://msedge.sf.dl.delivery.mp.microsoft.com/fixture.exe',
+                    'bytes': 7, 'sha256': '0' * 64 if case == 'hash-mismatch' else hashlib.sha256(b'fixture').hexdigest()}))
+                output = root / 'staged'
+                status = 'NotSigned' if case == 'untrusted' else 'Valid'
+                command = (
+                    'function Invoke-WebRequest { param($Uri,$OutFile,$TimeoutSec,$MaximumRedirection); '
+                    'if ($MaximumRedirection -ne 0) { throw "Unexpected redirects" }; [IO.File]::WriteAllText($OutFile, "fixture") }; '
+                    'function Get-AuthenticodeSignature { param($LiteralPath); '
+                    f'[pscustomobject]@{{ Status = "{status}"; SignerCertificate = @{{ Subject = "CN=Microsoft Corporation" }} }} }}; '
+                    f'& {quote(ROOT / "scripts/windows/stage-store-webview2.ps1")} -Manifest {quote(manifest)} -OutputDirectory {quote(output)}')
+                result = subprocess.run([POWERSHELL, '-NoProfile', '-Command', command],
+                                        capture_output=True, text=True, timeout=30)
+                self.assertEqual(result.returncode == 0, case == 'valid', result.stderr)
+                self.assertEqual((output / 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe').exists(), case == 'valid')
+                self.assertEqual(list(output.glob('download-*')), [])
+
     def test_candidate_rejects_missing_offline_prerequisite_before_signing_or_output(self):
         with tempfile.TemporaryDirectory() as temporary:
             output = Path(temporary) / 'not-created'
@@ -93,6 +119,44 @@ class StorePackagingTests(unittest.TestCase):
                                      '-OfflineWebView2Sha256', '0' * 64], capture_output=True, text=True, timeout=30)
             self.assertNotEqual(result.returncode, 0)
             self.assertIn('SHA256 mismatch', result.stderr)
+
+
+class StoreReceiptTests(unittest.TestCase):
+    def test_receipt_matches_final_installer_source_and_complete_pe_audit(self):
+        spec = importlib.util.spec_from_file_location('store_receipt', ROOT / 'scripts/windows/write-store-receipt.py')
+        receipt = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(receipt)
+        for case in ('valid', 'tampered-installer', 'missing-uninstaller', 'wrong-source'):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temporary:
+                output = Path(temporary)
+                installer = output / 'LightTable-0.5.0-windows-x64-setup.exe'
+                installer.write_bytes(b'signed fixture')
+                archive = output / 'LightTable-0.5.0-windows-x64.zip'
+                with zipfile.ZipFile(archive, 'w') as bundle:
+                    bundle.writestr('LightTable/build-manifest.json', json.dumps({
+                        'source_revision': 'a' * 40, 'version': '0.5.0', 'store_candidate': True,
+                        'authenticode_signed': True, 'webview2_offline_sha256': 'b' * 64}))
+                input_manifest = output / 'input.json'
+                input_manifest.write_text(json.dumps({'sha256': 'b' * 64}))
+                (output / 'windows-signatures.json').write_text(json.dumps({
+                    'source_revision': 'a' * 40, 'archive_sha256': receipt.sha256(archive),
+                    'signatures': [{'file': installer.name, 'sha256': receipt.sha256(installer), 'status': 'Valid'}]}))
+                (output / 'windows-store-pe-signatures.json').write_text(json.dumps({
+                    'pe_count': 1, 'invalid_count': 0, 'signatures': [{
+                        'path': 'native.pyd' if case == 'missing-uninstaller' else 'Uninstall.exe', 'status': 'Valid'}]}))
+                if case == 'tampered-installer':
+                    installer.write_bytes(b'changed after signing')
+                revision = 'c' * 40 if case == 'wrong-source' else 'a' * 40
+                if case != 'valid':
+                    with self.assertRaises(ValueError):
+                        receipt.write_receipt(output, input_manifest, revision)
+                    self.assertFalse((output / 'store-candidate-receipt.json').exists())
+                else:
+                    path = receipt.write_receipt(output, input_manifest, revision)
+                    data = json.loads(path.read_text())
+                    self.assertEqual(data['source_revision'], revision)
+                    self.assertEqual(len(data['artifacts']), 4)
+                    self.assertIn('NOT DONE', data['offline_clean_machine_acceptance'])
 
 
 if __name__ == '__main__':

--- a/tests/windows_webview2.ps1
+++ b/tests/windows_webview2.ps1
@@ -112,3 +112,31 @@ Expect-Failure 'timed out'
 Assert $script:State.Killed 'Timed-out bootstrapper was not stopped'
 Assert $script:State.Disposed 'Timed-out process handle was not disposed'
 Write-Output 'WebView2 runtime behavior checks passed'
+
+# An explicit bundled standalone installer never accesses the network, even
+# when its file or signature is invalid. The original bundle remains untouched.
+$Offline = Join-Path ([IO.Path]::GetTempPath()) ('lighttable-offline-test-' + [Guid]::NewGuid() + '.exe')
+try {
+    [IO.File]::WriteAllText($Offline, 'test standalone installer')
+    Reset-State
+    $script:State.DownloadFailure = $true
+    Install-WebView2Runtime -OfflineInstaller $Offline
+    Assert $script:State.Launched 'Bundled runtime was not installed'
+    Assert (-not $script:State.Downloaded) 'Offline installation accessed the network'
+    Assert (Test-Path -LiteralPath $Offline) 'Offline bundle input was removed'
+    foreach ($Case in @('missing', 'untrusted')) {
+        Reset-State
+        $script:State.DownloadFailure = $true
+        $Candidate = $Offline
+        if ($Case -eq 'missing') { $Candidate += '.missing' }
+        else { $script:State.Signature = 'NotSigned' }
+        $Failed = $false
+        try { Install-WebView2Runtime -OfflineInstaller $Candidate } catch { $Failed = $true }
+        Assert $Failed 'Invalid offline installer was accepted'
+        Assert (-not $script:State.Downloaded) 'Offline failure fell back to a download'
+        Assert (-not $script:State.Launched) 'Invalid offline installer was launched'
+    }
+} finally {
+    Remove-Item -LiteralPath $Offline -Force
+}
+Write-Output 'Offline WebView2 behavior checks passed'

--- a/web/app.js
+++ b/web/app.js
@@ -803,6 +803,8 @@ function syncControls() {
   $('filmProfileState').textContent = profileEnabled ? tr("On") : tr("Off");
   $('filmProfileOffNote').hidden = profileEnabled;
   $('filmProfileSection').classList.toggle('profile-off', !profileEnabled);
+  document.querySelector('#filmProfileSection [data-reset="film"]').hidden =
+    !profileEnabled && RESET_GROUPS.film.every((key) => S.params[key] === S.filmDefaults[key]);
   const filmStages = $('filmStagesSection');
   if (profileEnabled && filmStages.classList.contains('profile-off')) {
     filmStages.open = true;
@@ -6908,7 +6910,7 @@ function syncCullBars() {
   const rating = commonMarkValue(targets, 'rating', 0);
   const multiple = targets.length > 1;
   let title = tr("No photo selected");
-  let detail = tr("Select a photo to rate or flag");
+  let detail = '';
   if (active && multiple) {
     title = trn('{count} photo selected', '{count} photos selected', targets.length);
     detail = tr('Flags and ratings apply to selection');
@@ -8210,6 +8212,7 @@ function updateTransferActions() {
   const targets = transferTargets();
   const primaryKey = ['windows', 'linux'].includes(window.__LIGHTTABLE_PLATFORM__) ? 'Ctrl' : '⌘';
   $('copyBtn').disabled = !cur();
+  $('pasteBtn').hidden = !S.clipboard;
   $('pasteBtn').disabled = !S.clipboard || !targets.length;
   $('pasteAllBtn').disabled = !S.clipboard || !visible().length;
   $('virtualCopyBtn').disabled = !cur();

--- a/web/index.html
+++ b/web/index.html
@@ -240,10 +240,10 @@
         <div class="transfer-actions detail-transfer-actions" role="group" aria-label="Edit settings" data-i18n-attrs="{&quot;aria-label&quot;:&quot;Edit settings&quot;}">
           <button class="quiet compact transfer-btn" id="copyBtn" title="Copy edit settings (Ctrl/⌘⇧C)" aria-label="Copy edit settings" disabled data-i18n-attrs="{&quot;title&quot;:&quot;Copy edit settings (Ctrl/⌘⇧C)&quot;,&quot;aria-label&quot;:&quot;Copy edit settings&quot;}">
             <svg class="transfer-icon" viewBox="0 0 20 20" aria-hidden="true"><rect x="7" y="6" width="9" height="10" rx="1.5"/><path d="M13 6V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v8A1.5 1.5 0 0 0 4.5 14H7"/></svg>
-            <span data-i18n-text="{&quot;0&quot;:&quot;Copy&quot;}">Copy</span><span aria-hidden="true">…</span>
+            <span data-i18n-text="{&quot;0&quot;:&quot;Copy Settings...&quot;}">Copy Settings...</span>
             <svg class="transfer-check" viewBox="0 0 20 20" aria-hidden="true"><path d="m4 10 4 4 8-9"/></svg>
           </button>
-          <button class="quiet compact transfer-btn" id="pasteBtn" title="Copy settings first" aria-label="Paste edit settings" disabled data-i18n-attrs="{&quot;title&quot;:&quot;Copy settings first&quot;,&quot;aria-label&quot;:&quot;Paste edit settings&quot;}">
+          <button class="quiet compact transfer-btn" id="pasteBtn" title="Copy settings first" aria-label="Paste edit settings" disabled hidden data-i18n-attrs="{&quot;title&quot;:&quot;Copy settings first&quot;,&quot;aria-label&quot;:&quot;Paste edit settings&quot;}">
             <svg class="transfer-icon" viewBox="0 0 20 20" aria-hidden="true"><path d="M6 5H4.5A1.5 1.5 0 0 0 3 6.5v9A1.5 1.5 0 0 0 4.5 17h11a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 15.5 5H14"/><path d="M7 3h6v4H7zM10 9v5m-2-2 2 2 2-2"/></svg>
             <span data-i18n-text="{&quot;0&quot;:&quot;Paste&quot;}">Paste</span>
             <svg class="transfer-check" viewBox="0 0 20 20" aria-hidden="true"><path d="m4 10 4 4 8-9"/></svg>
@@ -906,7 +906,7 @@
   <div class="cullbar survey-cullbar" role="toolbar" aria-label="Flag and rate survey photo" data-i18n-attrs="{&quot;aria-label&quot;:&quot;Flag and rate survey photo&quot;}">
     <div class="cullbar-context">
       <strong data-cull-context-title data-i18n-text="{&quot;0&quot;:&quot;Survey&quot;}">Survey</strong>
-      <span data-cull-context-detail aria-live="polite" data-i18n-text="{&quot;0&quot;:&quot;Choose a photo to rate or flag&quot;}">Choose a photo to rate or flag</span>
+      <span data-cull-context-detail aria-live="polite"></span>
     </div>
     <div class="cullbar-primary">
       <div class="cullbar-segment cullbar-flags" role="group" aria-label="Flag" data-i18n-attrs="{&quot;aria-label&quot;:&quot;Flag&quot;}">

--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ar",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "اختر شخصًا",
     "Choose a photo folder": "اختر مجلد صور",
     "Choose a photo to edit": "اختر صورة لتحريرها",
-    "Choose a photo to rate or flag": "اختر صورة لتقييمها أو وضع علامة عليها",
     "Choose a preset to see its source and conversion coverage.": "اختر preset لرؤية مصدره وتغطية التحويل.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "اختر عملية طباعة للنيغاتيفات وافهم سبب اختفاء عناصر التحكم في الطباعة مع فيلم الشريحة.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "اختر نقطة محفوظة في المحدد لتحريرها، أو استخدم حذف النقطة لإزالتها.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "حدد صورة لنسخ إعداداتها",
     "Select a photo to edit": "حدِّد صورة لتحريرها",
     "Select a photo to preview": "تحديد صورة للمعاينة",
-    "Select a photo to rate or flag": "حدد صورة لتقييمها أو وضع علامة عليها",
     "Select a photo, or a set in a grid, and open Info.": "حدد صورة، أو مجموعة في الشبكة، وافتح معلومات.",
     "Select a photo.": "حدد صورة.",
     "Select a range of distances from the camera; refine the far and near limits": "حدد نطاقًا من المسافات من الكاميرا؛ وصقل الحدود البعيدة والقريبة",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "عند فتح الاستعراض من استبعاد بمساعدة، قارن المجموعة المقترحة وضع علامة على الصور كلٌ على حدة. يتوفر اجعلها محددة في استعراض عادي: فهو يختار صورة الاستعراض النشطة ويرفض الصور الأخرى التي لا تزال في الاستعراض. يؤدي هذا إلى تغيير أعلامها. يمكن لبيانات RAW وJPEG الوصفية المرتبطة أن توسّع هذه التغييرات في الأعلام لتشمل المرافقين.",
     "{count} matching photo shown: {criteria}.": "تم عرض {count} صورة مطابقة: {criteria}.",
     "{count} matching photos shown: {criteria}.": "تم عرض {count} صور مطابقة: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "تُجهَّز معاينات الشبكة في الخلفية عند إضافة المجلدات أو إعادة فحصها. تظهر أولاً معاينات كبيرة للصور الأصلية، ثم تحل محلها المعاينات التي تتضمن تعديلاتك عندما تصبح جاهزة."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "تُجهَّز معاينات الشبكة في الخلفية عند إضافة المجلدات أو إعادة فحصها. تظهر أولاً معاينات كبيرة للصور الأصلية، ثم تحل محلها المعاينات التي تتضمن تعديلاتك عندما تصبح جاهزة.",
+    "Copy Settings...": "نسخ الإعدادات..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/bn.json
+++ b/web/locales/bn.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "bn",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "একজন ব্যক্তি বেছে নিন",
     "Choose a photo folder": "একটি ফটো ফোল্ডার নির্বাচন করুন",
     "Choose a photo to edit": "সম্পাদনার জন্য একটি ফটো নির্বাচন করুন",
-    "Choose a photo to rate or flag": "রেটিং বা ফ্ল্যাগ দেওয়ার জন্য একটি ফটো নির্বাচন করুন",
     "Choose a preset to see its source and conversion coverage.": "একটি প্রিসেট বেছে নিয়ে এর source এবং conversion coverage দেখুন।",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "নেগেটিভের জন্য একটি print process বেছে নিন এবং slide film-এর জন্য print controls কেন অদৃশ্য হয়ে যায় তা বুঝুন।",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "যে saved point-টি বেছে নিয়ে সম্পাদনা করতে চান, selector-এ সেটি বেছে নিন, অথবা মুছতে Delete point ব্যবহার করুন।",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "এর সেটিংস কপি করতে একটি ফটো নির্বাচন করুন",
     "Select a photo to edit": "সম্পাদনার জন্য একটি ফটো নির্বাচন করুন",
     "Select a photo to preview": "পূর্বরূপ দেখতে একটি ফটো নির্বাচন করুন",
-    "Select a photo to rate or flag": "রেট বা ফ্ল্যাগ দিতে একটি ফটো নির্বাচন করুন",
     "Select a photo, or a set in a grid, and open Info.": "একটি ফটো, বা গ্রিডের একটি সেট নির্বাচন করুন, এবং Info খুলুন।",
     "Select a photo.": "একটি ফটো নির্বাচন করুন।",
     "Select a range of distances from the camera; refine the far and near limits": "ক্যামেরা থেকে দূরত্বের একটি পরিসর নির্বাচন করুন; দূর এবং কাছের সীমা সূক্ষ্মভাবে ঠিক করুন",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Assisted culling থেকে Survey খোলা হলে, প্রস্তাবিত গ্রুপটি তুলনা করুন এবং পৃথক ফটোগুলোতে ফ্ল্যাগ দিন। একটি নিয়মিত Survey-তে Make select উপলভ্য থাকে: এটি সক্রিয় survey photo-টি নির্বাচন করে এবং Survey-তে থাকা অন্য ফটোগুলোকে প্রত্যাখ্যান করে। এতে তাদের ফ্ল্যাগ পরিবর্তিত হয়। লিঙ্ক করা RAW এবং JPEG metadata এই ফ্ল্যাগ পরিবর্তনগুলো companion-গুলিতে বাড়িয়ে দিতে পারে।",
     "{count} matching photo shown: {criteria}.": "{count}টি মিলযুক্ত ফটো দেখানো হয়েছে: {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count}টি মিলযুক্ত ফটো দেখানো হয়েছে: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "ফোল্ডার যোগ করলে বা আবার স্ক্যান করলে গ্রিডের প্রিভিউ পটভূমিতে তৈরি হয়। প্রথমে মূল ছবির বড় প্রিভিউ দেখা যায়; আপনার সম্পাদনাসহ প্রিভিউ তৈরি হলে সেগুলোর জায়গায় দেখানো হয়।"
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "ফোল্ডার যোগ করলে বা আবার স্ক্যান করলে গ্রিডের প্রিভিউ পটভূমিতে তৈরি হয়। প্রথমে মূল ছবির বড় প্রিভিউ দেখা যায়; আপনার সম্পাদনাসহ প্রিভিউ তৈরি হলে সেগুলোর জায়গায় দেখানো হয়।",
+    "Copy Settings...": "সেটিংস কপি..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "de",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Eine Person auswählen",
     "Choose a photo folder": "Einen Fotoordner auswählen",
     "Choose a photo to edit": "Wählen Sie ein Foto zum Bearbeiten aus",
-    "Choose a photo to rate or flag": "Ein Foto zum Bewerten oder Markieren auswählen",
     "Choose a preset to see its source and conversion coverage.": "Wählen Sie eine Vorgabe, um ihre Quelle und Abdeckung der Umwandlung zu sehen.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Wählen Sie einen Druckprozess für Negative und verstehen Sie, warum Drucksteuerungen bei Diafilm verschwinden.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Wählen Sie einen gespeicherten Punkt im Auswahlwerkzeug aus, um ihn zu bearbeiten, oder verwenden Sie Punkt löschen, um ihn zu entfernen.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Wählen Sie ein Foto aus, um seine Einstellungen zu kopieren",
     "Select a photo to edit": "Wählen Sie ein Foto zum Bearbeiten aus",
     "Select a photo to preview": "Ein Foto zur Vorschau auswählen",
-    "Select a photo to rate or flag": "Wählen Sie ein Foto aus, um es zu bewerten oder zu markieren",
     "Select a photo, or a set in a grid, and open Info.": "Wählen Sie ein Foto oder eine Auswahl im Raster und öffnen Sie Info.",
     "Select a photo.": "Ein Foto auswählen.",
     "Select a range of distances from the camera; refine the far and near limits": "Wähle einen Entfernungsbereich von der Kamera; verfeinere die ferne und nahe Grenze",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Wenn die Übersicht aus dem Assistiertes Aussortieren geöffnet wird, vergleichen Sie die vorgeschlagene Gruppe und markieren Sie Fotos einzeln. Auswahl treffen ist in einer normalen Übersicht verfügbar: Es wählt das aktive Übersichts-Foto aus und lehnt die übrigen Fotos ab, die sich noch in der Übersicht befinden. Dadurch werden ihre Markierungen geändert. Verknüpfte RAW- und JPEG-Metadaten können diese Markierungsänderungen auf Begleitprogramme übertragen.",
     "{count} matching photo shown: {criteria}.": "{count} passendes Foto angezeigt: {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count} passende Fotos angezeigt: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Rastervorschauen werden im Hintergrund vorbereitet, wenn Sie Ordner hinzufügen oder erneut einlesen. Zunächst erscheinen große Vorschauen der Originale; Vorschauen mit Ihren Bearbeitungen ersetzen sie, sobald sie bereit sind."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Rastervorschauen werden im Hintergrund vorbereitet, wenn Sie Ordner hinzufügen oder erneut einlesen. Zunächst erscheinen große Vorschauen der Originale; Vorschauen mit Ihren Bearbeitungen ersetzen sie, sobald sie bereit sind.",
+    "Copy Settings...": "Einstellungen kopieren..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "en",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "pluralsDigest": "48cbd3ff74f519cc3776cc3d829ff2c99c4f684f8c4a8c0631d2c20d1c50b6b6",
   "plurals": {
     " · {count} paired file linked": {
@@ -756,7 +756,6 @@
     "Choose a person": "Choose a person",
     "Choose a photo folder": "Choose a photo folder",
     "Choose a photo to edit": "Choose a photo to edit",
-    "Choose a photo to rate or flag": "Choose a photo to rate or flag",
     "Choose a preset to see its source and conversion coverage.": "Choose a preset to see its source and conversion coverage.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Choose a print process for negatives and understand why print controls disappear for slide film.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Choose a saved point in the selector to edit it, or use Delete point to remove it.",
@@ -1002,6 +1001,7 @@
     "Copies every readable row into a fresh file. Readable now: {value}. Keeps edits made after the last backup; rows on damaged pages are lost.": "Copies every readable row into a fresh file. Readable now: {value}. Keeps edits made after the last backup; rows on damaged pages are lost.",
     "Copy": "Copy",
     "Copy Edit Settings": "Copy Edit Settings",
+    "Copy Settings...": "Copy Settings...",
     "Copy and Paste are below the photo in Detail view.": "Copy and Paste are below the photo in Detail view.",
     "Copy and Paste transfer the groups you explicitly select. Settings in unchecked groups stay as they are on each destination. This is an explicit copy/paste workflow: later edits to the source do not automatically synchronize to the destinations.": "Copy and Paste transfer the groups you explicitly select. Settings in unchecked groups stay as they are on each destination. This is an explicit copy/paste workflow: later edits to the source do not automatically synchronize to the destinations.",
     "Copy and verify it into the library": "Copy and verify it into the library",
@@ -2810,7 +2810,6 @@
     "Select a photo to copy its settings": "Select a photo to copy its settings",
     "Select a photo to edit": "Select a photo to edit",
     "Select a photo to preview": "Select a photo to preview",
-    "Select a photo to rate or flag": "Select a photo to rate or flag",
     "Select a photo, or a set in a grid, and open Info.": "Select a photo, or a set in a grid, and open Info.",
     "Select a photo.": "Select a photo.",
     "Select a range of distances from the camera; refine the far and near limits": "Select a range of distances from the camera; refine the far and near limits",

--- a/web/locales/es.json
+++ b/web/locales/es.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "es",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Elegir una persona",
     "Choose a photo folder": "Elige una carpeta de fotos",
     "Choose a photo to edit": "Elige una foto para editar",
-    "Choose a photo to rate or flag": "Elegir una foto para calificar o marcar",
     "Choose a preset to see its source and conversion coverage.": "Elige un ajuste preestablecido para ver su cobertura de origen y conversión.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Elige un proceso de impresión para negativos y comprende por qué los controles de impresión desaparecen para película diapositiva.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Elige un punto guardado en el selector para editarlo, o usa Eliminar punto para quitarlo.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Seleccione una foto para copiar su configuración",
     "Select a photo to edit": "Selecciona una foto para editar",
     "Select a photo to preview": "Selecciona una foto para previsualizar",
-    "Select a photo to rate or flag": "Selecciona una foto para puntuarla o marcarla",
     "Select a photo, or a set in a grid, and open Info.": "Selecciona una foto, o un conjunto en una cuadrícula, y abre Información.",
     "Select a photo.": "Seleccionar una foto.",
     "Select a range of distances from the camera; refine the far and near limits": "Selecciona un rango de distancias desde la cámara; ajusta los límites lejanos y cercanos",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Cuando Vista general se abre desde Descartado asistido, compara el grupo sugerido y marca las fotos individualmente. Hacer selección está disponible en una Vista general normal: selecciona la foto activa de la vista general y rechaza las otras fotos que aún están en la vista general. Esto cambia sus marcas. Los metadatos vinculados RAW y JPEG pueden extender esos cambios de marca a los compañeros.",
     "{count} matching photo shown: {criteria}.": "Se muestra {count} foto coincidente: {criteria}.",
     "{count} matching photos shown: {criteria}.": "Se muestran {count} fotos coincidentes: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Las vistas previas de la cuadrícula se preparan en segundo plano al añadir o volver a analizar carpetas. Primero aparecen vistas previas grandes de los originales; las vistas previas con tus ediciones las sustituyen cuando están listas."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Las vistas previas de la cuadrícula se preparan en segundo plano al añadir o volver a analizar carpetas. Primero aparecen vistas previas grandes de los originales; las vistas previas con tus ediciones las sustituyen cuando están listas.",
+    "Copy Settings...": "Copiar ajustes..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "fr",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Choisir une personne",
     "Choose a photo folder": "Choisissez un dossier de photos",
     "Choose a photo to edit": "Choisissez une photo à modifier",
-    "Choose a photo to rate or flag": "Choisir une photo à noter ou à marquer",
     "Choose a preset to see its source and conversion coverage.": "Choisissez un préréglage pour voir sa source et sa couverture de conversion.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Choisissez un processus d’impression pour les négatifs et comprenez pourquoi les contrôles d’impression disparaissent pour les films diapositives.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Choisissez un point enregistré dans le sélecteur pour le modifier, ou utilisez Supprimer le point pour l’enlever.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Sélectionnez une photo pour copier ses réglages",
     "Select a photo to edit": "Sélectionnez une photo à modifier",
     "Select a photo to preview": "Sélectionner une photo à prévisualiser",
-    "Select a photo to rate or flag": "Sélectionnez une photo pour la noter ou la marquer",
     "Select a photo, or a set in a grid, and open Info.": "Sélectionnez une photo, ou un ensemble dans une grille, puis ouvrez Infos.",
     "Select a photo.": "Sélectionner une photo.",
     "Select a range of distances from the camera; refine the far and near limits": "Sélectionner une plage de distances depuis l’appareil photo ; affiner les limites proche et lointaine",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Lorsque Vue d'ensemble est ouverte depuis Tri assisté, comparez le groupe suggéré et marquez les photos individuellement. Faire la sélection est disponible dans une Vue d'ensemble normale : il sélectionne la photo active de la vue d'ensemble et rejette les autres photos toujours dans la vue d'ensemble. Cela modifie leurs drapeaux. Les métadonnées RAW et JPEG liées peuvent étendre ces modifications de drapeau aux compagnons.",
     "{count} matching photo shown: {criteria}.": "{count} photo correspondante affichée : {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count} photos correspondantes affichées : {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Les aperçus de la grille sont préparés en arrière-plan lorsque vous ajoutez ou réanalysez des dossiers. De grands aperçus des originaux s’affichent d’abord ; les aperçus avec vos retouches les remplacent dès qu’ils sont prêts."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Les aperçus de la grille sont préparés en arrière-plan lorsque vous ajoutez ou réanalysez des dossiers. De grands aperçus des originaux s’affichent d’abord ; les aperçus avec vos retouches les remplacent dès qu’ils sont prêts.",
+    "Copy Settings...": "Copier les réglages..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/help/ar.json
+++ b/web/locales/help/ar.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "ar",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/bn.json
+++ b/web/locales/help/bn.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "bn",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/de.json
+++ b/web/locales/help/de.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "de",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/es.json
+++ b/web/locales/help/es.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "es",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/fr.json
+++ b/web/locales/help/fr.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "fr",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/hi.json
+++ b/web/locales/help/hi.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "hi",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/id.json
+++ b/web/locales/help/id.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "id",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/it.json
+++ b/web/locales/help/it.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "it",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/ja.json
+++ b/web/locales/help/ja.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "ja",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/ko.json
+++ b/web/locales/help/ko.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "ko",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/nl.json
+++ b/web/locales/help/nl.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "nl",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/pl.json
+++ b/web/locales/help/pl.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "pl",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/pt.json
+++ b/web/locales/help/pt.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "pt",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/ru.json
+++ b/web/locales/help/ru.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "ru",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/th.json
+++ b/web/locales/help/th.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "th",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/tr.json
+++ b/web/locales/help/tr.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "tr",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/vi.json
+++ b/web/locales/help/vi.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "vi",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/zh-Hans.json
+++ b/web/locales/help/zh-Hans.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "zh-Hans",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/help/zh-Hant.json
+++ b/web/locales/help/zh-Hant.json
@@ -3188,5 +3188,5 @@
     }
   ],
   "locale": "zh-Hant",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508"
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3"
 }

--- a/web/locales/hi.json
+++ b/web/locales/hi.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "hi",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "एक व्यक्ति चुनें",
     "Choose a photo folder": "एक फ़ोटो फ़ोल्डर चुनें",
     "Choose a photo to edit": "संपादित करने के लिए एक फ़ोटो चुनें",
-    "Choose a photo to rate or flag": "रेट या फ़्लैग करने के लिए एक फ़ोटो चुनें",
     "Choose a preset to see its source and conversion coverage.": "किसी preset का source और conversion coverage देखने के लिए उसे चुनें।",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "निगेटिव्स के लिए print process चुनें और समझें कि slide film के लिए print controls क्यों गायब हो जाते हैं।",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "इसे संपादित करने के लिए selector में कोई saved point चुनें, या हटाने के लिए Delete point का उपयोग करें।",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "उसकी सेटिंग्स कॉपी करने के लिए एक फ़ोटो चुनें",
     "Select a photo to edit": "संपादित करने के लिए एक फ़ोटो चुनें",
     "Select a photo to preview": "पूर्वावलोकन के लिए एक फ़ोटो चुनें",
-    "Select a photo to rate or flag": "रेट करने या फ़्लैग करने के लिए एक फ़ोटो चुनें",
     "Select a photo, or a set in a grid, and open Info.": "एक फ़ोटो, या ग्रिड में एक सेट चुनें, और जानकारी खोलें।",
     "Select a photo.": "एक फ़ोटो चुनें.",
     "Select a range of distances from the camera; refine the far and near limits": "कैमरे से दूरियों की एक सीमा चुनें; दूर और निकट सीमाएँ परिष्कृत करें",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "जब सर्वेक्षण सहायता-प्राप्त छँटाई से खोला जाता है, तो सुझाए गए समूह की तुलना करें और फ़ोटो को अलग-अलग फ़्लैग करें। नियमित सर्वेक्षण में चयन बनाएं उपलब्ध है: यह सक्रिय सर्वेक्षण फ़ोटो चुनता है और सर्वेक्षण में बची अन्य फ़ोटो को अस्वीकृत करता है। इससे उनके फ़्लैग बदलते हैं। जुड़ा हुआ RAW और JPEG मेटाडेटा इन फ़्लैग परिवर्तनों को सहायक तक बढ़ा सकता है.",
     "{count} matching photo shown: {criteria}.": "{criteria}: {count} मिलान करने वाली फ़ोटो दिखाई गई:।",
     "{count} matching photos shown: {criteria}.": "{criteria}: {count} मिलान करने वाली फ़ोटो दिखाई गईं:।",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "फ़ोल्डर जोड़ने या दोबारा स्कैन करने पर ग्रिड के पूर्वावलोकन पृष्ठभूमि में तैयार होते हैं। पहले मूल तस्वीरों के बड़े पूर्वावलोकन दिखाई देते हैं; आपके संपादनों वाले पूर्वावलोकन तैयार होते ही उनकी जगह ले लेते हैं।"
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "फ़ोल्डर जोड़ने या दोबारा स्कैन करने पर ग्रिड के पूर्वावलोकन पृष्ठभूमि में तैयार होते हैं। पहले मूल तस्वीरों के बड़े पूर्वावलोकन दिखाई देते हैं; आपके संपादनों वाले पूर्वावलोकन तैयार होते ही उनकी जगह ले लेते हैं।",
+    "Copy Settings...": "सेटिंग्स की प्रतिलिपि..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/id.json
+++ b/web/locales/id.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "id",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Pilih seseorang",
     "Choose a photo folder": "Pilih folder foto",
     "Choose a photo to edit": "Pilih sebuah foto untuk diedit",
-    "Choose a photo to rate or flag": "Pilih foto untuk diberi rating atau bendera",
     "Choose a preset to see its source and conversion coverage.": "Pilih preset untuk melihat sumber dan cakupan konversinya.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Pilih proses cetak untuk negatif dan pahami mengapa kontrol cetak menghilang untuk film slide.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Pilih titik yang disimpan di selector untuk mengeditnya, atau gunakan Delete point untuk menghapusnya.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Pilih sebuah foto untuk menyalin pengaturannya",
     "Select a photo to edit": "Pilih sebuah foto untuk diedit",
     "Select a photo to preview": "Pilih sebuah foto untuk pratinjau",
-    "Select a photo to rate or flag": "Pilih foto untuk memberi rating atau bendera",
     "Select a photo, or a set in a grid, and open Info.": "Pilih foto, atau satu set dalam kisi, lalu buka Info.",
     "Select a photo.": "Pilih sebuah foto.",
     "Select a range of distances from the camera; refine the far and near limits": "Pilih rentang jarak dari kamera; perhalus batas jauh dan dekat",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Saat Survey dibuka dari Seleksi terbantu, bandingkan grup yang disarankan dan beri bendera pada foto satu per satu. Buat pilihan tersedia dalam Survey biasa: ini memilih foto survei aktif dan menolak foto lain yang masih ada di survei. Ini mengubah benderanya. Metadata RAW dan JPEG tertaut dapat memperluas perubahan bendera tersebut ke pendamping.",
     "{count} matching photo shown: {criteria}.": "{count} foto cocok ditampilkan: {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count} foto cocok ditampilkan: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Pratinjau kisi disiapkan di latar belakang saat Anda menambahkan atau memindai ulang folder. Pratinjau besar dari foto asli muncul terlebih dahulu; pratinjau dengan suntingan Anda menggantikannya setelah siap."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Pratinjau kisi disiapkan di latar belakang saat Anda menambahkan atau memindai ulang folder. Pratinjau besar dari foto asli muncul terlebih dahulu; pratinjau dengan suntingan Anda menggantikannya setelah siap.",
+    "Copy Settings...": "Salin pengaturan..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "it",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Scegli una persona",
     "Choose a photo folder": "Scegli una cartella di foto",
     "Choose a photo to edit": "Scegli una foto da modificare",
-    "Choose a photo to rate or flag": "Scegli una foto da valutare o contrassegnare",
     "Choose a preset to see its source and conversion coverage.": "Scegli un predefinito per vedere la sua copertura di origine e conversione.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Scegli un processo di stampa per i negativi e comprendi perché i controlli di stampa scompaiono per la pellicola diapositiva.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Scegli un punto salvato nel selettore per modificarlo, oppure usa Elimina punto per rimuoverlo.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Seleziona una foto per copiarne le impostazioni",
     "Select a photo to edit": "Seleziona una foto da modificare",
     "Select a photo to preview": "Seleziona una foto per l'anteprima",
-    "Select a photo to rate or flag": "Seleziona una foto per assegnare valutazione o contrassegno",
     "Select a photo, or a set in a grid, and open Info.": "Seleziona una foto, oppure un insieme nella griglia, e apri Info.",
     "Select a photo.": "Seleziona una foto.",
     "Select a range of distances from the camera; refine the far and near limits": "Seleziona un intervallo di distanze dalla fotocamera; rifinisci i limiti lontano e vicino",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Quando Panoramica viene aperta da Scarto assistito, confronta il gruppo suggerito e contrassegna le foto singolarmente. Crea selezione è disponibile in una Panoramica normale: seleziona la foto attiva della panoramica e rifiuta le altre foto ancora nella panoramica. Questo modifica i loro contrassegni. I metadati RAW e JPEG collegati possono estendere tali modifiche dei contrassegni ai componenti complementari.",
     "{count} matching photo shown: {criteria}.": "Mostrata {count} foto corrispondente: {criteria}.",
     "{count} matching photos shown: {criteria}.": "Mostrate {count} foto corrispondenti: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Le anteprime della griglia vengono preparate in background quando aggiungi o riesamini le cartelle. Prima vengono mostrate anteprime grandi degli originali; le anteprime con le tue modifiche le sostituiscono appena sono pronte."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Le anteprime della griglia vengono preparate in background quando aggiungi o riesamini le cartelle. Prima vengono mostrate anteprime grandi degli originali; le anteprime con le tue modifiche le sostituiscono appena sono pronte.",
+    "Copy Settings...": "Copia impostazioni..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ja",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "人物を選択",
     "Choose a photo folder": "写真フォルダーを選択してください",
     "Choose a photo to edit": "編集する写真を選択してください",
-    "Choose a photo to rate or flag": "レーティングまたはフラグを付ける写真を選択",
     "Choose a preset to see its source and conversion coverage.": "プリセットを選んで、ソースと変換の適用範囲を確認します。",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "ネガ用の印画処理を選び、スライドフィルムで印刷コントロールが消える理由を理解します。",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "セレクターで保存済みのポイントを選んで編集するか、ポイントを削除で削除します。",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "設定をコピーする写真を選択してください",
     "Select a photo to edit": "編集する写真を選択してください",
     "Select a photo to preview": "プレビューする写真を選択",
-    "Select a photo to rate or flag": "評価またはフラグを付ける写真を選択してください",
     "Select a photo, or a set in a grid, and open Info.": "写真、またはグリッド内のセットを選択して、情報を開きます。",
     "Select a photo.": "写真を選択。",
     "Select a range of distances from the camera; refine the far and near limits": "カメラからの距離範囲を選択します。遠近の制限を調整してください",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "サーベイが支援付き選別から開かれた場合は、推奨グループを比較し、写真に個別にフラグを付けてください。選択を作成は通常のサーベイで使用できます。これは、アクティブなサーベイ写真を選択し、サーベイ内に残っている他の写真を却下します。これにより、それらのフラグが変更されます。リンクされたRAWとJPEGのメタデータにより、これらのフラグ変更をコンパニオンにも適用できます。",
     "{count} matching photo shown: {criteria}.": "一致した写真を{count}枚表示中: {criteria}。",
     "{count} matching photos shown: {criteria}.": "一致した写真を{count}枚表示中: {criteria}。",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "フォルダの追加や再スキャン時に、グリッドのプレビューがバックグラウンドで作成されます。最初に元の写真の大きなプレビューが表示され、編集を反映したプレビューが準備でき次第、置き換わります。"
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "フォルダの追加や再スキャン時に、グリッドのプレビューがバックグラウンドで作成されます。最初に元の写真の大きなプレビューが表示され、編集を反映したプレビューが準備でき次第、置き換わります。",
+    "Copy Settings...": "設定をコピー..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ko",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "사람 선택",
     "Choose a photo folder": "사진 폴더를 선택하세요",
     "Choose a photo to edit": "편집할 사진을 선택하세요",
-    "Choose a photo to rate or flag": "평점 또는 플래그를 지정할 사진 선택",
     "Choose a preset to see its source and conversion coverage.": "사전 설정을 선택하여 원본 및 변환 범위를 확인합니다.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "음화에 사용할 인쇄 공정을 선택하고, 슬라이드 필름에서 인쇄 컨트롤이 사라지는 이유를 이해하세요.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "선택기에서 저장된 점을 선택해 편집하거나, 점 삭제를 사용해 제거하세요.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "설정을 복사할 사진을 선택하세요",
     "Select a photo to edit": "편집할 사진을 선택하세요",
     "Select a photo to preview": "미리 볼 사진을 선택하세요",
-    "Select a photo to rate or flag": "평점이나 플래그를 지정할 사진을 선택하세요",
     "Select a photo, or a set in a grid, and open Info.": "사진 또는 그리드의 한 세트를 선택하고 정보를 엽니다.",
     "Select a photo.": "사진을 선택하세요.",
     "Select a range of distances from the camera; refine the far and near limits": "카메라로부터의 거리 범위를 선택하세요. 원거리 및 근거리 한계를 세부 조정합니다",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "서베이가 보조 선별에서 열리면 추천 그룹을 비교하고 사진에 개별적으로 플래그를 지정하세요. 일반 서베이에서는 선택 항목 만들기를 사용할 수 있습니다. 이는 활성 서베이 사진을 선택하고 서베이에 남아 있는 다른 사진들을 거부합니다. 이렇게 하면 해당 사진의 플래그가 변경됩니다. 연결된 RAW 및 JPEG 메타데이터는 이러한 플래그 변경을 보조 사진으로 확장할 수 있습니다.",
     "{count} matching photo shown: {criteria}.": "일치하는 사진 {count}장 표시됨: {criteria}.",
     "{count} matching photos shown: {criteria}.": "일치하는 사진 {count}장 표시됨: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "폴더를 추가하거나 다시 스캔하면 그리드 미리보기가 백그라운드에서 준비됩니다. 먼저 원본 사진의 큰 미리보기가 표시되고, 편집 내용이 반영된 미리보기가 준비되는 대로 교체됩니다."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "폴더를 추가하거나 다시 스캔하면 그리드 미리보기가 백그라운드에서 준비됩니다. 먼저 원본 사진의 큰 미리보기가 표시되고, 편집 내용이 반영된 미리보기가 준비되는 대로 교체됩니다.",
+    "Copy Settings...": "설정 복사..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "nl",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Kies een persoon",
     "Choose a photo folder": "Kies een fotomap",
     "Choose a photo to edit": "Kies een foto om te bewerken",
-    "Choose a photo to rate or flag": "Kies een foto om te beoordelen of te markeren",
     "Choose a preset to see its source and conversion coverage.": "Kies een voorinstelling om de bron- en conversiedekking te bekijken.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Kies een afdrukproces voor negatieven en begrijp waarom afdrukbedieningen verdwijnen voor diafilm.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Kies een opgeslagen punt in de selector om het te bewerken, of gebruik Punt verwijderen om het te verwijderen.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Selecteer een foto om de instellingen te kopiëren",
     "Select a photo to edit": "Selecteer een foto om te bewerken",
     "Select a photo to preview": "Selecteer een foto om een voorbeeld te zien",
-    "Select a photo to rate or flag": "Selecteer een foto om te beoordelen of van markering te voorzien",
     "Select a photo, or a set in a grid, and open Info.": "Selecteer een foto, of een set in een raster, en open Info.",
     "Select a photo.": "Selecteer een foto.",
     "Select a range of distances from the camera; refine the far and near limits": "Selecteer een bereik van afstanden vanaf de camera; verfijn de verre en nabije limieten",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Wanneer Overzicht wordt geopend vanuit Ondersteund selecteren, vergelijk dan de voorgestelde groep en markeer foto's afzonderlijk. Selectie maken is beschikbaar in een normaal Overzicht: het kiest de actieve overzichtsfoto en wijst de andere foto's die nog in het overzicht staan af. Dit wijzigt hun markeringen. Gekoppelde RAW- en JPEG-metagegevens kunnen die markeringswijzigingen uitbreiden naar metgezellen.",
     "{count} matching photo shown: {criteria}.": "{count} overeenkomende foto weergegeven: {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count} overeenkomende foto's weergegeven: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Rastervoorbeelden worden op de achtergrond voorbereid wanneer je mappen toevoegt of opnieuw scant. Eerst verschijnen grote voorbeelden van de originelen; voorbeelden met je bewerkingen vervangen deze zodra ze klaar zijn."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Rastervoorbeelden worden op de achtergrond voorbereid wanneer je mappen toevoegt of opnieuw scant. Eerst verschijnen grote voorbeelden van de originelen; voorbeelden met je bewerkingen vervangen deze zodra ze klaar zijn.",
+    "Copy Settings...": "Instellingen kopiëren..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "pl",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Wybierz osobę",
     "Choose a photo folder": "Wybierz folder ze zdjęciami",
     "Choose a photo to edit": "Wybierz zdjęcie do edycji",
-    "Choose a photo to rate or flag": "Wybierz zdjęcie do oceny lub oznaczenia",
     "Choose a preset to see its source and conversion coverage.": "Wybierz preset, aby zobaczyć jego źródło i zakres konwersji.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Wybierz proces druku dla negatywów i zrozum, dlaczego sterowanie drukiem znika dla filmu slajdowego.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Wybierz zapisany punkt w selektorze, aby go edytować, albo użyj Usuń punkt, aby go usunąć.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Wybierz zdjęcie, aby skopiować jego ustawienia",
     "Select a photo to edit": "Wybierz zdjęcie do edycji",
     "Select a photo to preview": "Wybierz zdjęcie, aby wyświetlić podgląd",
-    "Select a photo to rate or flag": "Wybierz zdjęcie, aby je ocenić lub oznaczyć",
     "Select a photo, or a set in a grid, and open Info.": "Wybierz zdjęcie albo zestaw w siatce i otwórz Informacje.",
     "Select a photo.": "Wybierz zdjęcie.",
     "Select a range of distances from the camera; refine the far and near limits": "Wybierz zakres odległości od aparatu; doprecyzuj granice daleką i bliską",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Gdy Przegląd zostanie otwarty z Wspomaganej selekcji, porównaj sugerowaną grupę i oznaczaj zdjęcia pojedynczo. Opcja Ustaw zaznaczenie jest dostępna w zwykłym widoku Przegląd: zaznacza aktywne zdjęcie z przeglądu i odrzuca pozostałe zdjęcia nadal znajdujące się w przeglądzie. Zmienia to ich flagi. Powiązane metadane RAW i JPEG mogą rozszerzyć te zmiany flag na towarzyszy.",
     "{count} matching photo shown: {criteria}.": "Wyświetlono {count} pasujące zdjęcie: {criteria}.",
     "{count} matching photos shown: {criteria}.": "Wyświetlono {count} pasujące zdjęcia: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Podglądy siatki są przygotowywane w tle podczas dodawania lub ponownego skanowania folderów. Najpierw pojawiają się duże podglądy oryginałów; podglądy z wprowadzonymi zmianami zastępują je, gdy są gotowe."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Podglądy siatki są przygotowywane w tle podczas dodawania lub ponownego skanowania folderów. Najpierw pojawiają się duże podglądy oryginałów; podglądy z wprowadzonymi zmianami zastępują je, gdy są gotowe.",
+    "Copy Settings...": "Kopiuj ustawienia..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/pt.json
+++ b/web/locales/pt.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "pt",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Escolha uma pessoa",
     "Choose a photo folder": "Escolha uma pasta de fotos",
     "Choose a photo to edit": "Escolha uma foto para editar",
-    "Choose a photo to rate or flag": "Escolha uma foto para avaliar ou aplicar bandeira",
     "Choose a preset to see its source and conversion coverage.": "Escolha uma predefinição para ver sua origem e cobertura de conversão.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Escolha um processo de impressão para negativos e entenda por que os controles de print desaparecem para filme slide.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Escolha um ponto salvo no seletor para editá-lo, ou use Excluir ponto para removê-lo.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Selecione uma foto para copiar suas configurações",
     "Select a photo to edit": "Selecione uma foto para editar",
     "Select a photo to preview": "Selecione uma foto para pré-visualizar",
-    "Select a photo to rate or flag": "Selecione uma foto para avaliar ou marcar",
     "Select a photo, or a set in a grid, and open Info.": "Selecione uma foto ou um conjunto em uma grade e abra Informações.",
     "Select a photo.": "Selecionar uma foto.",
     "Select a range of distances from the camera; refine the far and near limits": "Selecione uma faixa de distâncias da câmera; refine os limites distante e próximo",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Quando Varredura é aberto a partir de seleção assistida, compare o grupo sugerido e marque as fotos individualmente. Fazer seleção está disponível em uma Varredura normal: ele seleciona a foto ativa da varredura e rejeita as outras fotos ainda na varredura. Isso altera suas bandeiras. Os metadados vinculados de RAW e JPEG podem estender essas alterações de bandeira aos companheiros.",
     "{count} matching photo shown: {criteria}.": "{count} foto correspondente exibida: {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count} fotos correspondentes exibidas: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "As prévias da grade são preparadas em segundo plano quando você adiciona ou verifica novamente pastas. Primeiro aparecem prévias grandes dos originais; as prévias com suas edições as substituem quando ficam prontas."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "As prévias da grade são preparadas em segundo plano quando você adiciona ou verifica novamente pastas. Primeiro aparecem prévias grandes dos originais; as prévias com suas edições as substituem quando ficam prontas.",
+    "Copy Settings...": "Copiar configurações..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/ru.json
+++ b/web/locales/ru.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ru",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Выберите человека",
     "Choose a photo folder": "Выберите папку с фото",
     "Choose a photo to edit": "Выберите фото для редактирования",
-    "Choose a photo to rate or flag": "Выберите фото, чтобы оценить или пометить флажком",
     "Choose a preset to see its source and conversion coverage.": "Выберите пресет, чтобы увидеть его исходный профиль и покрытие преобразования.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Выберите процесс печати для негативов и поймите, почему элементы управления печатью исчезают для слайд-пленки.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Выберите сохраненную точку в селекторе, чтобы отредактировать ее, или используйте Удалить точку, чтобы убрать ее.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Выберите фото, чтобы скопировать его настройки",
     "Select a photo to edit": "Выберите фото для редактирования",
     "Select a photo to preview": "Выберите фото для предпросмотра",
-    "Select a photo to rate or flag": "Выберите фото, чтобы оценить или пометить флажком",
     "Select a photo, or a set in a grid, and open Info.": "Выберите фото или набор в сетке и откройте Инфо.",
     "Select a photo.": "Выбрать фото.",
     "Select a range of distances from the camera; refine the far and near limits": "Выберите диапазон расстояний от камеры; уточните дальнюю и ближнюю границы",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Когда Обзор открыт из Помощь при отбраковке, сравните предложенную группу и помечайте фото по отдельности. Сделать выделение доступно в обычном Обзор: оно выбирает активное фото обзора и отклоняет другие фото, которые все еще находятся в обзоре. Это изменяет их флажки. Связанные метаданные RAW и JPEG могут распространить эти изменения флажков на сопутствующее приложение.",
     "{count} matching photo shown: {criteria}.": "Показано {count} совпадающее фото: {criteria}.",
     "{count} matching photos shown: {criteria}.": "Показано {count} совпадающих фото: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "При добавлении или повторном сканировании папок превью для сетки создаются в фоновом режиме. Сначала появляются крупные превью оригиналов; по мере готовности их заменяют превью с вашими правками."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "При добавлении или повторном сканировании папок превью для сетки создаются в фоновом режиме. Сначала появляются крупные превью оригиналов; по мере готовности их заменяют превью с вашими правками.",
+    "Copy Settings...": "Копировать настройки..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/th.json
+++ b/web/locales/th.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "th",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "เลือกบุคคล",
     "Choose a photo folder": "เลือกโฟลเดอร์ภาพถ่าย",
     "Choose a photo to edit": "เลือกภาพถ่ายเพื่อแก้ไข",
-    "Choose a photo to rate or flag": "เลือกภาพถ่ายเพื่อให้คะแนนหรือตั้งธง",
     "Choose a preset to see its source and conversion coverage.": "เลือกพรีเซ็ตเพื่อดูแหล่งที่มาและความครอบคลุมของการแปลง",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "เลือกกระบวนการพิมพ์สำหรับเนกาทีฟ และทำความเข้าใจว่าทำไมตัวควบคุมการพิมพ์จึงหายไปสำหรับฟิล์มสไลด์",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "เลือกจุดที่บันทึกไว้ในตัวเลือกเพื่อแก้ไข หรือใช้ ลบจุด เพื่อลบออก",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "เลือกภาพถ่ายเพื่อคัดลอกการตั้งค่า",
     "Select a photo to edit": "เลือกภาพถ่ายเพื่อแก้ไข",
     "Select a photo to preview": "เลือกภาพถ่ายเพื่อดูพรีวิว",
-    "Select a photo to rate or flag": "เลือกภาพถ่ายเพื่อให้คะแนนหรือใส่ธง",
     "Select a photo, or a set in a grid, and open Info.": "เลือกภาพถ่าย หรือชุดภาพในตารางกริด แล้วเปิด ข้อมูล",
     "Select a photo.": "เลือกภาพถ่ายหนึ่งภาพ.",
     "Select a range of distances from the camera; refine the far and near limits": "เลือกช่วงระยะจากกล้อง; ปรับขีดจำกัดไกลและใกล้ให้เหมาะสม",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "เมื่อเปิด มุมมองภาพรวม จาก การคัดทิ้งแบบช่วย ให้เปรียบเทียบกลุ่มที่แนะนำและตั้งธงภาพถ่ายทีละภาพ ใช้ สร้างที่เลือก ได้ใน มุมมองภาพรวม ปกติ: มันจะเลือกรูปภาพในมุมมองภาพรวมที่ใช้งานอยู่และปฏิเสธภาพถ่ายอื่นๆ ที่ยังอยู่ในมุมมองภาพรวมนั้น การทำเช่นนี้จะเปลี่ยนธงของพวกมัน เมทาดาทา RAW และ JPEG ที่เชื่อมโยงกันสามารถขยายการเปลี่ยนธงนั้นไปยังโปรแกรมคู่หูได้",
     "{count} matching photo shown: {criteria}.": "แสดงภาพถ่ายที่ตรงกัน {count} ภาพ: {criteria}.",
     "{count} matching photos shown: {criteria}.": "แสดงภาพถ่ายที่ตรงกัน {count} ภาพ: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "เมื่อคุณเพิ่มหรือสแกนโฟลเดอร์อีกครั้ง ระบบจะเตรียมภาพตัวอย่างในตารางอยู่เบื้องหลัง โดยจะแสดงภาพตัวอย่างขนาดใหญ่จากต้นฉบับก่อน แล้วแทนที่ด้วยภาพตัวอย่างที่มีการแก้ไขของคุณเมื่อพร้อม"
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "เมื่อคุณเพิ่มหรือสแกนโฟลเดอร์อีกครั้ง ระบบจะเตรียมภาพตัวอย่างในตารางอยู่เบื้องหลัง โดยจะแสดงภาพตัวอย่างขนาดใหญ่จากต้นฉบับก่อน แล้วแทนที่ด้วยภาพตัวอย่างที่มีการแก้ไขของคุณเมื่อพร้อม",
+    "Copy Settings...": "คัดลอกการตั้งค่า..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/tr.json
+++ b/web/locales/tr.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "tr",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Bir kişi seçin",
     "Choose a photo folder": "Bir fotoğraf klasörü seçin",
     "Choose a photo to edit": "Düzenlemek için bir fotoğraf seçin",
-    "Choose a photo to rate or flag": "Derecelendirmek veya işaretlemek için bir fotoğraf seçin",
     "Choose a preset to see its source and conversion coverage.": "Kaynağını ve dönüştürme kapsamını görmek için bir hazır ayar seçin.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Negatifler için bir baskı işlemi seçin ve slayt film için neden print kontrollerinin kaybolduğunu anlayın.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Bir noktayı düzenlemek için seçicide kayıtlı bir noktayı seçin veya kaldırmak için Noktayı sil’i kullanın.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Ayarlarını kopyalamak için bir fotoğraf seçin",
     "Select a photo to edit": "Düzenlemek için bir fotoğraf seçin",
     "Select a photo to preview": "Önizlemek için bir fotoğraf seç",
-    "Select a photo to rate or flag": "Derecelendirmek veya bayraklamak için bir fotoğraf seçin",
     "Select a photo, or a set in a grid, and open Info.": "Bir fotoğraf veya ızgaradaki bir seti seçin ve Bilgi’yi açın.",
     "Select a photo.": "Bir fotoğraf seç.",
     "Select a range of distances from the camera; refine the far and near limits": "Kameraya olan uzaklık aralığını seçin; uzak ve yakın sınırları daraltın",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "İncele Yardımlı ayıklama'dan açıldığında, önerilen grubu karşılaştırın ve fotoğrafları tek tek bayraklayın. Normal bir İncele'de Seçim yap kullanılabilir: etkin inceleme fotoğrafını seçer ve incelemedeki diğer fotoğrafları reddeder. Bu, bayraklarını değiştirir. Bağlı RAW ve JPEG üstverisi bu bayrak değişikliklerini eşlikçilere yayabilir.",
     "{count} matching photo shown: {criteria}.": "{count} eşleşen fotoğraf gösteriliyor: {criteria}.",
     "{count} matching photos shown: {criteria}.": "{count} eşleşen fotoğraf gösteriliyor: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Klasör eklediğinizde veya yeniden taradığınızda ızgara önizlemeleri arka planda hazırlanır. Önce orijinallerin büyük önizlemeleri görünür; düzenlemelerinizi içeren önizlemeler hazır oldukça bunların yerini alır."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Klasör eklediğinizde veya yeniden taradığınızda ızgara önizlemeleri arka planda hazırlanır. Önce orijinallerin büyük önizlemeleri görünür; düzenlemelerinizi içeren önizlemeler hazır oldukça bunların yerini alır.",
+    "Copy Settings...": "Ayarları kopyala..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/vi.json
+++ b/web/locales/vi.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "vi",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "Chọn một người",
     "Choose a photo folder": "Chọn một thư mục ảnh",
     "Choose a photo to edit": "Chọn một ảnh để chỉnh sửa",
-    "Choose a photo to rate or flag": "Chọn một ảnh để xếp hạng hoặc đánh cờ",
     "Choose a preset to see its source and conversion coverage.": "Chọn một thiết lập sẵn để xem phạm vi nguồn và chuyển đổi của nó.",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "Chọn một quy trình in cho phim âm bản và hiểu vì sao các điều khiển in biến mất đối với phim slide.",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "Chọn một điểm đã lưu trong bộ chọn để chỉnh sửa nó, hoặc dùng Xóa điểm để loại bỏ nó.",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "Chọn một ảnh để sao chép cài đặt của nó",
     "Select a photo to edit": "Chọn một ảnh để chỉnh sửa",
     "Select a photo to preview": "Chọn một ảnh để xem trước",
-    "Select a photo to rate or flag": "Chọn một ảnh để chấm điểm hoặc gắn cờ",
     "Select a photo, or a set in a grid, and open Info.": "Chọn một ảnh, hoặc một tập trong lưới, và mở Thông tin.",
     "Select a photo.": "Chọn một ảnh.",
     "Select a range of distances from the camera; refine the far and near limits": "Chọn một phạm vi khoảng cách tính từ máy ảnh; tinh chỉnh giới hạn xa và gần",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "Khi Xem nhanh được mở từ Lọc ảnh có hỗ trợ, hãy so sánh nhóm được gợi ý và gắn cờ từng ảnh riêng lẻ. Tạo vùng chọn có sẵn trong một Xem nhanh bình thường: nó chọn ảnh Xem nhanh đang hoạt động và từ chối các ảnh khác vẫn còn trong Xem nhanh. Điều này sẽ thay đổi cờ của chúng. Siêu dữ liệu RAW và JPEG được liên kết có thể mở rộng các thay đổi cờ đó sang các ứng dụng đi kèm.",
     "{count} matching photo shown: {criteria}.": "Đã hiển thị {count} ảnh khớp: {criteria}.",
     "{count} matching photos shown: {criteria}.": "Đã hiển thị {count} ảnh khớp: {criteria}.",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Bản xem trước trong lưới được chuẩn bị ở chế độ nền khi bạn thêm hoặc quét lại thư mục. Bản xem trước lớn của ảnh gốc xuất hiện trước; bản xem trước có các chỉnh sửa của bạn sẽ thay thế khi sẵn sàng."
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "Bản xem trước trong lưới được chuẩn bị ở chế độ nền khi bạn thêm hoặc quét lại thư mục. Bản xem trước lớn của ảnh gốc xuất hiện trước; bản xem trước có các chỉnh sửa của bạn sẽ thay thế khi sẵn sàng.",
+    "Copy Settings...": "Sao chép cài đặt..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/zh-Hans.json
+++ b/web/locales/zh-Hans.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "zh-Hans",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "选择个人",
     "Choose a photo folder": "选择一个照片文件夹",
     "Choose a photo to edit": "选择一张要编辑的照片",
-    "Choose a photo to rate or flag": "选择要评分或标记的照片",
     "Choose a preset to see its source and conversion coverage.": "选择一个预设，以查看其来源和转换覆盖范围。",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "为底片选择一种打印工艺，并了解为什么幻灯片胶片会使打印控制消失。",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "在选择器中选择一个已保存的点以编辑它，或使用删除点将其移除。",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "选择一张照片以复制其设置",
     "Select a photo to edit": "选择一张照片进行编辑",
     "Select a photo to preview": "选择一张照片以预览",
-    "Select a photo to rate or flag": "选择一张照片以评分或标记",
     "Select a photo, or a set in a grid, and open Info.": "选择一张照片，或在网格中选择一组，然后打开 信息。",
     "Select a photo.": "选择一张照片。",
     "Select a range of distances from the camera; refine the far and near limits": "选择与相机的距离范围；细化远近限制",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "从辅助筛选打开概览时，请比较建议组并逐张标记照片。在常规概览中，“创建选区”可用：它会选择当前概览照片，并拒绝仍在概览中的其他照片。这会更改它们的标记。关联的 RAW 和 JPEG 元数据可以将这些标记更改扩展到伴侣。",
     "{count} matching photo shown: {criteria}.": "显示了 {count} 张匹配照片：{criteria}。",
     "{count} matching photos shown: {criteria}.": "显示了 {count} 张匹配照片：{criteria}。",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "添加或重新扫描文件夹时，网格预览会在后台生成。首先显示较大的原始照片预览；包含您编辑效果的预览准备就绪后，会替换原始预览。"
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "添加或重新扫描文件夹时，网格预览会在后台生成。首先显示较大的原始照片预览；包含您编辑效果的预览准备就绪后，会替换原始预览。",
+    "Copy Settings...": "复制设置..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/locales/zh-Hant.json
+++ b/web/locales/zh-Hant.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "zh-Hant",
-  "sourceDigest": "5e874d90b789ec10814337da32a4673f76a937b72b8afa1a1b96a2fae37be508",
+  "sourceDigest": "b6dfbc9bbd95c411628d93a0b049a3a8a1560c6c62d814dab3e668c5fcadb6a3",
   "generation": {
     "model": "gpt-5.4-mini",
     "reviewStatus": "machine-translated"
@@ -475,7 +475,6 @@
     "Choose a person": "選擇人物",
     "Choose a photo folder": "選擇相片資料夾",
     "Choose a photo to edit": "選擇一張相片進行編輯",
-    "Choose a photo to rate or flag": "選擇一張相片進行評分或加旗標",
     "Choose a preset to see its source and conversion coverage.": "選擇一個預設集以查看其來源與轉換涵蓋範圍。",
     "Choose a print process for negatives and understand why print controls disappear for slide film.": "為底片選擇列印處理，並了解為什麼在幻燈片底片上列印控制會消失。",
     "Choose a saved point in the selector to edit it, or use Delete point to remove it.": "在選擇器中選擇已儲存的點位來編輯它，或使用「刪除點位」將其移除。",
@@ -2492,7 +2491,6 @@
     "Select a photo to copy its settings": "選取相片以複製其設定",
     "Select a photo to edit": "選擇一張相片進行編輯",
     "Select a photo to preview": "選取一張相片以預覽",
-    "Select a photo to rate or flag": "選取相片以評分或加上旗標",
     "Select a photo, or a set in a grid, and open Info.": "選取一張相片，或在格線中選取一組，然後打開資訊。",
     "Select a photo.": "選取相片。",
     "Select a range of distances from the camera; refine the far and near limits": "選取與相機距離的一段範圍；調整遠端與近端限制",
@@ -4153,7 +4151,8 @@
     "When Survey is opened from Assisted culling, compare the suggested group and flag photos individually. Make select is available in a regular Survey: it picks the active survey photo and rejects the other photos still in the survey. This changes their flags. Linked RAW and JPEG metadata can extend those flag changes to companions.": "從「輔助篩選」開啟「總覽」時，請比較建議群組並個別為相片加上旗標。在一般的總覽中，「建立選取」可用：它會選取目前作用中的總覽相片，並拒絕總覽中其餘的相片。這會變更它們的旗標。已連結的 RAW 與 JPEG 中繼資料可將這些旗標變更延伸至伴隨程式。",
     "{count} matching photo shown: {criteria}.": "顯示 {count} 張符合的相片：{criteria}。",
     "{count} matching photos shown: {criteria}.": "顯示 {count} 張符合的相片：{criteria}。",
-    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "新增或重新掃描資料夾時，網格預覽會在背景產生。首先顯示較大的原始照片預覽；包含您編輯效果的預覽準備就緒後，便會取代原始預覽。"
+    "Grid previews are prepared in the background when you add or rescan folders. Large source previews appear first; previews with your edits replace them as they become ready.": "新增或重新掃描資料夾時，網格預覽會在背景產生。首先顯示較大的原始照片預覽；包含您編輯效果的預覽準備就緒後，便會取代原始預覽。",
+    "Copy Settings...": "複製設定..."
   },
   "plurals": {
     " · {count} paired file linked": {

--- a/web/style.css
+++ b/web/style.css
@@ -93,6 +93,12 @@ body {
 }
 button, select, input, textarea { color:var(--ink); font:inherit; }
 button { cursor:default; }
+/* Disclosure headings are controls, including those without a section class. */
+summary {
+  cursor:default;
+  -webkit-user-select:none;
+  user-select:none;
+}
 button:focus-visible, select:focus-visible, input:focus-visible, textarea:focus-visible, summary:focus-visible {
   outline:2px solid var(--slider-accent);
   outline-offset:1px;
@@ -513,7 +519,7 @@ input[type=checkbox]:disabled { opacity:.4; }
 .sidebar-disclosure-body > label { display:block; margin:10px 0 4px; color:var(--muted); font-size:11px; }
 .sidebar-disclosure-body > label.check-row { display:flex; margin:0; color:var(--ink-2); }
 .sidebar-note { margin:0 0 8px; color:var(--muted); font-size:10px; line-height:1.45; }
-.ai-cull-disclosure { max-height:260px; overflow-y:auto; }
+.ai-cull-disclosure { max-height:260px; overflow-y:auto; padding-bottom:8px; }
 .ai-cull-disclosure > summary { position:sticky; top:0; z-index:1; background:var(--chrome); }
 .ai-cull-disclosure .cull-group { margin-top:8px; }
 .ai-cull-disclosure .cull-group-title { margin-bottom:2px; color:var(--muted-2); font-size:10px; font-weight:600; text-transform:uppercase; }
@@ -1931,7 +1937,7 @@ body { display:flex; flex-direction:column; }
 .collection-block.is-empty #collectionList,
 .collection-block.is-empty #addToCollection { display:none; }
 .collection-block.is-empty .folder-heading > span:last-child { display:flex; width:100%; gap:6px; }
-.collection-block.is-empty #addCollection { display:flex; flex:1; justify-content:space-between; align-items:center; padding:5px 8px; height:32px; }
+.collection-block.is-empty #addCollection { display:flex; flex:1; justify-content:space-between; align-items:center; padding:5px 3px; height:32px; text-align:left; }
 .collection-block.is-empty .collection-create-label { display:inline; font-size:12px; }
 .collection-block.is-empty #addSmartCollection { align-self:center; }
 


### PR DESCRIPTION
Disclosure headings now use control cursors and avoid accidental text selection. Film profile Reset hides when Film is off and its resettable sliders are at defaults. The sidebar gains the requested alignment and culling padding, the unused rating prompt is removed, and Copy Settings... is explicit while Paste appears after copying. The copy label and generated Help source versions are synchronized across all 20 locales.

The completed Windows Store preparation adds an opt-in signed candidate workflow: a pinned offline WebView2 prerequisite, native payload and uninstaller signature checks, publisher metadata, and receipts tied to the final artifact hashes and source revision. Signature reports use relative paths from directory enumeration, avoiding malformed paths when Windows expands temporary-directory aliases; the regression check includes nested native modules. It does not submit to the Store or publish a release.

Validation: 146 Windows tests (3 platform skips), 2 WebView2 tests, 16 focused UI tests, 4 workflow contracts, Actionlint, JavaScript syntax, Help checks, and localization checks. The integrated browser confirmed labels, initial Paste visibility, disclosure cursor styles, and sidebar spacing; the individual control changes also have prior browser verification. Full signed Windows execution and clean offline-machine acceptance remain separate release gates.
