### PR TITLE
Use straight dividers across sidebar and popup controls

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -285,7 +285,7 @@
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d"
+        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06"
       }
     },
     "film-grain-and-format": {
@@ -392,7 +392,7 @@
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d",
+        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06",
         "web/thumbnail-errors.js": "0009004ecc17943d34546c797234770a498ae9671b92c94eb309de1af58ef78e",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
@@ -406,7 +406,7 @@
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d"
+        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06"
       }
     },
     "raw-jpeg-pairs": {
@@ -511,7 +511,7 @@
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "eae7ae2a0d2c78f093b1a78d281d1b09dd0fac07aa9d9da04231b8fbf86edf8d",
+        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },

--- a/web/style.css
+++ b/web/style.css
@@ -107,7 +107,7 @@ button {
   padding:4px 12px;
   background:var(--btn-face);
   color:var(--ink-2);
-  box-shadow:inset 0 1px 0 var(--edge-hi);
+  box-shadow:none;
   font-size:12px;
   font-weight:500;
   white-space:nowrap;
@@ -115,7 +115,7 @@ button {
 }
 /* Pointer feedback must not replace a toggle's persistent selected styling. */
 button:hover:not(:disabled):not(.on) { background:var(--btn-face-hover); border-color:var(--btn-line); color:#fff; }
-button:active:not(:disabled):not(.on) { background:var(--btn-face-active); box-shadow:inset 0 1px 2px rgba(0,0,0,.45); }
+button:active:not(:disabled):not(.on) { background:var(--btn-face-active); }
 button:disabled { opacity:.38; }
 button.on { border-color:var(--slider-accent); color:var(--on-ink); background:var(--on-soft); }
 .quiet { border-color:transparent; background:transparent; color:var(--ink-2); box-shadow:none; }
@@ -124,7 +124,7 @@ button.on { border-color:var(--slider-accent); color:var(--on-ink); background:v
 .icon-btn { width:28px; min-width:28px; height:28px; min-height:28px; padding:0; border-radius:var(--radius-s); display:inline-grid; place-items:center; }
 .icon-btn.on { border-color:transparent; background:var(--active); color:var(--accent); }
 .accent-btn, .primary-btn { min-height:30px; padding-inline:16px; color:#fff; font-weight:600; }
-.accent-btn { border-color:var(--accent-strong); background:var(--accent-strong); box-shadow:inset 0 1px 0 rgba(255,255,255,.14); }
+.accent-btn { border-color:var(--accent-strong); background:var(--accent-strong); }
 .accent-btn:hover:not(:disabled) { background:#378ce9; border-color:#378ce9; }
 .primary-btn { background:#3d3d46; border-color:var(--btn-line); }
 .primary-btn:hover:not(:disabled) { background:#474751; border-color:var(--btn-line); }
@@ -132,6 +132,18 @@ button.on { border-color:var(--slider-accent); color:var(--on-ink); background:v
 .text-btn { border:0; padding:6px 0; background:none; color:var(--muted); font-weight:500; box-shadow:none; }
 .text-btn:hover:not(:disabled) { background:none; color:#fff; }
 .text-btn.negative:hover:not(:disabled) { color:var(--skip); }
+
+/* Flat list rows use straight dividers; keep rounded hover/selection fills. */
+.source-row, .collection-row, .settings-nav button, .context-menu button { position:relative; }
+.source-row + .source-row::before,
+.source-filters .source-row::before,
+.collection-row + .collection-row::before,
+.settings-nav button + button::before,
+.context-menu button + button::before {
+  content:""; position:absolute; top:0; left:0; right:0; height:1px;
+  background:var(--line-soft); pointer-events:none;
+}
+.context-menu button + button::before { background:var(--line); }
 
 /* Fields */
 select, textarea, input[type=text], input[type=search], input[type=number], input:not([type]) {
@@ -794,7 +806,8 @@ body.filmstrip-resizing { cursor:ns-resize; user-select:none; }
 .app.grid-mode .panel { opacity:0; pointer-events:none; }
 .toolrail { grid-column:2; grid-row:1; display:flex; flex-direction:column; align-items:center; gap:2px; padding:7px 4px 12px; overflow-y:auto; border-left:1px solid var(--line-soft); background:linear-gradient(var(--inset) 92%,rgba(26,26,26,.76)); scrollbar-width:none; }
 .toolrail::-webkit-scrollbar { display:none; }
-.tool-btn { width:48px; min-height:52px; flex-shrink:0; display:flex; align-items:center; justify-content:center; border:0; border-radius:var(--radius); padding:4px; background:transparent; color:var(--muted); }
+.tool-btn { position:relative; width:48px; min-height:52px; flex-shrink:0; display:flex; align-items:center; justify-content:center; border:0; border-radius:var(--radius); padding:4px; background:transparent; color:var(--muted); }
+.tool-btn + .tool-btn::before { content:""; position:absolute; top:-1px; left:0; right:0; height:1px; background:var(--line-soft); pointer-events:none; }
 .tool-btn svg { width:24px; height:24px; }
 .tool-btn:hover { background:var(--hover); color:#fff; }
 .tool-btn.on { background:var(--active); color:#fff; }
@@ -1261,7 +1274,6 @@ a.reset:hover { color:#fff; }
   border:1px solid var(--field-line);
   border-radius:var(--radius-s);
   background:var(--field-inset);
-  box-shadow:inset 0 1px 0 rgba(255,255,255,.03);
   color:var(--ink);
   font-size:12px;
   font-weight:400;


### PR DESCRIPTION
Replace the curved highlights inherited by sidebar buttons, popup actions, Library filters, and Settings navigation with thin straight gray dividers. Preserve button geometry, hover and selected fills, and existing menu section separators.

Verified matching before/after screenshots in the running app preview, all four Library filter dividers, popup section separators, and Settings navigation. Fifteen focused UI/Help tests, Help build/check, all 19 Help localization checks, and git diff --check passed.
