### PR TITLE
Prepare signed offline Windows Store candidates

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,6 +10,11 @@ on:
         description: Package version (leave blank for a CI build)
         required: false
         type: string
+      store_candidate:
+        description: Build a Chonkers LLC Microsoft Store EXE candidate (requires a stable version and release signing)
+        required: false
+        default: false
+        type: boolean
       require_signing:
         description: Require valid Authenticode signatures for release artifacts
         required: false
@@ -28,6 +33,11 @@ on:
         description: Exact source commit selected by the release workflow
         required: false
         type: string
+      store_candidate:
+        description: Build a Chonkers LLC Microsoft Store EXE candidate (requires a stable version and release signing)
+        required: false
+        default: false
+        type: boolean
       require_signing:
         description: Require valid Authenticode signatures for release artifacts
         required: false
@@ -46,12 +56,12 @@ permissions:
 
 concurrency:
   # A routine main build must not cancel a production-signed candidate.
-  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_run_id || 'build' }}-${{ inputs.require_signing && 'signed' || 'unsigned' }}
+  group: windows-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_run_id || 'build' }}-${{ (inputs.require_signing || inputs.store_candidate) && 'signed' || 'unsigned' }}-${{ inputs.store_candidate && 'store' || 'direct' }}
   cancel-in-progress: true
 
 jobs:
   native-recheck:
-    if: github.event_name == 'workflow_dispatch' && inputs.build_run_id != ''
+    if: github.event_name == 'workflow_dispatch' && inputs.build_run_id != '' && !inputs.store_candidate
     permissions:
       contents: read
       actions: read
@@ -60,7 +70,7 @@ jobs:
       build_run_id: ${{ inputs.build_run_id }}
 
   installer-check:
-    if: github.event_name != 'workflow_dispatch' || !inputs.build_run_id
+    if: github.event_name != 'workflow_dispatch' || !inputs.build_run_id || inputs.store_candidate
     runs-on: windows-2022
     timeout-minutes: 10
     steps:
@@ -136,6 +146,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_updater.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_windows_store_packaging.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_webview2_runtime.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -156,7 +168,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   package:
-    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || !inputs.build_run_id)
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || !inputs.build_run_id || inputs.store_candidate)
     needs: installer-check
     runs-on: windows-2022
     timeout-minutes: 90
@@ -164,28 +176,42 @@ jobs:
       contents: read
       id-token: write
     # windows-release permits only main and v* tags; windows-ci has no Azure trust.
-    environment: ${{ inputs.require_signing && 'windows-release' || 'windows-ci' }}
+    environment: ${{ (inputs.require_signing || inputs.store_candidate) && 'windows-release' || 'windows-ci' }}
     env:
       UV_CACHE_DIR: ${{ github.workspace }}\.build\uv-cache
-      AZURE_SIGNING_ENDPOINT: ${{ inputs.require_signing && vars.AZURE_SIGNING_ENDPOINT || '' }}
-      AZURE_SIGNING_ACCOUNT: ${{ inputs.require_signing && vars.AZURE_SIGNING_ACCOUNT || '' }}
-      AZURE_SIGNING_PROFILE: ${{ inputs.require_signing && vars.AZURE_SIGNING_PROFILE || '' }}
-      AZURE_TENANT_ID: ${{ inputs.require_signing && vars.AZURE_TENANT_ID || '' }}
-      AZURE_CLIENT_ID: ${{ inputs.require_signing && vars.AZURE_CLIENT_ID || '' }}
+      PACKAGE_OUTPUT: ${{ inputs.store_candidate && 'dist/store-candidate' || 'dist' }}
+      AZURE_SIGNING_ENDPOINT: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_ENDPOINT || '' }}
+      AZURE_SIGNING_ACCOUNT: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_ACCOUNT || '' }}
+      AZURE_SIGNING_PROFILE: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_PROFILE || '' }}
+      AZURE_TENANT_ID: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_TENANT_ID || '' }}
+      AZURE_CLIENT_ID: ${{ (inputs.require_signing || inputs.store_candidate) && vars.AZURE_CLIENT_ID || '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_ref || github.sha }}
 
+      - name: Validate Store candidate selection
+        if: inputs.store_candidate
+        shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          RECHECK_RUN: ${{ inputs.build_run_id }}
+        run: |
+          if ($env:PACKAGE_VERSION -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') { throw "Store candidates require an explicit stable version." }
+          if ($env:RECHECK_RUN) { throw "Store candidate builds cannot be combined with native recheck mode." }
+          if ($env:GITHUB_REF -ne 'refs/heads/main' -and $env:GITHUB_REF -notmatch '^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$') {
+            throw "Store candidates must build from main or a release version tag."
+          }
+
       - name: Install pinned Azure signing dependencies
-        if: inputs.require_signing && vars.AZURE_SIGNING_ENDPOINT != ''
+        if: (inputs.require_signing || inputs.store_candidate) && vars.AZURE_SIGNING_ENDPOINT != ''
         shell: pwsh
         run: ./scripts/windows/install-signing-tools.ps1
 
       - name: Validate Windows signing configuration
         shell: pwsh
         env:
-          REQUIRE_SIGNING: ${{ inputs.require_signing && 'true' || 'false' }}
+          REQUIRE_SIGNING: ${{ (inputs.require_signing || inputs.store_candidate) && 'true' || 'false' }}
           WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
@@ -195,6 +221,11 @@ jobs:
             throw "Windows release updates require SPARKLE_PRIVATE_KEY."
           }
           if ($env:REQUIRE_SIGNING -eq 'true') { ./scripts/windows/signing-smoke.ps1 }
+
+      - name: Stage the pinned offline WebView2 prerequisite
+        if: inputs.store_candidate
+        shell: pwsh
+        run: ./scripts/windows/stage-store-webview2.ps1 -OutputDirectory ./.build/store-inputs
 
       - name: Restore build caches
         uses: actions/cache@v4
@@ -223,8 +254,9 @@ jobs:
         id: build-package
         shell: pwsh
         env:
+          STORE_CANDIDATE: ${{ inputs.store_candidate && 'true' || 'false' }}
           PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
-          REQUIRE_SIGNING: ${{ inputs.require_signing && 'true' || 'false' }}
+          REQUIRE_SIGNING: ${{ (inputs.require_signing || inputs.store_candidate) && 'true' || 'false' }}
           WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
@@ -241,17 +273,35 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_updater.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_windows_store_packaging.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_webview2_runtime.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          ./scripts/windows/build-release.ps1 -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
+          $StoreOptions = @{}
+          if ($env:STORE_CANDIDATE -eq 'true') {
+            $InputRecord = Get-Content ./packaging/webview2-store-input.json -Raw | ConvertFrom-Json
+            $StoreOptions = @{
+              StoreCandidate = $true
+              OfflineWebView2Installer = (Join-Path ./.build/store-inputs $InputRecord.filename)
+              OfflineWebView2Sha256 = $InputRecord.sha256
+            }
+          }
+          ./scripts/windows/build-release.ps1 @StoreOptions -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
 
       - name: Verify signatures in the completed artifacts
-        if: inputs.require_signing
+        if: inputs.require_signing || inputs.store_candidate
         shell: pwsh
         run: |
-          $Archive = Get-ChildItem ./dist/LightTable-*-windows-x64.zip | Select-Object -First 1
-          $Installer = Get-ChildItem ./dist/LightTable-*-windows-x64-setup.exe | Select-Object -First 1
-          ./scripts/windows/verify-release-signatures.ps1 -Archive $Archive.FullName -Installer $Installer.FullName -Report ./dist/windows-signatures.json
+          $Archive = Get-ChildItem "$env:PACKAGE_OUTPUT/LightTable-*-windows-x64.zip" | Select-Object -First 1
+          $Installer = Get-ChildItem "$env:PACKAGE_OUTPUT/LightTable-*-windows-x64-setup.exe" | Select-Object -First 1
+          ./scripts/windows/verify-release-signatures.ps1 -Archive $Archive.FullName -Installer $Installer.FullName -Report "$env:PACKAGE_OUTPUT/windows-signatures.json"
+
+      - name: Record Store candidate checksums and build inputs
+        if: inputs.store_candidate
+        shell: pwsh
+        run: |
+          python ./scripts/windows/write-store-receipt.py $env:PACKAGE_OUTPUT ./packaging/webview2-store-input.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload portable build and installer
         # Preserve a completed package for diagnosis/rechecks even if native
@@ -262,17 +312,19 @@ jobs:
         with:
           name: LightTable-windows-x64
           path: |
-            dist/LightTable-*-windows-x64.zip
-            dist/LightTable-*-windows-x64-setup.exe
-            dist/appcast-windows-x64.xml
-            dist/windows-signatures.json
+            ${{ env.PACKAGE_OUTPUT }}/LightTable-*-windows-x64.zip
+            ${{ env.PACKAGE_OUTPUT }}/LightTable-*-windows-x64-setup.exe
+            ${{ env.PACKAGE_OUTPUT }}/appcast-windows-x64.xml
+            ${{ env.PACKAGE_OUTPUT }}/windows-signatures.json
+            ${{ env.PACKAGE_OUTPUT }}/windows-store-pe-signatures.json
+            ${{ env.PACKAGE_OUTPUT }}/store-candidate-receipt.json
           if-no-files-found: error
 
       - name: Require native edit, export and restart
         timeout-minutes: 10
         shell: pwsh
         run: |
-          $Archive = Get-ChildItem ./dist/LightTable-*-windows-x64.zip | Select-Object -First 1
+          $Archive = Get-ChildItem "$env:PACKAGE_OUTPUT/LightTable-*-windows-x64.zip" | Select-Object -First 1
           Expand-Archive -LiteralPath $Archive.FullName -DestinationPath ./.build/native-candidate
           $Bundle = (Resolve-Path ./.build/native-candidate/LightTable).Path
           & "$Bundle/Python/python.exe" -B ./scripts/windows/desktop-smoke.py $Bundle --timeout 240 --report-dir ./.build/windows-desktop-evidence

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -339,3 +339,68 @@ preview surface is not enabled in the Windows shell. Measure decode, GPU work,
 webview upload, and presentation separately before choosing whether a native
 DirectX viewport is needed. Apple-only AI providers and HEIF export also remain
 separate feature-porting work.
+
+## Microsoft Store EXE candidate
+
+Store preparation uses the existing per-user NSIS installer. It is an opt-in
+build mode; direct downloads keep their current defaults. It does not reserve
+a Store name, enroll a publisher, upload anything, or prove certification.
+
+On a Windows build runner with the existing release-signing prerequisites,
+provide the **x64 Evergreen Standalone Installer** from
+[Microsoft WebView2 downloads](https://developer.microsoft.com/microsoft-edge/webview2/)
+and record its SHA256 when acquiring it. Do not use the small online bootstrapper.
+The build checks that pinned hash and a trusted Microsoft signature before any
+compilation. Offline setup never falls back to downloading a prerequisite.
+
+```powershell
+./scripts/windows/build-release.ps1 -Version 0.5.0 -StoreCandidate `
+  -OfflineWebView2Installer C:\release-inputs\MicrosoftEdgeWebView2RuntimeInstallerX64.exe `
+  -OfflineWebView2Sha256 '<recorded 64-character SHA256>'
+```
+
+Use a selected stable release number in place of the example. Outputs are under
+`dist/store-candidate/`; do not overwrite an already submitted version. The
+existing Azure signing configuration runs only on approved main/version-tag
+GitHub Actions contexts. The command also requires the existing update-signing
+key. This mode does not change credentials, certificates, or Azure identity.
+
+Candidate builds:
+
+- Embed the standalone WebView2 prerequisite and invoke it silently when needed.
+- Scan the native payload by PE header, including Python `.pyd` modules. Sign
+  unsigned EXE/DLL/PYD files with the configured release signer and preserve
+  valid vendor signatures. Reject invalid signatures or unsupported unsigned PE
+  suffixes rather than silently ignoring them.
+- Sign NSIS's generated uninstaller before embedding it, then audit every PE in
+  the installed payload. `windows-store-pe-signatures.json` records each path,
+  SHA256, signature status, and publisher. A failure blocks the candidate.
+- Set candidate installer CompanyName and installed-app publisher metadata to
+  `Chonkers LLC`. Direct-release metadata remains unchanged. Metadata does not
+  change the certificate's legal identity: review the actual signing identity
+  with the Chonkers LLC Partner Center account before submission.
+
+Partner Center installation arguments: `/S` (case-sensitive). Silent uninstall
+uses `/S`. The installer is per-user and currently leaves its own update service
+in control, as with other EXE installations; it is not an MSIX package.
+
+### Evidence still required before initial submission
+
+The existing successful Windows release run predates this candidate mode. Run
+it on Windows and retain the installed-payload signature report, installer
+hash, build manifest, native startup/edit/export/restart evidence, and install,
+repair, uninstall results. Separately exercise installation on clean Windows
+10/11 x64 with WebView2 absent and network disabled, then launch and export.
+An ordinary CI image with WebView2 already present cannot prove this case.
+Check that `/S` shows no setup UI and no app is launched by setup. Confirm all
+supported OS/device claims and that uninstall preserves photos and catalogs.
+
+Host the final signed EXE at a permanent **versioned HTTPS URL** only after
+release approval. Record its SHA256 and never replace bytes at that URL.
+Complete publisher verification, name reservation, Store listing assets,
+privacy/support links, age rating, and certification notes in Partner Center.
+No Store release is prepared merely because the four original application
+signatures or the standard Windows workflow passed.
+
+Sources: [Store EXE package requirements](https://learn.microsoft.com/windows/apps/publish/publish-your-app/msi/app-package-requirements)
+and [Microsoft's offline WebView2 deployment](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution#offline-deployment).

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -404,3 +404,38 @@ signatures or the standard Windows workflow passed.
 
 Sources: [Store EXE package requirements](https://learn.microsoft.com/windows/apps/publish/publish-your-app/msi/app-package-requirements)
 and [Microsoft's offline WebView2 deployment](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution#offline-deployment).
+
+### Dispatch the initial candidate after the preparation branch is merged
+
+The checked-in `packaging/webview2-store-input.json` pins the acquired Microsoft
+x64 standalone download (258,614,480 bytes; SHA256
+`e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831`).
+The workflow downloads only that Microsoft CDN URL without redirects and checks
+its byte length, SHA256, and trusted Microsoft signature on Windows. If the CDN
+no longer serves those exact bytes, acquire and review a new input explicitly;
+never replace the checksum automatically.
+
+```sh
+gh workflow run windows-build.yml --repo reville/lighttable-digital-darkroom \
+  --ref main -f version=0.5.0 -F store_candidate=true -F require_signing=true
+```
+
+This command is an instruction for a future authorized run, not evidence that a
+run occurred. Store mode implies required signing even when the separate signing
+input is false, uses the existing `windows-release` environment, accepts only
+main/version-tag dispatches, and cannot be combined with native-recheck mode.
+The direct-download workflow defaults and artifact name remain unchanged.
+
+The `LightTable-windows-x64` workflow artifact contains the candidate ZIP and
+EXE, signature reports, signed appcast, and `store-candidate-receipt.json`.
+The receipt cross-checks the source commit, final installer hash, archive hash,
+prerequisite hash, and installed PE report including the uninstaller. Native
+edit/export/restart still gates the job and uploads separate
+`Windows-native-acceptance` evidence. The receipt explicitly leaves clean-machine
+offline acceptance unconfirmed until that independent Windows test is done.
+
+For the selected initial release `0.5.0`, the proposed public EXE URL is
+`https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-windows-x64-setup.exe`.
+This is a proposed location, not a live download. Publish only the exact verified
+candidate bytes after all release and Store gates pass; do not replace bytes at
+that URL after submission.

--- a/packaging/webview2-store-input.json
+++ b/packaging/webview2-store-input.json
@@ -1,0 +1,10 @@
+{
+  "filename": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+  "bytes": 258614480,
+  "sha256": "e7fa35755196ad9223596ef021a1ce6799509142eaa40ba35f634026be50b831",
+  "acquired_at": "2026-09-09",
+  "source_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/a8f5ad97-0b01-41e5-9245-e8fc9ba9b311/MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+  "microsoft_redirect": "https://go.microsoft.com/fwlink/?LinkId=2124701",
+  "authenticode_verified_on_windows": false,
+  "status": "Downloaded from Microsoft; checksum recorded and PE header checked. Trusted signature and actual offline behavior still require Windows validation."
+}

--- a/scripts/windows/build-release.ps1
+++ b/scripts/windows/build-release.ps1
@@ -4,11 +4,40 @@ param(
     [string]$OutputDirectory = "dist",
     [switch]$PortableOnly,
     [switch]$RuntimeSmokeOnly,
-    [switch]$RequireSigning
+    [switch]$RequireSigning,
+    [switch]$StoreCandidate,
+    [string]$OfflineWebView2Installer = "",
+    [string]$OfflineWebView2Sha256 = ""
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# A Store candidate embeds its prerequisite and signs the entire native payload.
+# Certification still requires a clean offline Windows acceptance run.
+if ($StoreCandidate) {
+    if ($PortableOnly -or $RuntimeSmokeOnly) { throw "StoreCandidate requires an installer build." }
+    if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') { throw "StoreCandidate requires a stable numeric version." }
+    $RequireSigning = $true
+    if ([string]::IsNullOrWhiteSpace($OfflineWebView2Installer)) {
+        throw "StoreCandidate requires the x64 WebView2 Evergreen Standalone Installer."
+    }
+}
+if ($OfflineWebView2Installer -or $OfflineWebView2Sha256) {
+    if ($OfflineWebView2Sha256 -notmatch '^[a-fA-F0-9]{64}$' -or
+        -not (Test-Path -LiteralPath $OfflineWebView2Installer -PathType Leaf)) {
+        throw "Supply an existing offline WebView2 installer and its pinned SHA256."
+    }
+    $OfflineWebView2Installer = (Resolve-Path -LiteralPath $OfflineWebView2Installer).Path
+    if ((Get-FileHash -LiteralPath $OfflineWebView2Installer -Algorithm SHA256).Hash -ne $OfflineWebView2Sha256) {
+        throw "Offline WebView2 installer SHA256 mismatch."
+    }
+    $WebViewSignature = Get-AuthenticodeSignature -LiteralPath $OfflineWebView2Installer
+    if ($WebViewSignature.Status -ne 'Valid' -or $null -eq $WebViewSignature.SignerCertificate -or
+        $WebViewSignature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)') {
+        throw "The offline WebView2 installer must have a valid Microsoft signature."
+    }
+}
 
 # Public releases must fail before downloads or compilation when signing is
 # unavailable. CI builds can run without a certificate unless explicitly gated.
@@ -36,6 +65,7 @@ $Output = if ([IO.Path]::IsPathRooted($OutputDirectory)) {
 } else {
     Join-Path $Project $OutputDirectory
 }
+if ($StoreCandidate) { $Output = Join-Path $Output "store-candidate" }
 $BuildRoot = Join-Path ([IO.Path]::GetTempPath()) ("lighttable-windows-" + [Guid]::NewGuid())
 $Payload = Join-Path $BuildRoot "LightTable"
 $Resources = Join-Path $Payload "Resources\LightTable"
@@ -206,6 +236,9 @@ try {
         (Join-Path $Project "windows-shell\target\$Target\release\lighttable-desktop-shell.exe") `
         (Join-Path $Payload "LightTable.exe")
 
+    if ($StoreCandidate) {
+        & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $Payload -SignMissing
+    }
     if ($SigningEnabled) {
         & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files @(
             (Join-Path $Payload "LightTable.exe"),
@@ -233,6 +266,8 @@ try {
         python_version = $PythonVersion
         vc_runtime_version = $VCRuntimeVersion
         authenticode_signed = [bool]$SigningEnabled
+        store_candidate = [bool]$StoreCandidate
+        webview2_offline_sha256 = $OfflineWebView2Sha256.ToLowerInvariant()
     } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $Payload "build-manifest.json") -Encoding utf8
 
     if (-not $PortableOnly) {
@@ -240,7 +275,17 @@ try {
         $UninstallManifest = Join-Path $BuildRoot "uninstall-files.nsh"
         & $PythonExe -B (Join-Path $Project "scripts\windows\make-uninstall-manifest.py") $Payload $UninstallManifest
         if ($LASTEXITCODE -ne 0) { throw "Could not generate the safe uninstall file list" }
-        & $MakeNsis.Source `
+        $InstallerOptions = @()
+        if ($OfflineWebView2Installer) {
+            $InstallerOptions += "/DOFFLINE_WEBVIEW2_INSTALLER=$OfflineWebView2Installer"
+        }
+        if ($StoreCandidate) {
+            $InstallerOptions += "/DSIGN_UNINSTALLER_SCRIPT=$(Join-Path $PSScriptRoot 'sign-uninstaller.ps1')"
+            $InstallerOptions += "/DPUBLISHER=Chonkers LLC"
+            $InstallerOptions += "/DSTORE_NUMERIC_VERSION=$Version.0"
+            $InstallerOptions += "/DSIGNING_POWERSHELL=$((Get-Process -Id $PID).Path)"
+        }
+        & $MakeNsis.Source @InstallerOptions `
             "/WX" `
             "/DVERSION=$Version" `
             "/DPAYLOAD=$Payload" `
@@ -251,7 +296,8 @@ try {
         if ($SigningEnabled) {
             & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files $Installer
         }
-        & (Join-Path $Project "scripts\windows\installer-smoke.ps1") -Installer $Installer -Version $Version
+        & (Join-Path $Project "scripts\windows\installer-smoke.ps1") -Installer $Installer -Version $Version `
+            -VerifyStoreSignatures:$StoreCandidate -ExpectedPublisher $(if ($StoreCandidate) { "Chonkers LLC" } else { "Nicholas Reville" }) -SignatureReport (Join-Path $Output "windows-store-pe-signatures.json")
         if ($RequireSigning) {
             # WinSparkle accepts both the current Sparkle 32-byte seed and its
             # older 96-byte private-key format. No key material is logged or

--- a/scripts/windows/ensure-webview2.ps1
+++ b/scripts/windows/ensure-webview2.ps1
@@ -1,4 +1,4 @@
-param([switch]$CheckOnly)
+param([switch]$CheckOnly, [string]$OfflineInstaller = "")
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
@@ -35,7 +35,7 @@ function Test-WebView2Runtime {
     return $false
 }
 
-function Install-WebView2Runtime {
+function Install-WebView2Runtime([string]$OfflineInstaller = "") {
     if (Test-WebView2Runtime) {
         Write-Host "Microsoft Edge WebView2 Runtime is already installed."
         return
@@ -46,9 +46,17 @@ function Install-WebView2Runtime {
     New-Item -ItemType Directory -Path $Temporary | Out-Null
     try {
         Write-Host "Installing Microsoft Edge WebView2 Runtime..."
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-        Invoke-WebRequest -UseBasicParsing -TimeoutSec 120 `
-            -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $Bootstrapper
+        if (-not [string]::IsNullOrWhiteSpace($OfflineInstaller)) {
+            # An explicit offline package must never fall back to the network.
+            if (-not (Test-Path -LiteralPath $OfflineInstaller -PathType Leaf)) {
+                throw "The bundled offline WebView2 installer is missing."
+            }
+            Copy-Item -LiteralPath $OfflineInstaller -Destination $Bootstrapper
+        } else {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+            Invoke-WebRequest -UseBasicParsing -TimeoutSec 120 `
+                -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $Bootstrapper
+        }
         $Signature = Get-AuthenticodeSignature -LiteralPath $Bootstrapper
         if ($Signature.Status -ne 'Valid' -or $null -eq $Signature.SignerCertificate -or
             $Signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)') {
@@ -85,7 +93,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             if (Test-WebView2Runtime) { exit 0 }
             exit 1
         }
-        Install-WebView2Runtime
+        Install-WebView2Runtime -OfflineInstaller $OfflineInstaller
     } catch {
         [Console]::Error.WriteLine("$($_.Exception.Message) Install Microsoft Edge WebView2 Runtime from https://developer.microsoft.com/microsoft-edge/webview2 and run LightTable setup again.")
         exit 1

--- a/scripts/windows/installer-smoke.ps1
+++ b/scripts/windows/installer-smoke.ps1
@@ -2,7 +2,10 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$Installer,
     [Parameter(Mandatory = $true)]
-    [string]$Version
+    [string]$Version,
+    [switch]$VerifyStoreSignatures,
+    [string]$SignatureReport = "",
+    [string]$ExpectedPublisher = "Nicholas Reville"
 )
 
 $ErrorActionPreference = "Stop"
@@ -20,9 +23,10 @@ function Get-RawUserPath {
 
 function Invoke-InstallerProcess([string]$Executable, [string]$Arguments) {
     $Process = Start-Process -FilePath $Executable -ArgumentList $Arguments -PassThru
-    if (-not $Process.WaitForExit(120000)) {
+    $Timeout = if ($VerifyStoreSignatures) { 600000 } else { 120000 }
+    if (-not $Process.WaitForExit($Timeout)) {
         $Process.Kill()
-        throw "Installer process exceeded the two-minute smoke-test limit"
+        throw "Installer process exceeded the bounded smoke-test limit"
     }
     if ($Process.ExitCode -ne 0) { throw "Installer process exited with $($Process.ExitCode)" }
 }
@@ -56,8 +60,11 @@ try {
     if (-not (Test-Path (Join-Path $InstallPath "WinSparkle.dll"))) {
         throw "The Windows update component was not installed"
     }
+    if ($VerifyStoreSignatures) {
+        & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $InstallPath -Report $SignatureReport
+    }
     $Installed = Get-ItemProperty $RegistryPath
-    if ($Installed.DisplayVersion -ne $Version -or $Installed.Publisher -ne "Nicholas Reville") {
+    if ($Installed.DisplayVersion -ne $Version -or $Installed.Publisher -ne $ExpectedPublisher) {
         throw "Installed package identity does not match the release"
     }
     if ($Installed.InstallLocation -ne $InstallPath -or $Installed.QuietUninstallString -notmatch ' /S$') {

--- a/scripts/windows/installer.nsi
+++ b/scripts/windows/installer.nsi
@@ -11,6 +11,10 @@
   !error "UNINSTALL_MANIFEST is required"
 !endif
 
+!ifndef PUBLISHER
+  !define PUBLISHER "Nicholas Reville"
+!endif
+
 !include "LogicLib.nsh"
 !include "FileFunc.nsh"
 !include "WinMessages.nsh"
@@ -21,11 +25,23 @@
 
 Unicode True
 Name "LightTable"
+!ifdef STORE_NUMERIC_VERSION
+VIProductVersion "${STORE_NUMERIC_VERSION}"
+VIAddVersionKey /LANG=1033 "ProductName" "LightTable"
+VIAddVersionKey /LANG=1033 "CompanyName" "${PUBLISHER}"
+VIAddVersionKey /LANG=1033 "FileDescription" "LightTable Setup"
+VIAddVersionKey /LANG=1033 "FileVersion" "${VERSION}"
+VIAddVersionKey /LANG=1033 "LegalCopyright" "Copyright ${PUBLISHER}"
+!endif
 OutFile "${OUTPUT}"
 InstallDir "$LOCALAPPDATA\Programs\LightTable"
 RequestExecutionLevel user
 SetCompressor /SOLID lzma
 Var UpdateOwner
+
+!ifdef SIGN_UNINSTALLER_SCRIPT
+  !uninstfinalize '"${SIGNING_POWERSHELL}" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${SIGN_UNINSTALLER_SCRIPT}" -RequireSigning -Files "%1"' = 0
+!endif
 
 Function .onInit
   ${IfNot} ${RunningX64}
@@ -71,10 +87,15 @@ Section "Install"
   File /oname=ensure-webview2.ps1 "ensure-webview2.ps1"
   DetailPrint "Checking Microsoft Edge WebView2 Runtime…"
   ClearErrors
+!ifdef OFFLINE_WEBVIEW2_INSTALLER
+  File /oname=WebView2Standalone.exe "${OFFLINE_WEBVIEW2_INSTALLER}"
+  ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "$PLUGINSDIR\ensure-webview2.ps1" -OfflineInstaller "$PLUGINSDIR\WebView2Standalone.exe"' $0
+!else
   ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "$PLUGINSDIR\ensure-webview2.ps1"' $0
+!endif
   ${If} ${Errors}
   ${OrIf} $0 != 0
-    MessageBox MB_OK|MB_ICONSTOP "Microsoft Edge WebView2 Runtime could not be installed. Connect to the internet and run setup again, or install the Runtime from https://developer.microsoft.com/microsoft-edge/webview2 first." /SD IDOK
+    MessageBox MB_OK|MB_ICONSTOP "Microsoft Edge WebView2 Runtime could not be installed. Run setup again, or install the Runtime from https://developer.microsoft.com/microsoft-edge/webview2 first." /SD IDOK
     SetErrorLevel 1
     Abort
   ${EndIf}
@@ -116,7 +137,7 @@ Section "Install"
   CreateShortcut "$SMPROGRAMS\LightTable\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "DisplayName" "LightTable"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "DisplayVersion" "${VERSION}"
-  WriteRegStr HKCU "${UNINSTALL_KEY}" "Publisher" "Nicholas Reville"
+  WriteRegStr HKCU "${UNINSTALL_KEY}" "Publisher" "${PUBLISHER}"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "URLInfoAbout" "https://github.com/reville/lighttable-digital-darkroom"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "InstallLocation" "$INSTDIR"
   WriteRegStr HKCU "${UNINSTALL_KEY}" "DisplayIcon" "$INSTDIR\LightTable.exe"

--- a/scripts/windows/sign-azure.ps1
+++ b/scripts/windows/sign-azure.ps1
@@ -35,8 +35,8 @@ if ($CheckOnly) { return $true }
 if ($Files.Count -eq 0) { throw "At least one executable is required for Authenticode signing." }
 $Executables = @(foreach ($File in $Files) {
     $Executable = (Resolve-Path -LiteralPath $File).Path
-    if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll")) {
-        throw "The Windows release signing list must contain only executables or DLLs."
+    if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll", ".pyd")) {
+        throw "The Windows release signing list must contain only executables, DLLs, or Python native modules."
     }
     $Executable
 })

--- a/scripts/windows/sign-release.ps1
+++ b/scripts/windows/sign-release.ps1
@@ -68,8 +68,8 @@ try {
 
     foreach ($File in $Files) {
         $Executable = (Resolve-Path -LiteralPath $File).Path
-        if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll")) {
-            throw "The Windows release signing list must contain only executables or DLLs."
+        if ([IO.Path]::GetExtension($Executable).ToLowerInvariant() -notin @(".exe", ".dll", ".pyd")) {
+            throw "The Windows release signing list must contain only executables, DLLs, or Python native modules."
         }
         # Microsoft's SignTool syntax uses /fd for the file digest and /td with
         # /tr for an RFC 3161 timestamp. Pass arguments directly; never echo them.

--- a/scripts/windows/sign-uninstaller.ps1
+++ b/scripts/windows/sign-uninstaller.ps1
@@ -1,0 +1,16 @@
+param([Parameter(Mandatory)][string[]]$Files, [switch]$RequireSigning)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+if ($Files.Count -ne 1 -or -not $RequireSigning) { throw 'Exactly one uninstaller and required signing are expected.' }
+# NSIS supplies an extensionless temporary file. SignTool needs a PE filename,
+# and our release signer deliberately rejects arbitrary file types.
+$Directory = Join-Path ([IO.Path]::GetTempPath()) ('lighttable-uninstaller-sign-' + [Guid]::NewGuid())
+try {
+    New-Item -ItemType Directory -Path $Directory | Out-Null
+    $Executable = Join-Path $Directory 'Uninstall.exe'
+    Copy-Item -LiteralPath $Files[0] -Destination $Executable
+    & (Join-Path $PSScriptRoot 'sign-release.ps1') -RequireSigning -Files $Executable
+    Copy-Item -LiteralPath $Executable -Destination $Files[0] -Force
+} finally {
+    if (Test-Path -LiteralPath $Directory) { Remove-Item -LiteralPath $Directory -Recurse -Force }
+}

--- a/scripts/windows/stage-store-webview2.ps1
+++ b/scripts/windows/stage-store-webview2.ps1
@@ -1,0 +1,34 @@
+param(
+    [string]$Manifest = (Join-Path $PSScriptRoot '..\..\packaging\webview2-store-input.json'),
+    [Parameter(Mandatory)][string]$OutputDirectory
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$InputRecord = Get-Content -LiteralPath $Manifest -Raw | ConvertFrom-Json
+$Source = [Uri]$InputRecord.source_url
+if ($Source.Scheme -ne 'https' -or $Source.Host -ne 'msedge.sf.dl.delivery.mp.microsoft.com' -or
+    $Source.UserInfo -or $Source.Query -or $Source.Fragment -or
+    $InputRecord.filename -cne 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe' -or
+    $InputRecord.sha256 -notmatch '^[a-fA-F0-9]{64}$') {
+    throw 'Store WebView2 input must be the pinned Microsoft x64 standalone installer.'
+}
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+$Destination = Join-Path $OutputDirectory $InputRecord.filename
+# A failed or changed CDN download must never become a build input.
+$Temporary = Join-Path $OutputDirectory ('download-' + [Guid]::NewGuid() + '.exe')
+try {
+    Invoke-WebRequest -Uri $Source.AbsoluteUri -OutFile $Temporary -TimeoutSec 300 -MaximumRedirection 0
+    if ((Get-Item -LiteralPath $Temporary).Length -ne $InputRecord.bytes -or
+        (Get-FileHash -LiteralPath $Temporary -Algorithm SHA256).Hash -ne $InputRecord.sha256) {
+        throw 'Store WebView2 input size or SHA256 mismatch.'
+    }
+    $Signature = Get-AuthenticodeSignature -LiteralPath $Temporary
+    if ($Signature.Status -ne 'Valid' -or $null -eq $Signature.SignerCertificate -or
+        $Signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)') {
+        throw 'Store WebView2 input lacks a trusted Microsoft signature.'
+    }
+    Move-Item -LiteralPath $Temporary -Destination $Destination -Force
+    Write-Host 'Pinned x64 offline WebView2 input verified.'
+} finally {
+    if (Test-Path -LiteralPath $Temporary) { Remove-Item -LiteralPath $Temporary -Force }
+}

--- a/scripts/windows/store-pe-signatures.ps1
+++ b/scripts/windows/store-pe-signatures.ps1
@@ -24,8 +24,11 @@ function Test-PortableExecutable([string]$Path) {
 
 # Use PE headers rather than extensions: Python wheels carry native .pyd files,
 # and bundled native code can use other suffixes. Never erase a vendor signature.
-$Files = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force | Sort-Object FullName)
-$Evidence = @(foreach ($File in $Files) {
+# Ask the provider for relative names: Resolve-Path may retain a Windows 8.3
+# ancestor while FileInfo.FullName expands it, making string offsets incorrect.
+$RelativePaths = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force -Name | Sort-Object)
+$Evidence = @(foreach ($RelativePath in $RelativePaths) {
+    $File = Get-Item -LiteralPath (Join-Path $Root $RelativePath)
     $IsPe = Test-PortableExecutable $File.FullName
     if (-not $IsPe) {
         if ($File.Extension.ToLowerInvariant() -in @('.exe', '.dll', '.pyd')) {
@@ -39,7 +42,7 @@ $Evidence = @(foreach ($File in $Files) {
         $Signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
     }
     @{
-        path = $File.FullName.Substring($Root.TrimEnd([IO.Path]::DirectorySeparatorChar).Length + 1)
+        path = $RelativePath
         sha256 = (Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
         status = [string]$Signature.Status
         publisher = if ($null -ne $Signature.SignerCertificate) { $Signature.SignerCertificate.Subject } else { $null }

--- a/scripts/windows/store-pe-signatures.ps1
+++ b/scripts/windows/store-pe-signatures.ps1
@@ -1,0 +1,60 @@
+param(
+    [Parameter(Mandatory)][string]$Payload,
+    [switch]$SignMissing,
+    [string]$Report = ""
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Root = (Resolve-Path -LiteralPath $Payload).Path
+
+function Test-PortableExecutable([string]$Path) {
+    $Stream = [IO.File]::OpenRead($Path)
+    $Reader = [IO.BinaryReader]::new($Stream)
+    try {
+        if ($Stream.Length -lt 64 -or $Reader.ReadUInt16() -ne 0x5A4D) { return $false }
+        $Stream.Position = 0x3C
+        $Offset = $Reader.ReadUInt32()
+        if ($Offset -lt 64 -or $Offset -gt $Stream.Length - 4) { return $false }
+        $Stream.Position = $Offset
+        return $Reader.ReadUInt32() -eq 0x00004550
+    } finally {
+        $Reader.Dispose()
+    }
+}
+
+# Use PE headers rather than extensions: Python wheels carry native .pyd files,
+# and bundled native code can use other suffixes. Never erase a vendor signature.
+$Files = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force | Sort-Object FullName)
+$Evidence = @(foreach ($File in $Files) {
+    $IsPe = Test-PortableExecutable $File.FullName
+    if (-not $IsPe) {
+        if ($File.Extension.ToLowerInvariant() -in @('.exe', '.dll', '.pyd')) {
+            throw "Malformed native binary in payload: $($File.FullName)"
+        }
+        continue
+    }
+    $Signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
+    if ($SignMissing -and $Signature.Status -eq 'NotSigned') {
+        & (Join-Path $PSScriptRoot 'sign-release.ps1') -RequireSigning -Files $File.FullName
+        $Signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
+    }
+    @{
+        path = $File.FullName.Substring($Root.TrimEnd([IO.Path]::DirectorySeparatorChar).Length + 1)
+        sha256 = (Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+        status = [string]$Signature.Status
+        publisher = if ($null -ne $Signature.SignerCertificate) { $Signature.SignerCertificate.Subject } else { $null }
+    }
+})
+if ($Evidence.Count -eq 0) { throw 'No Portable Executable files found in the payload.' }
+$Invalid = @($Evidence | Where-Object { $_.status -ne 'Valid' })
+if ($Report) {
+    @{
+        pe_count = $Evidence.Count
+        invalid_count = $Invalid.Count
+        signatures = $Evidence
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $Report -Encoding utf8
+}
+if ($Invalid.Count -gt 0) {
+    throw "Store PE signature check failed for $($Invalid.Count) files: $(($Invalid | ForEach-Object { $_.path + ' (' + $_.status + ')' }) -join ', ')"
+}
+Write-Host "Verified $($Evidence.Count) Portable Executable signatures."

--- a/scripts/windows/write-store-receipt.py
+++ b/scripts/windows/write-store-receipt.py
@@ -1,0 +1,72 @@
+"""Record exact candidate artifacts after signature checks; no publishing or certification claims."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_receipt(output: Path, input_manifest: Path, revision: str) -> Path:
+    archives = list(output.glob('LightTable-*-windows-x64.zip'))
+    installers = list(output.glob('LightTable-*-windows-x64-setup.exe'))
+    if len(archives) != 1 or len(installers) != 1:
+        raise ValueError('Store output must contain exactly one archive and one installer')
+    archive, installer = archives[0], installers[0]
+    with zipfile.ZipFile(archive) as bundle:
+        manifest = json.loads(bundle.read('LightTable/build-manifest.json').decode('utf-8-sig'))
+    prerequisite = json.loads(input_manifest.read_text(encoding='utf-8-sig'))
+    signatures_path = output / 'windows-signatures.json'
+    signatures = json.loads(signatures_path.read_text(encoding='utf-8-sig'))
+    pe_path = output / 'windows-store-pe-signatures.json'
+    pe = json.loads(pe_path.read_text(encoding='utf-8-sig'))
+    if (manifest.get('source_revision') != revision or not manifest.get('store_candidate')
+            or not manifest.get('authenticode_signed')
+            or manifest.get('webview2_offline_sha256') != prerequisite['sha256']
+            or signatures.get('source_revision') != revision
+            or signatures.get('archive_sha256') != sha256(archive)):
+        raise ValueError('Candidate source, signatures, or pinned prerequisite evidence does not match')
+    if (not pe.get('pe_count') or pe.get('invalid_count') != 0
+            or len(pe.get('signatures', [])) != pe['pe_count']
+            or any(item.get('status') != 'Valid' for item in pe['signatures'])
+            or not any(Path(item['path'].replace('\\', '/')).name.lower() == 'uninstall.exe'
+                       for item in pe['signatures'])):
+        raise ValueError('A passing installed-payload PE report including the uninstaller is required')
+    installer_hash = sha256(installer)
+    if not any(item.get('file') == installer.name and item.get('sha256') == installer_hash
+               and item.get('status') == 'Valid' for item in signatures.get('signatures', [])):
+        raise ValueError('Installer signature evidence does not match the final installer')
+    version = manifest['version']
+    if installer.name != f'LightTable-{version}-windows-x64-setup.exe':
+        raise ValueError('Installer filename and package version disagree')
+    receipt = {
+        'source_revision': revision,
+        'version': version,
+        'publisher_metadata': 'Chonkers LLC',
+        'webview2_input': prerequisite,
+        'artifacts': [{'file': item.name, 'bytes': item.stat().st_size, 'sha256': sha256(item)}
+                      for item in (archive, installer, signatures_path, pe_path)],
+        'installed_pe_count': pe['pe_count'],
+        'offline_clean_machine_acceptance': 'NOT DONE: separate Windows proof required',
+        'native_acceptance': 'See the Windows-native-acceptance artifact and final job result',
+        'store_submission': 'Not submitted',
+    }
+    destination = output / 'store-candidate-receipt.json'
+    destination.write_text(json.dumps(receipt, indent=2) + '\n')
+    return destination
+
+
+if __name__ == '__main__':
+    source = Path(__file__).resolve().parents[2]
+    revision = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=source, text=True).strip()
+    print(write_receipt(Path(sys.argv[1]), Path(sys.argv[2]), revision))

--- a/tests/test_windows_store_packaging.py
+++ b/tests/test_windows_store_packaging.py
@@ -37,6 +37,8 @@ class StorePackagingTests(unittest.TestCase):
                 for name in ('LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'):
                     (payload / name).write_bytes(pe_fixture())
                 (payload / 'readme.txt').write_text('not executable')
+                (payload / 'nested folder').mkdir()
+                (payload / 'nested folder' / 'module.pyd').write_bytes(pe_fixture())
                 report = root / 'report.json'
                 # Substitute only certificate verification. Scan actual PE headers,
                 # walk the real filesystem and produce actual file hashes/report.
@@ -50,10 +52,11 @@ class StorePackagingTests(unittest.TestCase):
                 result = subprocess.run([POWERSHELL, '-NoProfile', '-Command', script], capture_output=True, text=True, timeout=30)
                 self.assertEqual(result.returncode != 0, invalid, result.stderr)
                 evidence = json.loads(report.read_text(encoding='utf-8-sig'))
-                self.assertEqual(evidence['pe_count'], 5)
+                self.assertEqual(evidence['pe_count'], 6)
                 self.assertEqual(evidence['invalid_count'], int(invalid))
                 self.assertEqual({row['path'] for row in evidence['signatures']},
-                                 {'LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'})
+                                 {'LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe',
+                                  str(Path('nested folder') / 'module.pyd')})
                 if invalid:
                     self.assertIn('native.pyd (NotSigned)', result.stderr)
 

--- a/tests/test_windows_store_packaging.py
+++ b/tests/test_windows_store_packaging.py
@@ -1,0 +1,99 @@
+"""Store preparation checks; native certificate and runtime proof still needs Windows."""
+import json
+from pathlib import Path
+import shutil
+import struct
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+POWERSHELL = shutil.which("pwsh") or shutil.which("powershell")
+
+
+def quote(path):
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def pe_fixture():
+    data = bytearray(128)
+    data[:2] = b'MZ'
+    struct.pack_into('<I', data, 0x3c, 64)
+    data[64:68] = b'PE\0\0'
+    return data
+
+
+@unittest.skipUnless(POWERSHELL, "PowerShell is required")
+class StorePackagingTests(unittest.TestCase):
+    def test_pe_audit_finds_python_modules_and_unusual_suffixes_and_reports_failures(self):
+        for invalid in (False, True):
+            with self.subTest(invalid=invalid), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                payload = root / 'payload with spaces'
+                payload.mkdir()
+                for name in ('LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'):
+                    (payload / name).write_bytes(pe_fixture())
+                (payload / 'readme.txt').write_text('not executable')
+                report = root / 'report.json'
+                # Substitute only certificate verification. Scan actual PE headers,
+                # walk the real filesystem and produce actual file hashes/report.
+                failure = "if ($LiteralPath.EndsWith('native.pyd')) { $status = 'NotSigned' };" if invalid else ''
+                script = (
+                    "function Get-AuthenticodeSignature { param($LiteralPath); $status = 'Valid'; "
+                    + failure + "[pscustomobject]@{ Status = $status; SignerCertificate = @{ Subject = 'fixture vendor' } } }; "
+                    + f"& {quote(ROOT / 'scripts/windows/store-pe-signatures.ps1')} "
+                    + f"-Payload {quote(payload)} -Report {quote(report)}"
+                )
+                result = subprocess.run([POWERSHELL, '-NoProfile', '-Command', script], capture_output=True, text=True, timeout=30)
+                self.assertEqual(result.returncode != 0, invalid, result.stderr)
+                evidence = json.loads(report.read_text(encoding='utf-8-sig'))
+                self.assertEqual(evidence['pe_count'], 5)
+                self.assertEqual(evidence['invalid_count'], int(invalid))
+                self.assertEqual({row['path'] for row in evidence['signatures']},
+                                 {'LightTable.exe', 'native.pyd', 'vendor.dll', 'renamed.bin', 'Uninstall.exe'})
+                if invalid:
+                    self.assertIn('native.pyd (NotSigned)', result.stderr)
+
+    def test_nsis_extensionless_uninstaller_is_signed_and_copied_back(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            script = root / 'sign-uninstaller.ps1'
+            shutil.copyfile(ROOT / 'scripts/windows/sign-uninstaller.ps1', script)
+            (root / 'sign-release.ps1').write_text(
+                'param([string[]]$Files,[switch]$RequireSigning)\n'
+                'if (-not $RequireSigning -or [IO.Path]::GetExtension($Files[0]) -ne ".exe") { throw "Incorrect signing input" }\n'
+                '[IO.File]::AppendAllText($Files[0], "signed-fixture")\n')
+            uninstaller = root / 'extensionless temp file'
+            uninstaller.write_text('native-fixture-')
+            result = subprocess.run([POWERSHELL, '-NoProfile', '-File', str(script),
+                                     '-RequireSigning', '-Files', str(uninstaller)],
+                                    capture_output=True, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(uninstaller.read_text(), 'native-fixture-signed-fixture')
+
+    def test_candidate_rejects_missing_offline_prerequisite_before_signing_or_output(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / 'not-created'
+            result = subprocess.run([POWERSHELL, '-NoProfile', '-File',
+                                     str(ROOT / 'scripts/windows/build-release.ps1'),
+                                     '-StoreCandidate', '-OutputDirectory', str(output)],
+                                    capture_output=True, text=True, timeout=30)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('Standalone Installer', result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_offline_hash_mismatch_stops_before_certificate_or_build_access(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = root / 'standalone.exe'
+            fixture.write_bytes(b'fixture')
+            result = subprocess.run([POWERSHELL, '-NoProfile', '-File',
+                                     str(ROOT / 'scripts/windows/build-release.ps1'), '-StoreCandidate',
+                                     '-OfflineWebView2Installer', str(fixture),
+                                     '-OfflineWebView2Sha256', '0' * 64], capture_output=True, text=True, timeout=30)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('SHA256 mismatch', result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_windows_store_packaging.py
+++ b/tests/test_windows_store_packaging.py
@@ -1,5 +1,8 @@
 """Store preparation checks; native certificate and runtime proof still needs Windows."""
 import json
+import hashlib
+import importlib.util
+import zipfile
 from pathlib import Path
 import shutil
 import struct
@@ -71,6 +74,29 @@ class StorePackagingTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(uninstaller.read_text(), 'native-fixture-signed-fixture')
 
+    def test_standalone_staging_checks_hash_and_microsoft_trust_before_promoting_input(self):
+        for case in ('valid', 'hash-mismatch', 'untrusted'):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                manifest = root / 'input.json'
+                manifest.write_text(json.dumps({
+                    'filename': 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe',
+                    'source_url': 'https://msedge.sf.dl.delivery.mp.microsoft.com/fixture.exe',
+                    'bytes': 7, 'sha256': '0' * 64 if case == 'hash-mismatch' else hashlib.sha256(b'fixture').hexdigest()}))
+                output = root / 'staged'
+                status = 'NotSigned' if case == 'untrusted' else 'Valid'
+                command = (
+                    'function Invoke-WebRequest { param($Uri,$OutFile,$TimeoutSec,$MaximumRedirection); '
+                    'if ($MaximumRedirection -ne 0) { throw "Unexpected redirects" }; [IO.File]::WriteAllText($OutFile, "fixture") }; '
+                    'function Get-AuthenticodeSignature { param($LiteralPath); '
+                    f'[pscustomobject]@{{ Status = "{status}"; SignerCertificate = @{{ Subject = "CN=Microsoft Corporation" }} }} }}; '
+                    f'& {quote(ROOT / "scripts/windows/stage-store-webview2.ps1")} -Manifest {quote(manifest)} -OutputDirectory {quote(output)}')
+                result = subprocess.run([POWERSHELL, '-NoProfile', '-Command', command],
+                                        capture_output=True, text=True, timeout=30)
+                self.assertEqual(result.returncode == 0, case == 'valid', result.stderr)
+                self.assertEqual((output / 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe').exists(), case == 'valid')
+                self.assertEqual(list(output.glob('download-*')), [])
+
     def test_candidate_rejects_missing_offline_prerequisite_before_signing_or_output(self):
         with tempfile.TemporaryDirectory() as temporary:
             output = Path(temporary) / 'not-created'
@@ -93,6 +119,44 @@ class StorePackagingTests(unittest.TestCase):
                                      '-OfflineWebView2Sha256', '0' * 64], capture_output=True, text=True, timeout=30)
             self.assertNotEqual(result.returncode, 0)
             self.assertIn('SHA256 mismatch', result.stderr)
+
+
+class StoreReceiptTests(unittest.TestCase):
+    def test_receipt_matches_final_installer_source_and_complete_pe_audit(self):
+        spec = importlib.util.spec_from_file_location('store_receipt', ROOT / 'scripts/windows/write-store-receipt.py')
+        receipt = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(receipt)
+        for case in ('valid', 'tampered-installer', 'missing-uninstaller', 'wrong-source'):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temporary:
+                output = Path(temporary)
+                installer = output / 'LightTable-0.5.0-windows-x64-setup.exe'
+                installer.write_bytes(b'signed fixture')
+                archive = output / 'LightTable-0.5.0-windows-x64.zip'
+                with zipfile.ZipFile(archive, 'w') as bundle:
+                    bundle.writestr('LightTable/build-manifest.json', json.dumps({
+                        'source_revision': 'a' * 40, 'version': '0.5.0', 'store_candidate': True,
+                        'authenticode_signed': True, 'webview2_offline_sha256': 'b' * 64}))
+                input_manifest = output / 'input.json'
+                input_manifest.write_text(json.dumps({'sha256': 'b' * 64}))
+                (output / 'windows-signatures.json').write_text(json.dumps({
+                    'source_revision': 'a' * 40, 'archive_sha256': receipt.sha256(archive),
+                    'signatures': [{'file': installer.name, 'sha256': receipt.sha256(installer), 'status': 'Valid'}]}))
+                (output / 'windows-store-pe-signatures.json').write_text(json.dumps({
+                    'pe_count': 1, 'invalid_count': 0, 'signatures': [{
+                        'path': 'native.pyd' if case == 'missing-uninstaller' else 'Uninstall.exe', 'status': 'Valid'}]}))
+                if case == 'tampered-installer':
+                    installer.write_bytes(b'changed after signing')
+                revision = 'c' * 40 if case == 'wrong-source' else 'a' * 40
+                if case != 'valid':
+                    with self.assertRaises(ValueError):
+                        receipt.write_receipt(output, input_manifest, revision)
+                    self.assertFalse((output / 'store-candidate-receipt.json').exists())
+                else:
+                    path = receipt.write_receipt(output, input_manifest, revision)
+                    data = json.loads(path.read_text())
+                    self.assertEqual(data['source_revision'], revision)
+                    self.assertEqual(len(data['artifacts']), 4)
+                    self.assertIn('NOT DONE', data['offline_clean_machine_acceptance'])
 
 
 if __name__ == '__main__':

--- a/tests/windows_webview2.ps1
+++ b/tests/windows_webview2.ps1
@@ -112,3 +112,31 @@ Expect-Failure 'timed out'
 Assert $script:State.Killed 'Timed-out bootstrapper was not stopped'
 Assert $script:State.Disposed 'Timed-out process handle was not disposed'
 Write-Output 'WebView2 runtime behavior checks passed'
+
+# An explicit bundled standalone installer never accesses the network, even
+# when its file or signature is invalid. The original bundle remains untouched.
+$Offline = Join-Path ([IO.Path]::GetTempPath()) ('lighttable-offline-test-' + [Guid]::NewGuid() + '.exe')
+try {
+    [IO.File]::WriteAllText($Offline, 'test standalone installer')
+    Reset-State
+    $script:State.DownloadFailure = $true
+    Install-WebView2Runtime -OfflineInstaller $Offline
+    Assert $script:State.Launched 'Bundled runtime was not installed'
+    Assert (-not $script:State.Downloaded) 'Offline installation accessed the network'
+    Assert (Test-Path -LiteralPath $Offline) 'Offline bundle input was removed'
+    foreach ($Case in @('missing', 'untrusted')) {
+        Reset-State
+        $script:State.DownloadFailure = $true
+        $Candidate = $Offline
+        if ($Case -eq 'missing') { $Candidate += '.missing' }
+        else { $script:State.Signature = 'NotSigned' }
+        $Failed = $false
+        try { Install-WebView2Runtime -OfflineInstaller $Candidate } catch { $Failed = $true }
+        Assert $Failed 'Invalid offline installer was accepted'
+        Assert (-not $script:State.Downloaded) 'Offline failure fell back to a download'
+        Assert (-not $script:State.Launched) 'Invalid offline installer was launched'
+    }
+} finally {
+    Remove-Item -LiteralPath $Offline -Force
+}
+Write-Output 'Offline WebView2 behavior checks passed'


### PR DESCRIPTION
The Windows installer currently downloads WebView2 when missing and does not audit every installed PE. Store candidate mode bundles a pinned Microsoft-signed offline runtime, signs the native payload and embedded uninstaller, and verifies installed file signatures before producing a receipt with exact source and artifact hashes.

The workflow exposes this mode through the existing trusted release-signing environment. Store candidates use Chonkers LLC installer metadata and require a stable version; direct build defaults remain unchanged.

Validation: six focused Store packaging tests passed after rebasing onto current main; actionlint and diff checks passed. Existing 28 Windows packaging tests, two WebView2 tests, and synthetic direct/Store NSIS compilation passed during preparation. The signed Windows workflow and separate clean offline Windows acceptance remain to be run after merge.
