### PR TITLE
Fix bright crop edges and shading seams

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -12,7 +12,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/first-run.js": "d3e3cc68759c3c7634b44c9edf562b2ae163120ae6255c38941222fa33eeebda",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
@@ -24,7 +24,7 @@
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/cull-batch.js": "f22524c715dcccbf0f0870cc464d5f45f328bcb20bb2e6793285dbe7a7ba9b87",
         "web/cull-similarity.js": "55d00a5f2a99b89f0ce1b140271af396872cbc9510e37404474be4b6ad4b6d13",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786"
       }
     },
@@ -34,14 +34,14 @@
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "capture-time": {
       "content": "ff0cc83fb27f3147353a662717ee91ca10017e8e663c4877e3a05dd017f44683",
       "sources": {
         "web/capture-time.js": "c8d62263728ab5a6a867392bc8b1a2bbe6a0a057cf903b8aeefa992f2b275487",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "xmp_sidecar.py": "7222b2987fb7f7e002e5be54fc32a6a63cdfb6abca586a9540c6764c040966af"
       }
     },
@@ -55,7 +55,7 @@
         "file_identity.py": "8810c0d7818352baaa5db681f6c5a895514d94a93fea47e4bb3e1e4b9bd6f8ce",
         "platform_paths.py": "ecb078415022d6886d6e2810cf4effa1529ada485ae145d42ecc0f5967971711",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/recovery.js": "fa5646aae6fdc5bc95dd317f08c9c3f78985a1c36d89785152d9cc55df1f0921",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72"
       }
@@ -64,7 +64,7 @@
       "content": "95bc3775974e6454f3d55661cf2db268196f4d73750fb1ba7f796bb23379cd36",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "colour-labels": {
@@ -78,14 +78,14 @@
       "content": "e712dfb148dc4b8ecf156bfd3c7f98fad29204a8091ffb048b1b85b781e3f6d8",
       "sources": {
         "web/color-tools.js": "a71a5f5f4e026534cc6a0dd37a8467ac508c19e19dd6012cec12ee5192aeea96",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-color-mixer-point-color": {
       "content": "9cfba81ef549fe43a8d1e2dc1ed7c7cc660202b4f2a640506af71f8e59fb0d7e",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-copy-paste-match-exposure": {
@@ -95,21 +95,21 @@
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-crop-geometry": {
       "content": "8540d6a3489f09244e5bb0f7b885bcf5bfd981b965c71dd1f3e2f317223462bc",
       "sources": {
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-curves": {
       "content": "a2280ce4abd9f79d1c1e6d0673c3d2ef6015fb01a14e4385e3c8621bd6b13a54",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-detail-effects-enhance": {
@@ -119,7 +119,7 @@
         "enhance_workflow.py": "b2b3fe529770388b3c4bf04345bf995a6d9a70ef866a5e917313f8b3de72506a",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/enhance-panel.js": "6efc59ea9686bf72062453c76d61a9a09ad86511b4d9737e8ba95409fd95daa7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-effects": {
@@ -127,7 +127,7 @@
       "sources": {
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-history-snapshots": {
@@ -135,14 +135,14 @@
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/history-panel.js": "5f7a77338be697479c921dc76a9668e7846c50e75cab47bfd634dfe924faec25",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-masks-ai": {
@@ -150,7 +150,7 @@
       "sources": {
         "semantic_masks.py": "d48eb799d0c3188d4dc48a573d193eec94fc087b4eb9fba9560ed41b8de585f7",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-masks-brush-gradients": {
@@ -159,7 +159,7 @@
         "edits.py": "ae9b0b2f5d0db5b1c3b5a30962ab07c5010bb270bba694b15934d0d1e4eb0394",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/editor-panels.js": "cbb1e16f590167c8f948629f3a851866a94e641daf0bc9af9694cb893d937446",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/mask-curve.js": "4db1ce1aa1d7c959762be56651cc5f7076bd363540309aef6aba3ba5a1bcf281",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254",
         "web/mask-shape.js": "890bfb7652c2424bb4444c1c51495887bb2d1605495a11a71d7205985fa0de65",
@@ -170,7 +170,7 @@
       "content": "69559a947ccd17ddcf891ab7791585d708eaa3b452ac32e1fe6fee456fe90167",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254"
       }
     },
@@ -181,7 +181,7 @@
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-presets": {
@@ -193,7 +193,7 @@
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/preset-amount.js": "c754d290a1333444cc76e5dc50de2cc4cab17deb8f44707c3358c4044f7bb476",
         "web/preset-browser.css": "607baaf24f673069d59e069381edb5fe64b138f4a9769addbc7d53c51e334768",
         "web/preset-browser.js": "9c2c3b0f606d505616bab7903e5857f1b8cef1dc9bffe9baab908ac238741833",
@@ -206,7 +206,7 @@
         "app/NativePreview.metal": "45aa8ae595982903f61554d60f6da370d0e77e905fad335f7ba9e250f0daaa02",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
       }
     },
@@ -221,14 +221,14 @@
       "content": "2e83d0be17ae55ef2edbd5cb335d18e9d96de22d032056f3dc9027bbe48fc35d",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "editing-white-balance": {
       "content": "f6b3b37c291e9d60356355f3668f15990e40995bedc9062c9a67a3da9425e271",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "export-filenames-and-folders": {
@@ -236,7 +236,7 @@
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "export-format-color-space": {
@@ -244,14 +244,14 @@
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "export-metadata-sidecars": {
       "content": "ff38b09d22440c0f8c975dc0e18bbb848413afd9ff205ab956f89d3335f3ce9d",
       "sources": {
         "export_workflow.py": "5289e6b3790e715d3df903125f83af51fbe80f387cde30c70ef881e8bf3c335d",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "export-photos": {
@@ -259,14 +259,14 @@
       "sources": {
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "external-editor": {
       "content": "905a7f2d9fc297adb88b6aa0c2f0f5bf7b21513ca1db891c3b7a3bf137aac2de",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154"
       }
     },
@@ -275,7 +275,7 @@
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "film-getting-started": {
@@ -284,15 +284,15 @@
         "film_tuning.py": "133a5e3200b69b2aa3b92f8bb471c93af449b5036bb8dfdd6610292175693860",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
-        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
+        "web/style.css": "44ce3032785a4e990dfa28e46b614d9803480f0772e4bd6462cc4bf2c8f7c9d5"
       }
     },
     "film-grain-and-format": {
       "content": "117e7f33220929f2089dd5c4cf181a4373f627020fb119ac3badcc3c53066dc5",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "film-halation-diffusion-scan": {
@@ -300,7 +300,7 @@
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "film-negative-paper-and-slides": {
@@ -309,14 +309,14 @@
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "flags-and-ratings": {
@@ -333,7 +333,7 @@
         "ingest_workflow.py": "bd0365f4184536485ef7e7ebc1506df5e302e2859bfa3678bde76dba5ad48518",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "import-lightroom-catalog": {
@@ -342,7 +342,7 @@
         "catalog_import.py": "3af2b1298264c69a9197b58dfadd3e1485ee89500c2ce3709d3de2cd93a79d29",
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "keyboard-midi": {
@@ -350,7 +350,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/midi.js": "a74a05ad2303790b15efaf9953afcf60f20ccfabf4d4f8bde7ae2eb99c834175"
       }
     },
@@ -387,12 +387,12 @@
         "server.py": "db06e23b253b33eb1eba47bcf9d4bd96c7d102c3d1516f3a1f91369a3bbb5228",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/preview-detail.js": "8601034c83de06c042fdd5528d7fde5ff69db567bdac7225f3b133b739836acc",
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3",
+        "web/style.css": "44ce3032785a4e990dfa28e46b614d9803480f0772e4bd6462cc4bf2c8f7c9d5",
         "web/thumbnail-errors.js": "0009004ecc17943d34546c797234770a498ae9671b92c94eb309de1af58ef78e",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
@@ -404,16 +404,16 @@
         "film_lab_ai/service.py": "fd684477d966d1014c1b72cb843871379db98b41fb800ec9f98a8d75c1eea842",
         "media_availability.py": "c450d7734d3e39f2c9bb6c5e39c855374ee4e03d6947c299315f558072aca25e",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3"
+        "web/style.css": "44ce3032785a4e990dfa28e46b614d9803480f0772e4bd6462cc4bf2c8f7c9d5"
       }
     },
     "raw-jpeg-pairs": {
       "content": "63ef5d08a8d6515e2677eb9344c41edafd7d2b2266703648040f4080033691b2",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
     },
@@ -431,7 +431,7 @@
         "catalog_scan.py": "694ded2af507f35ef95dcb358632fc0d8b3b8deb63d77029617b9e94b2abde18",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/library-filters.js": "1d05785c353a9d6d1324fba2961d4c3bb0e3c7f794bb4bdc35bf968c236e972d",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8",
         "web/photo-display-status.js": "33a66b26b9c7a8f9fed4c2151cf7c069b6c02adf89f094ce1885d557db458956"
@@ -445,7 +445,7 @@
         "server_updates.py": "e3b348cc4412d656a51e8410b07ec78d0ddf404eb6a5e506468d233d1cf17b6d",
         "web/desktop-theme.js": "29f65082cfffad6e59023c6dacc22f0af95b4226955df79c8afcb936219ecc3f",
         "web/desktop-updates.js": "b5da55533a5dbfc8d9652361ca4a6a4b31b388510214971619d03f81ff7588f9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/linux-layout.css": "885ae0e7ad37cd2af4feb2d94739c405a498dcd62ee95bf38cf5ff7d39a57ae5",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
         "windows-shell/src/main.rs": "e353385acc359ce539b6b6040100ab8fc7dfe0790adb7a0ddfa3260010a1a154",
@@ -457,7 +457,7 @@
       "sources": {
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/i18n.js": "48ec7b56c856a8db9bcd47315a6c697582a0207a1656d42ed43260c3627b7388",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/locale-bootstrap.js": "06fc13de85d1b216f01742ae5667c03b18a4fd413913281bb87aa7866b287845",
         "web/locales/manifest.json": "50952ea4e6e3b6028aeda3f9d36310905ecbe82e4825577b6912c0836a4e4c9c",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72"
@@ -467,7 +467,7 @@
       "content": "e6cf59f5fde950bf351b74084189c3d6fb585b9ef8f86c78a01c82db94da584d",
       "sources": {
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -484,7 +484,7 @@
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503"
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445"
       }
     },
     "survey-photos": {
@@ -509,9 +509,9 @@
         "app/main.swift": "f2b46f6e54cba5101197b3d74c7d32a822505e9ef667bfe47bd553d50f2a4628",
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
-        "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
+        "web/index.html": "a378babff833a7393d76cb0b0081c16e86b8987ed9c0b047389c0355376bf445",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3",
+        "web/style.css": "44ce3032785a4e990dfa28e46b614d9803480f0772e4bd6462cc4bf2c8f7c9d5",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -285,7 +285,7 @@
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
-        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06"
+        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3"
       }
     },
     "film-grain-and-format": {
@@ -392,7 +392,7 @@
         "web/preview-preferences.js": "560f67a98d3cb04bf1db8267716a30c2bbb46db93cb0790a8295dceb597fbf9d",
         "web/preview-progress.js": "ca6fb45f461c7cf13f6d16b08898fa885f7b428967a92ca2b43c464121104f27",
         "web/settings.js": "74d11462a0ddd9129ec66bfd8a8f48d96d40271f26e8001d3ccaf0eb7fe9bc72",
-        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06",
+        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3",
         "web/thumbnail-errors.js": "0009004ecc17943d34546c797234770a498ae9671b92c94eb309de1af58ef78e",
         "web/view-performance.js": "c0033153f2193e4da08f32bc460772ab79f532367574d47fa24ef86513d465f3"
       }
@@ -406,7 +406,7 @@
         "web/app.js": "b5636c1b3df2d57e16de3ccedecb5eb35e9f95a140645a39afa3cc6539d723b9",
         "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
-        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06"
+        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3"
       }
     },
     "raw-jpeg-pairs": {
@@ -511,7 +511,7 @@
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "17417793e3f41c04eb5e0e8054c6aa3b7b2dbba03e44a74955c5dcdcdc862503",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
-        "web/style.css": "1c6f76139b4019490b50d32f945ba4bbfc1799827ea193e625bbd1cb76af0d06",
+        "web/style.css": "45206292b9bf2c09ab14926ed88275bbeddaa6a180abefb0658d5a608b68e3c3",
         "web/zoom-motion.js": "e531b114d2009c3287052e4e42e01917ce71cf1471c70d2e33f707f350c5cce1"
       }
     },

--- a/web/index.html
+++ b/web/index.html
@@ -201,10 +201,12 @@
             <img id="orig" alt="Original photograph" data-i18n-attrs="{&quot;alt&quot;:&quot;Original photograph&quot;}">
             <img id="referenceImg" alt="Film reference" hidden data-i18n-attrs="{&quot;alt&quot;:&quot;Film reference&quot;}">
             <div id="cropLayer">
-              <span class="crop-dimmer crop-dimmer-top" aria-hidden="true"></span>
-              <span class="crop-dimmer crop-dimmer-right" aria-hidden="true"></span>
-              <span class="crop-dimmer crop-dimmer-bottom" aria-hidden="true"></span>
-              <span class="crop-dimmer crop-dimmer-left" aria-hidden="true"></span>
+              <div class="crop-shade" aria-hidden="true">
+                <span class="crop-dimmer crop-dimmer-top"></span>
+                <span class="crop-dimmer crop-dimmer-right"></span>
+                <span class="crop-dimmer crop-dimmer-bottom"></span>
+                <span class="crop-dimmer crop-dimmer-left"></span>
+              </div>
               <div id="cropRect" tabindex="0" role="group" aria-label="Crop selection. Drag to move; use the handles to resize." data-i18n-attrs="{&quot;aria-label&quot;:&quot;Crop selection. Drag to move; use the handles to resize.&quot;}">
                 <span class="crop-handle crop-handle-nw" data-crop-handle="nw" aria-hidden="true"></span>
                 <span class="crop-handle crop-handle-n" data-crop-handle="n" aria-hidden="true"></span>

--- a/web/style.css
+++ b/web/style.css
@@ -704,10 +704,12 @@ input[type=checkbox]:disabled { opacity:.4; }
 #cropLayer { position:absolute; inset:0; z-index:4; display:none; cursor:crosshair; touch-action:none; }
 #cropLayer.on { display:block; }
 .crop-dimmer { position:absolute; background:rgb(var(--crop-dim-rgb,0 0 0) / var(--crop-dim-alpha,.62)); pointer-events:none; }
-.crop-dimmer-top { inset:0 0 auto; height:var(--crop-y,0%); }
-.crop-dimmer-bottom { inset:calc(var(--crop-y,0%) + var(--crop-h,100%)) 0 0; }
-.crop-dimmer-left { left:0; top:var(--crop-y,0%); width:var(--crop-x,0%); height:var(--crop-h,100%); }
-.crop-dimmer-right { left:calc(var(--crop-x,0%) + var(--crop-w,100%)); right:0; top:var(--crop-y,0%); height:var(--crop-h,100%); }
+/* Cover the native preview's outward-rounded frame at fractional photo bounds.
+   Extend only the outside edges so the crop opening and dimmer seams stay put. */
+.crop-dimmer-top { inset:-1px -1px auto; height:calc(var(--crop-y,0%) + 1px); }
+.crop-dimmer-bottom { inset:calc(var(--crop-y,0%) + var(--crop-h,100%)) -1px -1px; }
+.crop-dimmer-left { left:-1px; top:var(--crop-y,0%); width:calc(var(--crop-x,0%) + 1px); height:var(--crop-h,100%); }
+.crop-dimmer-right { left:calc(var(--crop-x,0%) + var(--crop-w,100%)); right:-1px; top:var(--crop-y,0%); height:var(--crop-h,100%); }
 #cropRect {
   position:absolute;
   border:1px solid rgba(255,255,255,.96);

--- a/web/style.css
+++ b/web/style.css
@@ -703,13 +703,15 @@ input[type=checkbox]:disabled { opacity:.4; }
 .speed-hud { position:absolute; z-index:7; top:12px; left:50%; transform:translateX(-50%); padding:6px 12px; border-radius:var(--radius); background:rgba(16,16,16,.8); color:#fff; font-size:12px; font-weight:600; font-variant-numeric:tabular-nums; white-space:pre; pointer-events:none; box-shadow:0 2px 10px rgba(0,0,0,.4); backdrop-filter:blur(6px); }
 #cropLayer { position:absolute; inset:0; z-index:4; display:none; cursor:crosshair; touch-action:none; }
 #cropLayer.on { display:block; }
-.crop-dimmer { position:absolute; background:rgb(var(--crop-dim-rgb,0 0 0) / var(--crop-dim-alpha,.62)); pointer-events:none; }
+.crop-shade { position:absolute; inset:0; opacity:var(--crop-dim-alpha,.62); pointer-events:none; }
+.crop-dimmer { position:absolute; background:rgb(var(--crop-dim-rgb,0 0 0)); pointer-events:none; }
 /* Cover the native preview's outward-rounded frame at fractional photo bounds.
-   Extend only the outside edges so the crop opening and dimmer seams stay put. */
+   Overlap joins outside the crop opening to avoid fractional rasterization gaps.
+   The parent's opacity composites these solid regions once, without dark seams. */
 .crop-dimmer-top { inset:-1px -1px auto; height:calc(var(--crop-y,0%) + 1px); }
 .crop-dimmer-bottom { inset:calc(var(--crop-y,0%) + var(--crop-h,100%)) -1px -1px; }
-.crop-dimmer-left { left:-1px; top:var(--crop-y,0%); width:calc(var(--crop-x,0%) + 1px); height:var(--crop-h,100%); }
-.crop-dimmer-right { left:calc(var(--crop-x,0%) + var(--crop-w,100%)); right:-1px; top:var(--crop-y,0%); height:var(--crop-h,100%); }
+.crop-dimmer-left { left:-1px; top:calc(var(--crop-y,0%) - 1px); width:calc(var(--crop-x,0%) + 1px); height:calc(var(--crop-h,100%) + 2px); }
+.crop-dimmer-right { left:calc(var(--crop-x,0%) + var(--crop-w,100%)); right:-1px; top:calc(var(--crop-y,0%) - 1px); height:calc(var(--crop-h,100%) + 2px); }
 #cropRect {
   position:absolute;
   border:1px solid rgba(255,255,255,.96);


### PR DESCRIPTION
Crop mode could leave a bright strip at the photo's outer edge because the native preview rounds its frame outward. Fractional crop positions also exposed faint horizontal seams where the four shaded regions met.

Extend the outer shading by one CSS pixel, overlap its joins outside the crop opening, and composite opacity on their common parent. This keeps the shading uniform without changing crop geometry, handles, or exported pixels.

Validation: 393 web behavior tests, five crop contract tests, Help tests, and Help/localization checks pass. In the running application with a disposable flat-gray source, seam pixels are uniform at both 1× and 2× display scale; the before/after crop rectangle is identical. Checked crop acceptance, re-entry, rotation, and full-frame Reset. Native visual verification is NOT DONE because this task did not rebuild or foreground the installed app.
