### PR TITLE
Fix absolute photo paths in CLI requests

### DIFF
--- a/lighttable_cli/client.py
+++ b/lighttable_cli/client.py
@@ -70,6 +70,6 @@ class Client:
                              accept="image/*,application/octet-stream")
 
 
-def query(path: str, **values) -> str:
+def query(endpoint: str, **values) -> str:
     present = {key: value for key, value in values.items() if value is not None}
-    return path + ("?" + urllib.parse.urlencode(present) if present else "")
+    return endpoint + ("?" + urllib.parse.urlencode(present) if present else "")

--- a/tests/test_cli_selectors.py
+++ b/tests/test_cli_selectors.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+from urllib.parse import parse_qs, urlsplit
+
+from lighttable_cli.selectors import resolve_reference
+
+
+class AbsolutePhotoReferenceTests(unittest.TestCase):
+    def test_absolute_photo_path_reaches_resolver_without_corrupting_query(self):
+        client = mock.Mock()
+        client.get.return_value = {"name": "3:Photo #1 & café.CR3"}
+        path = "/Pictures/Photo #1 & café.CR3"
+
+        self.assertEqual(resolve_reference(client, path), ["3:Photo #1 & café.CR3"])
+
+        client.get.assert_called_once()
+        request = urlsplit(client.get.call_args.args[0])
+        self.assertEqual(request.path, "/api/resolve")
+        self.assertEqual(parse_qs(request.query), {"path": [path]})
+
+    def test_qualified_catalog_reference_does_not_call_path_resolver(self):
+        client = mock.Mock()
+        self.assertEqual(resolve_reference(client, "3:field.jpg"), ["3:field.jpg"])
+        client.get.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CLI commands using an absolute photo path failed before reaching the server because the URL helper’s `path` argument collided with the resolver’s `path` query parameter. Renaming the helper’s endpoint argument restores absolute-path resolution, including filenames with spaces, Unicode, and URL punctuation.

Validation: the new resolver regression tests and existing CLI installation tests pass (6 tests); all 58 Help articles retain current source anchors and reviewed versions. Found during validation of the initial macOS beta package.
