### PR TITLE
Use peach highlights without active button borders by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,10 @@ the existing tester forward. Its color picker and hex field update selections an
 active controls immediately; switching borders off leaves active button text
 and icons colored, without their fill or border. Photo selection outlines,
 semantic color swatches, and keyboard focus outlines remain available. Test
-settings stay in the current webview/browser origin's local storage; Reset
-restores the normal palette and borders. Escape or Close closes the tester;
-closing the editor also closes it. The testing controls remain English-only and
+settings stay in the current webview/browser origin's local storage. Fresh
+settings and Reset use the default highlight color #f9c184 with active-button
+borders off; saved appearance choices still take precedence. Escape or Close
+closes the tester; closing the editor also closes it. The testing controls remain English-only and
 absent from product menus and Help.
 Browser sessions use a separate popup; Windows and Linux desktop shells retain
 the existing inline tester under Ctrl-D.

--- a/tests/appearance-tester.test.mjs
+++ b/tests/appearance-tester.test.mjs
@@ -3,8 +3,7 @@ import assert from 'node:assert/strict';
 import {createAppearanceSettings} from '../web/appearance-tester.js';
 
 // Independent window state with queued cross-window messages, as in WebKit.
-function windows({storageAvailable = true, broadcastAvailable = true} = {}) {
-  let saved = null;
+function windows({storageAvailable = true, broadcastAvailable = true, saved = null} = {}) {
   const clients = [], channels = [], messages = [];
   return {
     flush() { while (messages.length) messages.shift()(); },
@@ -41,6 +40,8 @@ for (const options of [{}, {storageAvailable:false}, {broadcastAvailable:false}]
   test(`a separate tester updates the editor and retains settings after reopening ${JSON.stringify(options)}`, () => {
     const session = windows(options), editor = session.open(), tester = session.open();
     session.flush();
+    assert.deepEqual(editor.get(), {color:'#f9c184', borders:false});
+    assert.deepEqual(tester.get(), editor.get());
     tester.set({color:'#33CC99', borders:false});
     session.flush();
     assert.deepEqual(editor.get(), {color:'#33cc99', borders:false});
@@ -50,11 +51,25 @@ for (const options of [{}, {storageAvailable:false}, {broadcastAvailable:false}]
     assert.deepEqual(reopened.get(), editor.get());
     reopened.reset();
     session.flush();
-    assert.deepEqual(editor.get(), {color:null, borders:true});
+    assert.deepEqual(editor.get(), {color:'#f9c184', borders:false});
     assert.deepEqual(tester.get(), {color:'#33cc99', borders:false});
     editor.close(); reopened.close();
   });
 }
+
+test('saved choices override the defaults, and corrupt storage falls back safely', () => {
+  for (const [saved, expected] of [
+    [JSON.stringify({color:'#1144AA',borders:true}), {color:'#1144aa',borders:true}],
+    ['invalid json', {color:'#f9c184',borders:false}],
+    [JSON.stringify({color:'invalid',borders:'invalid'}), {color:'#f9c184',borders:false}],
+  ]) {
+    const editor = windows({saved}).open();
+    assert.deepEqual(editor.get(), expected);
+    editor.reset();
+    assert.deepEqual(editor.get(), {color:'#f9c184',borders:false});
+    editor.close();
+  }
+});
 
 test('an opening-window snapshot cannot undo an immediate color change', () => {
   const session = windows({storageAvailable:false}), editor = session.open();

--- a/web/appearance-tester-inline.js
+++ b/web/appearance-tester-inline.js
@@ -1,13 +1,6 @@
 // Preserve the existing tester in desktop shells without managed utility windows.
+import {isAppearanceColor, normalizeAppearance} from './appearance-tester.js';
 const STORAGE_KEY = 'lighttable.appearance-test.v1';
-const HEX = /^#[0-9a-f]{6}$/i;
-
-function normalizeAppearance(value) {
-  return {
-    color: typeof value?.color === 'string' && HEX.test(value.color) ? value.color.toLowerCase() : null,
-    borders: value?.borders !== false,
-  };
-}
 
 export function installAppearanceTester() {
   if (document.getElementById('appearanceTestDialog')) return;
@@ -53,7 +46,7 @@ export function installAppearanceTester() {
     root.toggleAttribute('data-appearance-no-borders', !settings.borders);
   };
   const sync = () => {
-    picker.value = settings.color || '#4b9cf5';
+    picker.value = settings.color;
     hex.value = picker.value;
     hex.removeAttribute('aria-invalid');
     borders.checked = settings.borders;
@@ -74,7 +67,7 @@ export function installAppearanceTester() {
   });
   hex.addEventListener('input', () => {
     const value = hex.value.trim();
-    const valid = HEX.test(value);
+    const valid = isAppearanceColor(value);
     hex.setAttribute('aria-invalid', String(!valid));
     if (!valid) return;
     settings.color = value.toLowerCase();

--- a/web/appearance-tester-window.js
+++ b/web/appearance-tester-window.js
@@ -1,11 +1,11 @@
-import {applyAppearance, createAppearanceSettings, normalizeAppearance} from './appearance-tester.js';
+import {applyAppearance, createAppearanceSettings, isAppearanceColor} from './appearance-tester.js';
 
 const picker = document.getElementById('appearanceTestColor');
 const hex = document.getElementById('appearanceTestHex');
 const borders = document.getElementById('appearanceTestBorders');
 const sync = value => {
   applyAppearance(document.documentElement, value);
-  picker.value = value.color || '#4b9cf5';
+  picker.value = value.color;
   hex.value = picker.value;
   hex.removeAttribute('aria-invalid');
   borders.checked = value.borders;
@@ -13,9 +13,10 @@ const sync = value => {
 const settings = createAppearanceSettings({onChange: sync});
 picker.addEventListener('input', () => settings.set({...settings.get(), color: picker.value}));
 hex.addEventListener('input', () => {
-  const color = normalizeAppearance({color: hex.value.trim()}).color;
-  hex.setAttribute('aria-invalid', String(!color));
-  if (color) settings.set({...settings.get(), color});
+  const color = hex.value.trim();
+  const valid = isAppearanceColor(color);
+  hex.setAttribute('aria-invalid', String(!valid));
+  if (valid) settings.set({...settings.get(), color});
 });
 hex.addEventListener('blur', () => sync(settings.get()));
 borders.addEventListener('change', () => settings.set({...settings.get(), borders: borders.checked}));

--- a/web/appearance-tester.css
+++ b/web/appearance-tester.css
@@ -1,5 +1,5 @@
-/* Override both the default palette and Linux's scoped desktop palette only
-   while a test color is set. Reset removes the attributes and restores both. */
+/* Apply the default highlight color or a saved appearance experiment to both
+   the base palette and Linux's scoped desktop palette. */
 :root[data-appearance-color],
 :root[data-appearance-color] :is(.topbar,.left-panel,.right-shell,.modal,.context-menu,.dd-menu,.setup-window,.help-panel,.view-options-popover,.library-filter-panel) {
   --accent:var(--appearance-accent);

--- a/web/appearance-tester.js
+++ b/web/appearance-tester.js
@@ -2,11 +2,16 @@
 const STORAGE_KEY = 'lighttable.appearance-test.v1';
 const CHANNEL_NAME = 'lighttable-appearance-test';
 const HEX = /^#[0-9a-f]{6}$/i;
+export const DEFAULT_APPEARANCE = Object.freeze({color: '#f9c184', borders: false});
+
+export function isAppearanceColor(value) {
+  return typeof value === 'string' && HEX.test(value);
+}
 
 export function normalizeAppearance(value) {
   return {
-    color: typeof value?.color === 'string' && HEX.test(value.color) ? value.color.toLowerCase() : null,
-    borders: value?.borders !== false,
+    color: isAppearanceColor(value?.color) ? value.color.toLowerCase() : DEFAULT_APPEARANCE.color,
+    borders: typeof value?.borders === 'boolean' ? value.borders : DEFAULT_APPEARANCE.borders,
   };
 }
 
@@ -38,7 +43,7 @@ export function createAppearanceSettings({win = window, onChange = () => {}} = {
     receivedUpdate = true;
     receive(value);
     try {
-      if (settings.color === null && settings.borders) win.localStorage.removeItem(STORAGE_KEY);
+      if (settings.color === DEFAULT_APPEARANCE.color && settings.borders === DEFAULT_APPEARANCE.borders) win.localStorage.removeItem(STORAGE_KEY);
       else win.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
     } catch (_) {}
     channel?.postMessage({type: 'settings', settings});


### PR DESCRIPTION
Fresh appearance settings now use the requested peach highlight (`#f9c184`) with active-button borders off. Reset restores those defaults, while existing saved color and border choices remain in effect. The separate tester and inline fallback share the same defaults and reject invalid hex input.

Validation: all 415 web tests pass, including settings synchronization, reopening, reset, saved preferences, and corrupt-storage fallback. Help, localization, and dynamic-message checks pass. In the running isolated app, verified peach highlights and borderless active Fit/Remove controls before opening the tester, custom settings synchronized across windows, invalid hex stayed unapplied, and Reset restored the defaults immediately.
