### PR TITLE
Validate signed Windows candidates on Windows 10, 11 and ARM

### DIFF
--- a/.github/workflows/windows-client-vm.yml
+++ b/.github/workflows/windows-client-vm.yml
@@ -1,0 +1,136 @@
+name: Windows client VM acceptance
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [codex/windows-client-acceptance]
+    paths:
+      - .github/workflows/windows-client-vm.yml
+      - scripts/windows/client-vm/**
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  client:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        windows: ['10', '11']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify the selected release build
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: 34408107209});
+            if (run.conclusion !== 'success' || run.head_sha !== '2e4d35d64dc09a35ec2262c1ca9c65bfa44c4912'
+                || run.path !== '.github/workflows/windows-build.yml') {
+              throw new Error('The selected signed candidate build identity is incorrect');
+            }
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: LightTable-windows-x64
+          path: .build/windows-client-download
+          run-id: 34408107209
+          github-token: ${{ github.token }}
+
+      - name: Parse Windows test scripts
+        shell: pwsh
+        run: |
+          $Failed = $false
+          foreach ($File in Get-ChildItem scripts/windows -Filter *.ps1 -Recurse) {
+            $Tokens = $null; $Errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($File.FullName, [ref]$Tokens, [ref]$Errors) | Out-Null
+            if ($Errors.Count) { $Errors | Format-List; $Failed = $true }
+          }
+          if ($Failed) { throw "PowerShell test scripts contain syntax errors" }
+
+      - name: Stage a fresh Microsoft evaluation VM
+        env:
+          WINDOWS_VERSION: ${{ matrix.windows }}
+        run: |
+          set -euo pipefail
+          test -c /dev/kvm
+          # Disposable hosted runner only; reclaim unused SDKs for the VM disk.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          python3 scripts/windows/client-vm/prepare.py "$WINDOWS_VERSION"
+          mkdir -p .build/client-vm/evidence .build/client-vm/storage
+          if [[ "$WINDOWS_VERSION" == 10 ]]; then
+            iso='https://software-static.download.prss.microsoft.com/dbazure/988969d5-f34g-4e03-ac9d-1f9786c66750/19045.2006.220908-0225.22h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso'
+            digest='ef7312733a9f5d7d51cfa04ac497671995674ca5e1058d5164d6028f0938d668'
+          else
+            iso='https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso'
+            digest='a61adeab895ef5a4db436e0a7011c92a2ff17bb0357f58b13bbc4062e535e7b9'
+          fi
+          curl --fail --location --retry 2 --max-time 600 "$iso" -o .build/client-vm/windows.iso
+          echo "$digest  .build/client-vm/windows.iso" | sha256sum --check
+          printf '%s\n' "$iso" "$digest" > .build/client-vm/evidence/media.txt
+          df -h .
+
+      - name: Boot Windows and run offline client acceptance
+        run: |
+          set -euo pipefail
+          root="$PWD/.build/client-vm"
+          docker run --detach --name lighttable-client --stop-timeout 30 \
+            --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN \
+            -e RAM_SIZE=8G -e CPU_CORES=4 -e DISK_SIZE=64G -e DISK_FMT=qcow2 \
+            -e DISK_TYPE=sata -e ADAPTER=e1000 -e NETWORK=user -e SAMBA=N \
+            -e BOOT_MODE=windows_secure -e TPM=Y -e VGA=std -e REMOVE=N -e VERSION=${{ matrix.windows }}e \
+            -v "$root/storage:/storage" -v "$root/windows.iso:/custom.iso:ro" \
+            -v "$root/custom.xml:/custom.xml:ro" -v "$root/oem:/oem:ro" \
+            -v "$root/evidence:/evidence" \
+            -v "$PWD/scripts/windows/client-vm/receive.py:/receive.py:ro" \
+            dockurr/windows@sha256:32cc92715a6c5dc1f63142d3be11059279d64d0faa7519618a07290b3076f9f2
+          docker exec -d lighttable-client python3 /receive.py
+          deadline=$((SECONDS + 2700))
+          while (( SECONDS < deadline )); do
+            if [[ -f "$root/evidence/complete" ]]; then break; fi
+            if [[ "$(docker inspect --format '{{.State.Running}}' lighttable-client)" != true ]]; then
+              docker logs --tail 80 lighttable-client
+              exit 1
+            fi
+            sleep 10
+          done
+          test -f "$root/evidence/complete"
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('.build/client-vm/evidence')
+          host = json.loads((root / 'host.json').read_text(encoding='utf-8-sig'))
+          print(json.dumps(host, indent=2))
+          if not host.get('ok'):
+              raise SystemExit('Windows client setup failed; see host.json')
+          result = json.loads((root / 'result.json').read_text(encoding='utf-8-sig'))
+          print(json.dumps(result, indent=2))
+          if not result.get('ok'):
+              raise SystemExit('Windows client acceptance failed; see result.json')
+          if not host.get('webview2_absent_before_offline_install'):
+              raise SystemExit('Offline runtime-present checks passed, but WebView2-absent acceptance remains unproven')
+          PY
+
+      - name: Stop the disposable VM
+        if: always()
+        run: |
+          mkdir -p .build/client-vm/evidence
+          if docker inspect lighttable-client >/dev/null 2>&1; then
+            docker logs lighttable-client > .build/client-vm/evidence/vm.log 2>&1
+            docker stop --time 30 lighttable-client || true
+            docker rm -f lighttable-client || true
+          fi
+          # Do not upload account configuration, VM disks, or Windows media.
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Windows-${{ matrix.windows }}-x64-client-acceptance
+          path: .build/client-vm/evidence/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/windows-client-vm.yml
+++ b/.github/workflows/windows-client-vm.yml
@@ -70,7 +70,15 @@ jobs:
             iso='https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso'
             digest='a61adeab895ef5a4db436e0a7011c92a2ff17bb0357f58b13bbc4062e535e7b9'
           fi
-          curl --fail --location --retry 2 --max-time 600 "$iso" -o .build/client-vm/windows.iso
+          # Microsoft throttles large single-stream downloads. Use four bounded
+          # connections and verify the complete image before starting the VM.
+          if ! command -v aria2c >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y aria2
+          fi
+          timeout 1200 aria2c --max-connection-per-server=4 --split=4 --min-split-size=16M \
+            --max-tries=3 --timeout=30 --retry-wait=5 --summary-interval=30 \
+            --file-allocation=none --dir=.build/client-vm --out=windows.iso "$iso"
           echo "$digest  .build/client-vm/windows.iso" | sha256sum --check
           printf '%s\n' "$iso" "$digest" > .build/client-vm/evidence/media.txt
           df -h .

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -7,11 +7,33 @@ on:
         description: Windows build run containing a successfully built LightTable-windows-x64 artifact
         required: true
         type: string
+      runner:
+        description: Windows Server x64 or Windows 11 ARM (x64 application under emulation)
+        required: false
+        default: windows-2022
+        type: choice
+        options:
+          - windows-2022
+          - windows-11-arm
+      installer_sha256:
+        description: Independently verified signed installer SHA-256; enables installer acceptance
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       build_run_id:
         description: Windows build run containing a successfully built LightTable-windows-x64 artifact
         required: true
+        type: string
+
+      runner:
+        required: false
+        default: windows-2022
+        type: string
+      installer_sha256:
+        required: false
+        default: ''
         type: string
 
 permissions:
@@ -20,8 +42,8 @@ permissions:
 
 jobs:
   native:
-    runs-on: windows-2022
-    timeout-minutes: 10
+    runs-on: ${{ inputs.runner || 'windows-2022' }}
+    timeout-minutes: 25
     steps:
       - name: Check out the dispatched native tester
         uses: actions/checkout@v4
@@ -66,7 +88,33 @@ jobs:
             core.setOutput('source_sha', run.head_sha);
             core.info(`Tester ${context.sha}; package source ${run.head_sha}; build run ${run_id}`);
 
+      - name: Record and verify Windows test host
+        shell: pwsh
+        env:
+          EXPECTED_RUNNER: ${{ inputs.runner || 'windows-2022' }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $OS = Get-CimInstance Win32_OperatingSystem
+          $Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+          @{
+            caption = $OS.Caption
+            version = $OS.Version
+            build = $OS.BuildNumber
+            product_type = $OS.ProductType
+            os_architecture = $Arch
+            application_architecture = "x64"
+            execution = $(if ($Arch -eq "Arm64") { "x64 emulation" } else { "native x64" })
+            image_version = $env:ImageVersion
+            runner = $env:EXPECTED_RUNNER
+            fresh_offline_webview2_absent_test = $false
+          } | ConvertTo-Json | Set-Content .build/windows-native-recheck-evidence/host.json
+          if ($env:EXPECTED_RUNNER -eq "windows-11-arm" -and
+              ($OS.ProductType -ne 1 -or [int]$OS.BuildNumber -lt 22000 -or $Arch -ne "Arm64")) {
+            throw "Expected a Windows 11 ARM client host"
+          }
+
       - name: Download the selected Windows package
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: LightTable-windows-x64
@@ -75,7 +123,42 @@ jobs:
           run-id: ${{ inputs.build_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Check the signed installer on the selected host
+        if: inputs.installer_sha256 != ''
+        shell: pwsh
+        env:
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
+          BUNDLE_SOURCE_SHA: ${{ steps.selected.outputs.source_sha }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $Report = @{ok = $false; installer_sha256 = $env:INSTALLER_SHA256}
+          try {
+            if ($env:INSTALLER_SHA256 -cnotmatch '^[0-9a-f]{64}$') { throw "Expected a SHA-256 digest" }
+            $Receipt = Get-Content .build/windows-native-download/store-candidate-receipt.json -Raw | ConvertFrom-Json
+            $Installers = @(Get-ChildItem .build/windows-native-download -Filter '*-setup.exe')
+            if ($Installers.Count -ne 1) { throw "Expected one installer" }
+            $Installer = $Installers[0]
+            if ((Get-FileHash $Installer.FullName -Algorithm SHA256).Hash.ToLowerInvariant() -cne $env:INSTALLER_SHA256) {
+              throw "Installer differs from the independently verified candidate"
+            }
+            $Signature = Get-AuthenticodeSignature $Installer.FullName
+            if ($Signature.Status -ne 'Valid') { throw "Installer signature is not valid" }
+            $Report.signer = $Signature.SignerCertificate.Subject
+            $Version = [regex]::Match($Installer.Name, '^LightTable-([0-9]+\.[0-9]+\.[0-9]+)-windows-x64-setup\.exe$').Groups[1].Value
+            if (-not $Version) { throw "Installer filename does not contain a stable version" }
+            $Report.version = $Version
+            & ./scripts/windows/installer-smoke.ps1 -Installer $Installer.FullName -Version $Version -ExpectedPublisher 'Chonkers LLC' -VerifyStoreSignatures -SignatureReport .build/windows-native-recheck-evidence/installed-signatures.json
+            if ($LASTEXITCODE -ne 0) { throw "Installer acceptance failed" }
+            $Report.ok = $true
+          } catch {
+            $Report.error = $_.Exception.Message
+            throw
+          } finally {
+            $Report | ConvertTo-Json -Depth 5 | Set-Content .build/windows-native-recheck-evidence/installer.json
+          }
+
       - name: Verify bundle identity and run native acceptance
+        if: ${{ !cancelled() && steps.download.conclusion == 'success' }}
         shell: pwsh
         env:
           BUNDLE_SOURCE_SHA: ${{ steps.selected.outputs.source_sha }}

--- a/docs/windows-client-acceptance.md
+++ b/docs/windows-client-acceptance.md
@@ -1,0 +1,31 @@
+# Windows client acceptance
+
+The signed Windows 0.5.1 candidate can be tested without rebuilding or changing its release bytes. Keep the package source commit separate from the tester commit.
+
+## Windows 11 ARM
+
+Dispatch `windows-native.yml` with `runner=windows-11-arm`, the completed Windows build run ID, and the independently verified installer SHA-256. The workflow records the real OS/CPU, verifies the installer, exercises install/reinstall/CLI/data-preserving uninstall, and runs the extracted portable app's editing, restart and 16-bit TIFF export journey.
+
+This tests the x64 application under Windows 11 ARM emulation. It does not create or prove a native ARM64 package. The hosted image has administrator privileges and preinstalled software; it does not establish fresh offline prerequisite installation or physical GPU/display behavior.
+
+## Windows 10 and 11 x64
+
+`windows-client-vm.yml` boots two fresh Microsoft Enterprise evaluation images on disposable GitHub Linux runners with KVM. This initial workflow intentionally pins the verified 0.5.1 build, installer digest, OS media URLs/checksums, and VM container digest. Review and change all candidate pins together for a future release.
+
+The VM setup uses a minimal custom unattended configuration and does not run the container's default Windows customization script. Windows UAC, firewall and Defender defaults remain in place. No VM ports are published, no GitHub credentials enter the guest, and only public application/test files are staged. An ephemeral local account exists only within the disposable guest; its generated configuration and VM disks are never uploaded.
+
+The elevated setup phase records the real OS/build, attempts WebView2 removal using Microsoft's own uninstaller, and checks the signed installer before disconnecting. This online certificate-chain check is recorded; it does not claim a completely cold certificate cache. It then disables all active network adapters and launches acceptance with the logged-on account's limited token. The test refuses to run elevated or with an active adapter.
+
+`installer-smoke.ps1 -NativeAcceptanceReport ...` checks the actual installed GUI through `desktop-smoke.py`, then verifies repair, CLI registration and data-preserving uninstall. The new `--allow-disposable-direct-install` option is only for a disposable test account: a direct install can alter that account's WinSparkle preferences. The default desktop smoke still rejects direct installs, and package-manager-owned installs remain rejected even with the option.
+
+The setup phase restores networking only after the tests finish, returns bounded evidence to a receiver inside the VM container, and shuts down Windows. Jobs have a 60-minute cap and always stop/remove the container. There is no paid VM provisioning.
+
+## Interpreting evidence
+
+- `host.json`: actual OS/CPU, UAC, runtime absence, network disconnection, online signature check and setup failures.
+- `result.json`: limited-token install/repair/CLI/uninstall result and exact installer digest.
+- `native/report.json`: installed shell, rendering, edit persistence across restart, HTTP health and TIFF export results.
+- `installed-signatures.json`: Authenticode evidence for the installed native payload, including its uninstaller.
+- `vm.log`: VM setup diagnostics. Review raw artifacts before sharing them publicly.
+
+A job cannot pass the missing-prerequisite gate unless WebView2 was genuinely absent before offline installation. If the vendor's uninstaller cannot remove a built-in runtime, report that boundary rather than deleting detection keys. A virtual software-rendered desktop is useful client compatibility evidence; it is not a physical GPU/color/HDR/performance benchmark. Same-version reinstall is not a signed old-to-new updater journey.

--- a/scripts/windows/client-vm/bootstrap.ps1
+++ b/scripts/windows/client-vm/bootstrap.ps1
@@ -1,0 +1,74 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Root = 'C:\OEM'
+$Evidence = Join-Path $Root 'evidence'
+New-Item -ItemType Directory -Force $Evidence | Out-Null
+$Adapters = @()
+$HostReport = @{ok = $false; bootstrap_error = $null; evaluation_vm = $true}
+try {
+    & icacls.exe $Root /grant ($env:USERNAME + ':(OI)(CI)M') /T /Q | Out-Null
+    $OS = Get-CimInstance Win32_OperatingSystem
+    $Config = Get-Content (Join-Path $Root 'candidate.json') -Raw | ConvertFrom-Json
+    $HostReport.caption = $OS.Caption
+    $HostReport.build = $OS.BuildNumber
+    $HostReport.product_type = $OS.ProductType
+    $HostReport.architecture = $env:PROCESSOR_ARCHITECTURE
+    $HostReport.expected_windows = $Config.windows
+    $HostReport.graphics = @(Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion)
+    $HostReport.uac_enabled = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System').EnableLUA
+    if ($OS.ProductType -ne 1 -or $env:PROCESSOR_ARCHITECTURE -ne 'AMD64') { throw 'Expected an x64 Windows client' }
+    if (($Config.windows -eq '11') -ne ([int]$OS.BuildNumber -ge 22000)) { throw 'Windows client version mismatch' }
+    . (Join-Path $Root 'scripts/ensure-webview2.ps1')
+    $HostReport.webview2_initially_present = Test-WebView2Runtime
+    # Use the vendor uninstaller only. Never fake absence by deleting registry keys.
+    if ($HostReport.webview2_initially_present) {
+        $Setups = @(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft\EdgeWebView\Application\*\Installer\setup.exe" -ErrorAction SilentlyContinue)
+        foreach ($Setup in $Setups) {
+            $Process = Start-Process $Setup.FullName -ArgumentList '--uninstall --msedgewebview --system-level --force-uninstall' -PassThru
+            if (-not $Process.WaitForExit(120000)) { $Process.Kill(); throw 'WebView2 removal timed out' }
+        }
+    }
+    $HostReport.webview2_absent_before_offline_install = -not (Test-WebView2Runtime)
+    # Verify the original file before disconnecting; record this trust-cache warmup.
+    $Installer = Join-Path $Root $Config.installer
+    if ((Get-FileHash $Installer -Algorithm SHA256).Hash.ToLowerInvariant() -cne $Config.installer_sha256) { throw 'Installer hash mismatch' }
+    $Signature = Get-AuthenticodeSignature $Installer
+    $HostReport.installer_signature_before_disconnect = $Signature.Status.ToString()
+    $HostReport.certificate_chain_checked_online_before_test = $true
+    if ($Signature.Status -ne 'Valid') { throw 'Installer signature is not trusted on the fresh client' }
+    $Adapters = @(Get-NetAdapter | Where-Object Status -eq 'Up')
+    $Adapters | Disable-NetAdapter -Confirm:$false
+    $HostReport.network_adapters_disabled = $true
+    # FirstLogonCommands is elevated. Schedule the test in the logged-on user's
+    # limited token so per-user installation is tested without administrator rights.
+    $Action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoLogo -NoProfile -ExecutionPolicy Bypass -File C:\OEM\guest-test.ps1'
+    $Principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited
+    $Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 20)
+    Register-ScheduledTask -TaskName 'LightTableClientAcceptance' -Action $Action -Principal $Principal -Settings $Settings -Force | Out-Null
+    Start-ScheduledTask -TaskName 'LightTableClientAcceptance'
+    $Deadline = (Get-Date).AddMinutes(20)
+    while ((Get-Date) -lt $Deadline -and -not (Test-Path (Join-Path $Root 'test.done'))) { Start-Sleep -Seconds 5 }
+    if (-not (Test-Path (Join-Path $Root 'test.done'))) { throw 'Client acceptance exceeded twenty minutes' }
+    $HostReport.ok = $true
+} catch {
+    $HostReport.bootstrap_error = $_.Exception.Message
+} finally {
+    foreach ($Adapter in $Adapters) { $Adapter | Enable-NetAdapter -Confirm:$false -ErrorAction Continue }
+    Stop-ScheduledTask -TaskName 'LightTableClientAcceptance' -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName 'LightTableClientAcceptance' -Confirm:$false -ErrorAction SilentlyContinue
+    $HostReport | ConvertTo-Json -Depth 8 | Set-Content (Join-Path $Evidence 'host.json') -Encoding utf8
+    # The receiver is private to the VM container, with no published port.
+    # Upload bounded test evidence only, never the Windows image or account file.
+    for ($Attempt = 0; $Attempt -lt 12; $Attempt++) {
+        try {
+            foreach ($File in Get-ChildItem $Evidence -Recurse -File) {
+                if ($File.Extension -notin @('.json', '.png', '.log', '.tif') -or $File.Length -gt 16MB) { continue }
+                $Relative = $File.FullName.Substring($Evidence.Length + 1).Replace('\', '/')
+                Invoke-WebRequest -UseBasicParsing -Method Put -Uri ('http://10.0.2.2:18080/' + $Relative) -InFile $File.FullName -TimeoutSec 20 | Out-Null
+            }
+            Invoke-WebRequest -UseBasicParsing -Method Put -Uri 'http://10.0.2.2:18080/complete' -Body 'done' -TimeoutSec 10 | Out-Null
+            break
+        } catch { Start-Sleep -Seconds 5 }
+    }
+    shutdown.exe /s /t 10
+}

--- a/scripts/windows/client-vm/guest-test.ps1
+++ b/scripts/windows/client-vm/guest-test.ps1
@@ -1,0 +1,26 @@
+param([string]$Root = 'C:\OEM')
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Evidence = Join-Path $Root 'evidence'
+New-Item -ItemType Directory -Force $Evidence | Out-Null
+$Report = @{ok = $false; offline = $true; account_is_elevated = $false}
+try {
+    $Principal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    $Report.account_is_elevated = $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if ($Report.account_is_elevated) { throw 'Installer acceptance must run unelevated' }
+    if (@(Get-NetAdapter | Where-Object Status -eq 'Up').Count) { throw 'A network adapter is still enabled' }
+    $Config = Get-Content (Join-Path $Root 'candidate.json') -Raw | ConvertFrom-Json
+    $Installer = Join-Path $Root $Config.installer
+    if ((Get-FileHash $Installer -Algorithm SHA256).Hash.ToLowerInvariant() -cne $Config.installer_sha256) {
+        throw 'Installer hash mismatch'
+    }
+    $Report.installer_sha256 = $Config.installer_sha256
+    & (Join-Path $Root 'scripts/installer-smoke.ps1') -Installer $Installer -Version $Config.version -ExpectedPublisher 'Chonkers LLC' -VerifyStoreSignatures -SignatureReport (Join-Path $Evidence 'installed-signatures.json') -NativeAcceptanceReport (Join-Path $Evidence 'native')
+    if ($LASTEXITCODE -ne 0) { throw 'Installer or installed desktop acceptance failed' }
+    $Report.ok = $true
+} catch {
+    $Report.error = $_.Exception.Message
+} finally {
+    $Report | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $Evidence 'result.json') -Encoding utf8
+    Set-Content (Join-Path $Root 'test.done') 'done'
+}

--- a/scripts/windows/client-vm/prepare.py
+++ b/scripts/windows/client-vm/prepare.py
@@ -1,0 +1,106 @@
+"""Stage only the verified candidate and test scripts for an ephemeral Windows VM."""
+from pathlib import Path
+import hashlib
+import json
+import secrets
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+
+version = sys.argv[1]
+if version not in ('10', '11'):
+    raise SystemExit('Expected Windows 10 or 11')
+root = Path('.build/client-vm')
+oem = root / 'oem'
+oem.mkdir(parents=True, exist_ok=True)
+download = Path('.build/windows-client-download')
+installer = download / 'LightTable-0.5.1-windows-x64-setup.exe'
+expected = 'a8fea5bf5fe7d5fde3fea3af4b20577a59fe887869d8170a67df5d641527ffd1'
+with installer.open('rb') as source:
+    actual = hashlib.file_digest(source, 'sha256').hexdigest()
+if actual != expected:
+    raise SystemExit('Signed candidate installer does not match the verified SHA-256')
+shutil.copy2(installer, oem / installer.name)
+shutil.copytree('scripts/windows', oem / 'scripts', ignore=shutil.ignore_patterns('client-vm', '__pycache__'))
+for name in ('guest-test.ps1', 'bootstrap.ps1'):
+    shutil.copy2(Path('scripts/windows/client-vm') / name, oem / name)
+(oem / 'candidate.json').write_text(json.dumps({
+    'version': '0.5.1', 'windows': version, 'installer': installer.name,
+    'installer_sha256': expected,
+    'source_sha': '2e4d35d64dc09a35ec2262c1ca9c65bfa44c4912',
+}), encoding='utf-8')
+
+# Minimal unattended Windows setup: preserve Defender, firewall, UAC and OS
+# requirements. No Dockur customization script or security bypass is staged.
+ns = 'urn:schemas-microsoft-com:unattend'
+wcm = 'http://schemas.microsoft.com/WMIConfig/2002/State'
+ET.register_namespace('', ns)
+ET.register_namespace('wcm', wcm)
+def add(parent, tag, value=None, **attributes):
+    item = ET.SubElement(parent, '{'+ns+'}'+tag, attributes)
+    if value is not None:
+        item.text = str(value)
+    return item
+def component(parent, name):
+    return add(parent, 'component', name=name, processorArchitecture='amd64',
+               publicKeyToken='31bf3856ad364e35', language='neutral', versionScope='nonSxS')
+def locale(parent, winpe=False):
+    c = component(parent, 'Microsoft-Windows-International-Core' + ('-WinPE' if winpe else ''))
+    if winpe:
+        add(add(c, 'SetupUILanguage'), 'UILanguage', 'en-US')
+    for field, value in [('InputLocale','0409:00000409'),('SystemLocale','en-US'),('UILanguage','en-US'),('UserLocale','en-US')]:
+        add(c, field, value)
+tree = ET.Element('{'+ns+'}unattend')
+pe = add(tree, 'settings', **{'pass': 'windowsPE'})
+locale(pe, True)
+setup = component(pe, 'Microsoft-Windows-Setup')
+disk = add(add(setup, 'DiskConfiguration'), 'Disk', **{'{'+wcm+'}action':'add'})
+add(disk, 'DiskID', 1)
+add(disk, 'WillWipeDisk', 'true')
+create = add(disk, 'CreatePartitions')
+modify = add(disk, 'ModifyPartitions')
+for order, kind, size, label, fmt in [(1,'EFI',128,'System','FAT32'),(2,'MSR',16,None,None),(3,'Primary',None,'Windows','NTFS')]:
+    part = add(create, 'CreatePartition', **{'{'+wcm+'}action':'add'})
+    add(part, 'Order', order); add(part, 'Type', kind)
+    add(part, 'Size' if size else 'Extend', size if size else 'true')
+    part = add(modify, 'ModifyPartition', **{'{'+wcm+'}action':'add'})
+    add(part, 'Order', order); add(part, 'PartitionID', order)
+    if label:
+        add(part, 'Label', label); add(part, 'Format', fmt)
+    if order == 3:
+        add(part, 'Letter', 'C')
+image = add(add(setup, 'ImageInstall'), 'OSImage')
+install = add(image, 'InstallTo')
+add(install, 'DiskID', 1); add(install, 'PartitionID', 3)
+metadata = add(add(image, 'InstallFrom'), 'MetaData', **{'{'+wcm+'}action':'add'})
+add(metadata, 'Key', '/IMAGE/INDEX'); add(metadata, 'Value', '1')
+user = add(setup, 'UserData')
+add(user, 'AcceptEula', 'true')
+add(user, 'FullName', 'LightTable Test')
+add(user, 'Organization', 'Chonkers LLC')
+add(add(setup, 'DynamicUpdate'), 'Enable', 'false')
+oobe = add(tree, 'settings', **{'pass':'oobeSystem'})
+locale(oobe)
+shell = component(oobe, 'Microsoft-Windows-Shell-Setup')
+password = secrets.token_urlsafe(32)
+accounts = add(add(shell, 'UserAccounts'), 'LocalAccounts')
+account = add(accounts, 'LocalAccount', **{'{'+wcm+'}action':'add'})
+add(account, 'Name', 'LightTableTest'); add(account, 'Group', 'Administrators')
+def set_password(parent):
+    node = add(parent, 'Password')
+    add(node, 'Value', password); add(node, 'PlainText', 'true')
+set_password(account)
+autologon = add(shell, 'AutoLogon')
+add(autologon, 'Username', 'LightTableTest'); add(autologon, 'Enabled', 'true'); add(autologon, 'LogonCount', 1)
+set_password(autologon)
+settings = add(shell, 'OOBE')
+for key in ('HideEULAPage', 'HideOEMRegistrationScreen', 'HideOnlineAccountScreens', 'HideWirelessSetupInOOBE'):
+    add(settings, key, 'true')
+add(settings, 'ProtectYourPC', 1)
+command = add(add(shell, 'FirstLogonCommands'), 'SynchronousCommand', **{'{'+wcm+'}action':'add'})
+add(command, 'Order', 1)
+add(command, 'CommandLine', 'powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File C:\\OEM\\bootstrap.ps1')
+add(command, 'Description', 'Run isolated LightTable client acceptance')
+ET.ElementTree(tree).write(root / 'custom.xml', encoding='utf-8', xml_declaration=True)
+(root / 'custom.xml').chmod(0o600)
+print('Staged verified installer and disposable Windows', version, 'configuration')

--- a/scripts/windows/client-vm/receive.py
+++ b/scripts/windows/client-vm/receive.py
@@ -1,0 +1,31 @@
+"""Bounded evidence receiver, listening inside a disposable VM container only."""
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import time
+
+ROOT = Path('/evidence')
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_PUT(self):
+        relative = self.path.lstrip('/')
+        path = (ROOT / relative).resolve()
+        size = int(self.headers.get('Content-Length', '0'))
+        if not path.is_relative_to(ROOT) or size > 16 * 1024 * 1024:
+            self.send_error(400)
+            return
+        if relative != 'complete' and path.suffix not in ('.json', '.png', '.log', '.tif'):
+            self.send_error(400)
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.rfile.read(size))
+        self.send_response(200)
+        self.end_headers()
+
+
+server = HTTPServer(('0.0.0.0', 18080), Handler)
+server.timeout = 5
+deadline = time.monotonic() + 3300
+while time.monotonic() < deadline and not (ROOT / 'complete').exists():
+    server.handle_request()
+server.server_close()

--- a/scripts/windows/desktop-smoke.py
+++ b/scripts/windows/desktop-smoke.py
@@ -60,12 +60,13 @@ def validate_paths(report: dict, root: Path, bundle: Path) -> None:
         raise RuntimeError("The native shell is not using the packaged resources")
 
 
-def validate_bundle(bundle: Path) -> None:
+def validate_bundle(bundle: Path, *, allow_disposable_direct_install: bool = False) -> None:
     for relative in ("LightTable.exe", "Python/python.exe", "Resources/LightTable/server.py"):
         if not (bundle / relative).is_file():
             raise RuntimeError(f"The Windows bundle is incomplete: {relative}")
     marker = bundle / "install-channel.txt"
-    if marker.exists() and marker.read_text(encoding="utf-8-sig").strip() != "portable":
+    channel = marker.read_text(encoding="utf-8-sig").strip() if marker.exists() else "portable"
+    if channel != "portable" and not (allow_disposable_direct_install and channel == "direct"):
         # A signed direct install configures WinSparkle's global registry state.
         # Validate the extracted ZIP so this smoke cannot alter that preference.
         raise RuntimeError("Use the extracted portable ZIP, not an installed/package-managed copy")
@@ -569,6 +570,8 @@ def main():
     parser.add_argument("--report-dir", type=Path, help="New directory for JSON evidence, logs and the exported TIFF")
     parser.add_argument("--stack-dumper", type=Path,
                         help="Optional py-spy.exe for failure diagnostics only; adds at most four 5-second dumps without locals")
+    parser.add_argument("--allow-disposable-direct-install", action="store_true",
+                        help="Allow a direct install ONLY in a disposable test account; WinSparkle may change its registry preferences")
     args = parser.parse_args()
     if sys.platform != "win32":
         parser.error("Run with packaged Python in a logged-on Windows desktop")
@@ -576,7 +579,7 @@ def main():
         parser.error("--timeout must be between 60 and 270 seconds, plus at most 25 seconds of cleanup")
     require_interactive_desktop()
     bundle = args.bundle.resolve()
-    validate_bundle(bundle)
+    validate_bundle(bundle, allow_disposable_direct_install=args.allow_disposable_direct_install)
     if Path(sys.executable).resolve() != (bundle / "Python/python.exe").resolve():
         parser.error("Run this script with the tested bundle's Python/python.exe")
     if args.report_dir:

--- a/scripts/windows/installer-smoke.ps1
+++ b/scripts/windows/installer-smoke.ps1
@@ -5,7 +5,8 @@ param(
     [string]$Version,
     [switch]$VerifyStoreSignatures,
     [string]$SignatureReport = "",
-    [string]$ExpectedPublisher = "Nicholas Reville"
+    [string]$ExpectedPublisher = "Nicholas Reville",
+    [string]$NativeAcceptanceReport = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -62,6 +63,10 @@ try {
     }
     if ($VerifyStoreSignatures) {
         & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $InstallPath -Report $SignatureReport
+    }
+    if ($NativeAcceptanceReport) {
+        & (Join-Path $InstallPath "Python/python.exe") -B (Join-Path $PSScriptRoot "desktop-smoke.py") $InstallPath --allow-disposable-direct-install --timeout 270 --report-dir $NativeAcceptanceReport
+        if ($LASTEXITCODE -ne 0) { throw "Installed desktop acceptance failed" }
     }
     $Installed = Get-ItemProperty $RegistryPath
     if ($Installed.DisplayVersion -ne $Version -or $Installed.Publisher -ne $ExpectedPublisher) {

--- a/tests/test_windows_desktop_smoke.py
+++ b/tests/test_windows_desktop_smoke.py
@@ -24,6 +24,22 @@ SPEC.loader.exec_module(smoke)
 
 
 class DesktopSmokeSafetyTests(unittest.TestCase):
+    def test_installed_bundle_requires_explicit_disposable_account_opt_in(self):
+        with tempfile.TemporaryDirectory() as directory:
+            bundle = Path(directory)
+            for relative in ("LightTable.exe", "Python/python.exe", "Resources/LightTable/server.py"):
+                path = bundle / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+            marker = bundle / "install-channel.txt"
+            marker.write_text("direct")
+            with self.assertRaises(RuntimeError):
+                smoke.validate_bundle(bundle)
+            smoke.validate_bundle(bundle, allow_disposable_direct_install=True)
+            marker.write_text("winget")
+            with self.assertRaises(RuntimeError):
+                smoke.validate_bundle(bundle, allow_disposable_direct_install=True)
+
     def test_environment_removes_inherited_overrides_and_isolates_native_support(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Superseded — current results verified September 10, 2026

The Windows ARM tester, installer/native checks, and improved Windows 10/11 VM harness are already integrated through PR #122. ARM x64-emulation acceptance for the signed 0.6.0 candidate passed in [run 34436651354](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34436651354). Its host/source/hash receipts, 421 valid installed signatures, native acceptance and TIFF hash were independently rechecked at closeout.

The newer [Windows 10/11 run 34481336232](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34481336232) passed Windows 10. Windows 11 passed offline unelevated installation, signatures and native edit/export/reopen, but failed the additional WebView2-absent condition because its runtime remained preinstalled. The failed historical 0.5.1 VM run below no longer describes current compatibility evidence.

PR #127 records the current results and remaining Windows release gates. No native ARM64 package or public Windows release is claimed. Closing this old draft as superseded preserves the integrated tester and leaves the unresolved prerequisite-absence and candidate-metadata requirements open.

---

## Historical proposal

Windows release checks previously ran only on Server 2022. This adds Windows 11 ARM emulation checks against an existing signed installer and fresh Windows 10/11 x64 evaluation VMs for offline, unelevated installer and installed-app acceptance.

The initial VM test pins the exact signed 0.5.1 installer, its successful source build, Microsoft evaluation media and the VM container. It preserves Windows security defaults, avoids exposing guest ports or GitHub credentials, records runtime absence and certificate-cache warmup, and stops every VM within a bounded job. Test documentation explains the remaining physical GPU and updater-journey limits.

Validation: workflow actionlint passed; PowerShell parsing passed on the hosted Linux runners; desktop smoke unit checks passed (28 tests, 4 Windows-only skips on macOS). Windows 11 ARM run 34412728826 passed installer, all 421 PE signatures, reinstall/CLI/uninstall, and portable edit/export/restart checks. Windows 10/11 x64 run 34413321346 is in progress; its result will be added before merge.
