### PR TITLE
Prevent image stretching during rotation

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -22,7 +22,7 @@
       "sources": {
         "film_lab_ai/culling.py": "08cb4e9ebda9ca5285422eab7c0be5938dd0a63c7bfefa3a22218ea3ed93773b",
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/cull-batch.js": "f22524c715dcccbf0f0870cc464d5f45f328bcb20bb2e6793285dbe7a7ba9b87",
         "web/cull-similarity.js": "55d00a5f2a99b89f0ce1b140271af396872cbc9510e37404474be4b6ad4b6d13",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
@@ -33,7 +33,7 @@
       "content": "adad5fd0f7d571ac3e11bd2ec2005da6630e2096c0ea6a75d9f3ed1d6be82b0e",
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/catalog-ui.js": "69693678ddbd446410d205aa89a7dfc59a66a2ee599c4b9680edd8a131b098d7",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
@@ -64,14 +64,14 @@
     "collections": {
       "content": "95bc3775974e6454f3d55661cf2db268196f4d73750fb1ba7f796bb23379cd36",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
     "colour-labels": {
       "content": "37ab0eedcaafc31195b889c3e9f9f05d1478b3045e0b5c91f540eedb45a4e083",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -85,7 +85,7 @@
     "editing-color-mixer-point-color": {
       "content": "9cfba81ef549fe43a8d1e2dc1ed7c7cc660202b4f2a640506af71f8e59fb0d7e",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -94,7 +94,7 @@
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
         "server.py": "cfaa6688ea4524d0c665f979c31e7caac0b4f876576202770de300a34867097a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/edit-transfer.js": "6f7e1d200278b43e8bf4beb76c86fc579eff508ac7cebc925e9ab4f782f334bd",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
@@ -109,7 +109,7 @@
     "editing-curves": {
       "content": "a2280ce4abd9f79d1c1e6d0673c3d2ef6015fb01a14e4385e3c8621bd6b13a54",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -118,7 +118,7 @@
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
         "enhance_workflow.py": "b2b3fe529770388b3c4bf04345bf995a6d9a70ef866a5e917313f8b3de72506a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/enhance-panel.js": "6efc59ea9686bf72062453c76d61a9a09ad86511b4d9737e8ba95409fd95daa7",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
@@ -127,14 +127,14 @@
       "content": "e65c38833c6557b83b0e471394ed3d4fda54c7e44a5a7f4cba7a7e25fd04df71",
       "sources": {
         "grade.py": "397ec8660d16bb7a4228328af13351460f72dbec27488397d5e19eefca69f439",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
     "editing-history-snapshots": {
       "content": "86dc3f8196fa62cc452db8d0cf86e40f2fe2450a1c8166cfe812177272853273",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/history-panel.js": "5f7a77338be697479c921dc76a9668e7846c50e75cab47bfd634dfe924faec25",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
@@ -142,7 +142,7 @@
     "editing-lens-corrections": {
       "content": "f762cdbf87f331ba924707d70b72ad271cc9bed2ab8403bbcc1b6df99276af31",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -150,7 +150,7 @@
       "content": "56f05787225ee65832eb9b7efbbc8305e4ef20a984c3b80b750523758095945c",
       "sources": {
         "semantic_masks.py": "d48eb799d0c3188d4dc48a573d193eec94fc087b4eb9fba9560ed41b8de585f7",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -158,7 +158,7 @@
       "content": "42ec3fba1017b0aa9669ce55654b4a33b354cce19ff79c9234b67947680e3fb9",
       "sources": {
         "edits.py": "d5d4f776bd589a74234f8c4a07317d09af499f4dc92d0bc595ba5b0c8fb5d4db",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/editor-panels.js": "9e3f72ac779699ea3ed2cb16f587d85810e6cff16dabfffeb068af8ee9135a5f",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/mask-curve.js": "f7a3d8fc5c1a87ae11ae0068347fbc161e6b181490195aeacd33cf00c354bd55",
@@ -170,7 +170,7 @@
     "editing-masks-ranges-refinements": {
       "content": "69559a947ccd17ddcf891ab7791585d708eaa3b452ac32e1fe6fee456fe90167",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/mask-raster.js": "5e4de2a78c2b50efd88001f154160ca59f38dfb444f71e4b9aa1231026fdf254"
       }
@@ -181,7 +181,7 @@
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
         "merge_workflow.py": "fd18f0129c707fd2236a0cc9a931f2c99a3c00434830f7c258c913b6127b9719",
         "server.py": "cfaa6688ea4524d0c665f979c31e7caac0b4f876576202770de300a34867097a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -194,7 +194,7 @@
         "preset_submission.py": "d0880b6df5b1d4fd31fc845cc8353da883f45ab430c00ee9faa3d403082ea5ca",
         "presets/builtin.json": "63d61a02335908284ced8e79b201d519adfb0b2b191e0d025a4d5c1010074c2d",
         "server.py": "cfaa6688ea4524d0c665f979c31e7caac0b4f876576202770de300a34867097a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/numeric-controls.js": "16bbb9018aa330965d4cc670ee9cf9356fe766ca1c8762458450af1ae206e4bc",
         "web/preset-amount.js": "f92e745b76a829d2e3f048360f345a265af0a2d5ddef44dcb3789c49ce1b90be",
@@ -208,7 +208,7 @@
       "content": "3d70eb73feed29823cf507dacaaefa5e836efbeda3815657693341cdb79c297d",
       "sources": {
         "app/NativePreview.metal": "45aa8ae595982903f61554d60f6da370d0e77e905fad335f7ba9e250f0daaa02",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/screen-overlay.js": "506b41925988e0fd95edbf4bc7a4ea634366d8bcc3d969e2ad20a94f35081097"
@@ -217,21 +217,21 @@
     "editing-save-recovery": {
       "content": "5ea77476828b252a78757b30d827464a516994d3c1cf84a3a6041bec601e2b2d",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/edit-save-queue.js": "f93aa9eb304dea08f65e05c9b7a3e36b645e42bf7b34499469e51cf446372859"
       }
     },
     "editing-tone": {
       "content": "2e83d0be17ae55ef2edbd5cb335d18e9d96de22d032056f3dc9027bbe48fc35d",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
     "editing-white-balance": {
       "content": "f6b3b37c291e9d60356355f3668f15990e40995bedc9062c9a67a3da9425e271",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -239,7 +239,7 @@
       "content": "007309327e1d2aa65e1c38fea9ce0347ee5b343c9a12b881419000c5ccd44999",
       "sources": {
         "export_workflow.py": "d2435a3e70ff3f2915d2b21b9940ba7cdf1a85a6deb7d5f91e0762cf9f4e5206",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -247,7 +247,7 @@
       "content": "5945724f1f5a9ad80dabdbb9b1943978a77aa5a373366307f8acc38aabd165f0",
       "sources": {
         "export_workflow.py": "d2435a3e70ff3f2915d2b21b9940ba7cdf1a85a6deb7d5f91e0762cf9f4e5206",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -262,14 +262,14 @@
       "content": "dbb37c4fdeb501f59294843e33d6aea92727bd952e76e11978a4a14af5535086",
       "sources": {
         "server.py": "cfaa6688ea4524d0c665f979c31e7caac0b4f876576202770de300a34867097a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
     "external-editor": {
       "content": "905a7f2d9fc297adb88b6aa0c2f0f5bf7b21513ca1db891c3b7a3bf137aac2de",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "windows-shell/src/main.rs": "99cc679b03302d0757da3e714c36077a923feb68dcc58b8490d492131fdfadee"
       }
@@ -277,7 +277,7 @@
     "film-exposure-and-processing": {
       "content": "7e395ef5e25bfefb2dd6fa21a8cd0be4cf096a07263f501b2d59fd321fa5cb46",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
@@ -286,7 +286,7 @@
       "content": "2ea19e843ce9c9a59afd0e8d2e0a3dd7927a6e7a413dc92a9b64c23f328516b6",
       "sources": {
         "film_tuning.py": "133a5e3200b69b2aa3b92f8bb471c93af449b5036bb8dfdd6610292175693860",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/style.css": "022755cd7acd15f32bc3bf4b68a4d85d8702d739a68e17cb51fcd5c7722e2003"
@@ -303,7 +303,7 @@
       "content": "78653d9b4be06ab3ad3357a96ba37a5691ec354181728c00953b54f21bf8fe4c",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
@@ -311,7 +311,7 @@
       "content": "54fd041aeb76d0acaf7428a3b9abea93e0382e8edc33effe895f0760dea943e0",
       "sources": {
         "film_pipeline.py": "9399c7765e076628cc5f74fe5bccd067729d577379952713e45cb9df4db982e4",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/film-browser.js": "64b42debb4610e5e6fc509e9d7b6b4444801bd01be1eefa0691cd5206f109234",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
@@ -319,14 +319,14 @@
     "film-reference-match": {
       "content": "8437ebbf70a45113536776e64be01fe91134024b82ba03807b1c0453a2a2719f",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
     "flags-and-ratings": {
       "content": "ce54b73eb484c64611a90f2203be69d11519bbcc23622c992284d11ef6d64b36",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
     },
@@ -353,7 +353,7 @@
       "content": "afa81f9e0bf349d0df5d83bf5a2b09497fd62c2c0ecc69fa629d2fa04382fdf0",
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/midi.js": "a74a05ad2303790b15efaf9953afcf60f20ccfabf4d4f8bde7ae2eb99c834175"
       }
@@ -363,7 +363,7 @@
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
         "keyword_workflow.py": "5c545bd45205bf294d15cddbaf43f27a39ad5c30b69e7f98fab579d2b61a73a4",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/keyword-batch.js": "e38195a5528e40635522473776ba9b0a2052f11a78ac77fb7cfe81fa3cc8a88e",
         "web/metadata-panel.js": "d6be67c2b0b58d543fabee1349bab40bbe40afffb5fe2ecd4414d7c996f69cda"
       }
@@ -389,7 +389,7 @@
         "media_availability.py": "c450d7734d3e39f2c9bb6c5e39c855374ee4e03d6947c299315f558072aca25e",
         "merge_acceleration.py": "3d87500b5ee5222f111cbf6edb99b9136720475466b7300c0b15920729de4f01",
         "server.py": "cfaa6688ea4524d0c665f979c31e7caac0b4f876576202770de300a34867097a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/gl.js": "2fd8424ee799b4fa17b924abf0dde58f818b4a3f294b466e97388401b381884a",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/preview-detail.js": "8601034c83de06c042fdd5528d7fde5ff69db567bdac7225f3b133b739836acc",
@@ -407,7 +407,7 @@
         "film_lab_ai/providers.py": "f3851032bf587133001bd03def0ec960c8906bea27c8c02888f8ded606f15927",
         "film_lab_ai/service.py": "fd684477d966d1014c1b72cb843871379db98b41fb800ec9f98a8d75c1eea842",
         "media_availability.py": "c450d7734d3e39f2c9bb6c5e39c855374ee4e03d6947c299315f558072aca25e",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/local-ai.js": "63ea7c3f284a620a51c17cae0ec96a7c4764073a9be698090b20cd20731fc786",
         "web/style.css": "022755cd7acd15f32bc3bf4b68a4d85d8702d739a68e17cb51fcd5c7722e2003"
@@ -416,7 +416,7 @@
     "raw-jpeg-pairs": {
       "content": "63ef5d08a8d6515e2677eb9344c41edafd7d2b2266703648040f4080033691b2",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/photo-pairs.js": "555822d1f88b09cc2ec316f2a7e1665f78721b8dab2053a97d9600550895a6d5"
       }
@@ -434,7 +434,7 @@
       "sources": {
         "catalog_scan.py": "adf3bc5e57ed9590756399aeb846ec97a2eb48decb1e2a34a84099326e9d4233",
         "dam_filters.py": "7190afdfe5aba3bd715ae281782a7fc966783aa4699ae3190e7eee058ae8bc0d",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/library-filters.js": "6b31fd6d3de54f3ce2f4846fb272faa277b10ccdad10737942176d667191f4c0",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8",
@@ -470,7 +470,7 @@
     "shortcut-schemes": {
       "content": "e6cf59f5fde950bf351b74084189c3d6fb585b9ef8f86c78a01c82db94da584d",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/labels.js": "4c9d878761970ccb1973ce5bd9d0df2b346463438132707778e6de16796520aa"
       }
@@ -479,7 +479,7 @@
       "content": "9b7e47fe1ac1a2ae85a54070f12b51d8876a2d4497b5f3dc3c0857cca2e1da6b",
       "sources": {
         "catalog.py": "812605b71f6905db85883a4cfdfb56cb8043d238030a976b891c168f70d4882f",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/library.js": "224f647c4d20a2c6efd65711391be3792ba01f4140ff392cd72b9032c059e4a8"
       }
     },
@@ -487,14 +487,14 @@
       "content": "667d42680ff9d3d60918660cb348f4d0add54a7577d29d9db4a20a48495425f0",
       "sources": {
         "soft_proof.py": "9d353ea6ba4bd911103632ec7e0463e08e8edf2679baa71fe24afd73d920e3aa",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90"
       }
     },
     "survey-photos": {
       "content": "1769c5e6c33849b62cd8407e16ceb7ae8f211b4a61d15f73fb7ca1a7933a3c15",
       "sources": {
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/survey.js": "79fd7a71ef314f25e5a6452f9def6d5edeac62799fd1305631f1607724363cc3"
       }
     },
@@ -503,7 +503,7 @@
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
         "server.py": "cfaa6688ea4524d0c665f979c31e7caac0b4f876576202770de300a34867097a",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "windows-shell/src/main.rs": "99cc679b03302d0757da3e714c36077a923feb68dcc58b8490d492131fdfadee"
       }
     },
@@ -511,7 +511,7 @@
       "content": "975a9835dec5975f6ab32385f01a8236fc962cdb8e94825a690a31adb8432c32",
       "sources": {
         "app/main.swift": "a2ab1ba64049c5c8d4d9c9e5d2559ae3a768add56bef8acb8868cf8ac5919764",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8",
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d",
         "web/compare-view.js": "c5e9aaaafaed1faa2dae944be7c6cc6a1774ef0eb0c8ce6a241edab5bee223e8",
         "web/index.html": "28544ca24f7bca7dd7faa73e985b4e88f05e6c22c1bf120a73da9a9a0a63cc90",
         "web/photo-pan.js": "5da50f7d5a650b4150b36fc3899d7a0f78cdbefcd79144b52ae2635112b845e8",
@@ -523,7 +523,7 @@
       "content": "de9620831ddcd8ecee7ce1f29fa1442122cfe5fa8183c0650ee8b3b34210d498",
       "sources": {
         "library_workflow.py": "b07bc79b58666fe92ce189ac4132a6904457e166f73c155f3f636fc683966e3c",
-        "web/app.js": "fcb478febfafa12b9fed3aedbd36540d62f041dc0345409b3093acfb966062c8"
+        "web/app.js": "79761f64cedb55a12d3220dff4b96d215433f30aca6edda5898e40dbf6b4440d"
       }
     },
     "xmp-interchange": {

--- a/tests/rotation-presentation.test.mjs
+++ b/tests/rotation-presentation.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../web/app.js', import.meta.url), 'utf8');
+function install(context, names) {
+  for (const name of names) {
+    vm.runInNewContext(source.match(new RegExp(`^function ${name}\\([^]*?^}$`, 'm'))[0], context);
+  }
+}
+
+function scene() {
+  const style = {setProperty(name, value) { this[name] = value; }};
+  const canvas = {width:1200, height:800};
+  const frame = {style, classList:{toggle() {}}};
+  const context = {
+    S:{params:{rotate:0}},
+    $:id => ({cv:canvas, cmp:frame,
+      zoomwrap:{getBoundingClientRect:() => ({width:900, height:600})}}[id]),
+    cur:() => ({name:'landscape.jpg', width:6000, height:4000}),
+    previewCrop:() => null, cropViewState:() => ({}), scheduleNativeViewportLayout() {},
+  };
+  install(context, ['cropSourceSize', 'cropViewportSize', 'syncCropPresentationNow']);
+  const aspect = () => parseFloat(style.width) / parseFloat(style.height);
+  return {context, canvas, aspect};
+}
+
+test('rotation keeps displayed pixels proportional while each quarter-turn render is pending', () => {
+  const {context, canvas, aspect} = scene();
+  for (const rotation of [90,180,270,0,270,180,90,0]) {
+    context.S.params.rotate = rotation;
+    context.syncCropPresentationNow();
+    assert.equal(aspect(), canvas.width / canvas.height, 'pending pixels must not stretch');
+    canvas.width = rotation % 180 ? 800 : 1200;
+    canvas.height = rotation % 180 ? 1200 : 800;
+    context.syncCropPresentationNow();
+    assert.equal(aspect(), canvas.width / canvas.height, 'new frame must fit the uploaded orientation');
+  }
+});
+
+test('cropped and actively cropping frames retain the displayed source aspect during rotation', () => {
+  const {context, canvas, aspect} = scene();
+  context.S.params.rotate = 90;
+  context.previewCrop = () => ({x:0.2,y:0.1,w:0.5,h:0.75});
+  context.syncCropPresentationNow();
+  assert.equal(aspect(), (canvas.width * 0.5) / (canvas.height * 0.75));
+  context.previewCrop = () => null;
+  context.S.cropping = true;
+  context.S.zoom = 1.4;
+  context.syncCropPresentationNow();
+  assert.equal(aspect(), canvas.width / canvas.height);
+});
+
+test('native geometry waits for its texture and the swap carries the final crop layout', async () => {
+  const {context, canvas} = scene();
+  const events = [], pending = new Map();
+  let displayed = {width:1200,height:800};
+  let frozen = false;
+  let cropScheduled = false;
+  Object.assign(context, {
+    performance:{now:() => 0}, window:{}, nativePreviewPending:pending,
+    packedMaskData:{}, GRADE_DEFAULTS:{},
+    postNative(command, payload) {
+      events.push({command,payload});
+      if (command === 'nativeNavigate') frozen = true;
+    },
+    applyCropVisual() { cropScheduled = true; },
+    cropFrameScheduler:{flush() { if (cropScheduled) context.syncCropPresentationNow(); }},
+    drawGrade() {}, buildMaskTexture:() => ({}), nativeMaskPayload:() => ({}),
+    nativeEditsPayload:() => ({}), scheduleNativeHelper() {}, originalPreviewURL:() => '/original',
+    nativeViewportPayload:() => ({canvas:{width:parseFloat(context.$('cmp').style.width),
+      height:parseFloat(context.$('cmp').style.height)}}),
+    scheduleNativeViewportLayout() {
+      if (!frozen) displayed = {width:canvas.width,height:canvas.height};
+    },
+  });
+  install(context, ['setNativeBaseImage']);
+  context.syncCropPresentationNow();
+  context.S.params.rotate = 90;
+  const result = context.setNativeBaseImage({native:{url:'/rotated',width:800,height:1200}}, 7);
+  assert.deepEqual(displayed, {width:1200,height:800}, 'old drawable stays at its old dimensions while loading');
+  assert.equal(events[0].command, 'nativeNavigate');
+  const swap = events.find(event => event.command === 'nativePreview');
+  assert.equal(swap.payload.canvas.width / swap.payload.canvas.height, 2/3);
+  assert.equal(swap.payload.generation, 7);
+  pending.get(7).resolve({presentation:'native-metal'});
+  assert.equal((await result).presentation, 'native-metal');
+});
+
+test('browser texture upload and frame orientation change in the same callback', async () => {
+  const {context, canvas, aspect} = scene();
+  const img = {naturalWidth:800,naturalHeight:1200};
+  context.syncCropPresentationNow();
+  context.S.params.rotate = 90;
+  context.S.seq = 8;
+  context.S.gl = {
+    cachedImage:() => img,
+    setImage(image) {
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      return {textureCacheHit:true};
+    },
+  };
+  Object.assign(context, {
+    performance:{now:() => 0},
+    installBrowserOriginal() {}, installBrowserReference() {}, drawGrade() {},
+    scheduleHistogram() {}, applyCropVisual() {},
+    cropFrameScheduler:{flush:() => context.syncCropPresentationNow()},
+  });
+  install(context, ['setWebGLBaseImage']);
+  await context.setWebGLBaseImage('/rotated', {generation:8});
+  assert.equal(aspect(), 2/3, 'frame must match new pixels without waiting for another animation frame');
+});

--- a/tests/test_crop_preview_contracts.py
+++ b/tests/test_crop_preview_contracts.py
@@ -31,13 +31,22 @@ class CropPreviewContractTests(unittest.TestCase):
                       self.javascript)
         for selector in ("#cv", "#orig", "#referenceImg"):
             self.assertIn(f".cmp.preview-framed > {selector}", self.css)
-        self.assertIn("const source = cropSourceSize();", self.javascript)
         self.assertIn(
             "wrap.width, wrap.height, source.width, source.height, frameCrop",
             self.javascript,
         )
         self.assertIn("const frame = $('cmp').getBoundingClientRect()",
                       self.javascript)
+
+    def test_rotation_presentation(self):
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("Node.js is required for rotation presentation checks")
+        result = subprocess.run(
+            [node, "--test", "tests/rotation-presentation.test.mjs"],
+            cwd=ROOT, capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_crop_viewport_and_compare_mapping_math(self):
         node = shutil.which("node")

--- a/web/app.js
+++ b/web/app.js
@@ -4086,11 +4086,16 @@ function setNativeBaseImage(render, generation, { preserveCanvasSize = false } =
   const canvasHeight = surface.viewport?.fullHeight || surface.height;
   if (canvasWidth > 0 && canvasHeight > 0 && !preserveCanvasSize) {
     if ($('cv').width !== canvasWidth || $('cv').height !== canvasHeight) {
+      // Keep the old drawable at its existing size until nativePreview installs
+      // the new texture and viewport together. Layout messages can otherwise
+      // stretch the previous orientation while this surface is still loading.
+      postNative('nativeNavigate', { generation });
       S.maskTextureDirty = true;
       $('cv').width = canvasWidth;
       $('cv').height = canvasHeight;
     }
     applyCropVisual();
+    cropFrameScheduler.flush();
     if (S.maskTextureDirty) drawGrade();
   }
   scheduleNativeViewportLayout();
@@ -4253,6 +4258,9 @@ function setWebGLBaseImage(dataUri, {
       } else drawGrade();
       scheduleHistogram(true);
       applyCropVisual();
+      // The upload changes the canvas orientation now; do not leave its CSS
+      // frame at the old aspect until the next animation-frame callback.
+      cropFrameScheduler.flush();
       res({ decodeMs: uploadStartedAt - startedAt,
         uploadMs: uploadedAt - uploadStartedAt, uploadedAt, textureCacheHit });
     };
@@ -6361,7 +6369,9 @@ function syncCropPresentationNow() {
   }
 
   const frameCrop = crop || { x: 0, y: 0, w: 1, h: 1 };
-  const source = cropSourceSize();
+  // Crop constraints use the requested orientation, but the visible frame must
+  // follow the pixels already uploaded. Rotation renders arrive asynchronously.
+  const source = { width: canvas.width, height: canvas.height };
   const viewport = cropViewportSize(
     wrap.width, wrap.height, source.width, source.height, frameCrop);
   if (viewport) {


### PR DESCRIPTION
Rotating a photo briefly resized the visible frame before the rotated pixels arrived, stretching the old image. Keep the frame proportional to the displayed canvas, then update the frame with the texture swap. The native handoff holds the previous drawable until its replacement is ready.

Adds four regression tests covering both rotation directions, crop framing, and native/browser handoffs. All four fail against the previous implementation. Help source reviews are current; user instructions and translated copy are unchanged.

Validation:
- 430 JavaScript tests passed.
- Full Python suite ran 1,899 tests with 41 skips. Five environment-related errors passed on focused rerun using the existing interpreter and LittleCMS library.
- Help build/check and all 19 localized Help catalogs passed.
- Hidden browser checks sampled 1,078 animation frames across clockwise and counterclockwise rotations with delayed renders; no distorted frames.
- Native on-screen rotation verification was not performed because it would interrupt the desktop. Background native regression checks passed.
