### PR TITLE
Validate public 0.6 upgrades and matching Arch packages

### DIFF
--- a/.github/workflows/arch-vm-release.yml
+++ b/.github/workflows/arch-vm-release.yml
@@ -1,10 +1,14 @@
 name: Arch virtual GPU acceptance
 on:
-  push:
-    branches: [codex/arch-omarchy-release-20260909]
   workflow_dispatch:
+    inputs:
+      package_run_id:
+        description: Completed Arch release acceptance run containing the packages to test
+        required: true
+        type: string
 permissions:
   contents: read
+  actions: read
 concurrency:
   group: arch-vm-${{ github.ref }}
   cancel-in-progress: true
@@ -20,6 +24,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: LightTable-${{ matrix.distribution }}-acceptance
+          path: baseline
+          run-id: ${{ inputs.package_run_id }}
+          github-token: ${{ github.token }}
       - name: Boot Arch with a virtual graphics device and test Hyprland
         env:
           DISTRIBUTION: ${{ matrix.distribution }}

--- a/.github/workflows/linux-release-acceptance.yml
+++ b/.github/workflows/linux-release-acceptance.yml
@@ -1,0 +1,42 @@
+name: Linux release acceptance
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+jobs:
+  public-upgrade:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare a fresh Ubuntu VM and download the public release
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgtk-3-0 libwebkit2gtk-4.1-0 libxdo3 libopenblas0 libgfortran5 libvulkan1 mesa-vulkan-drivers liblcms2-2 xvfb xauth dbus-x11 imagemagick xdg-utils desktop-file-utils gvfs
+          mkdir -p baseline candidate evidence
+          curl --fail --location --retry 2 --max-time 180 -o baseline/LightTable-0.5.0-linux-x86_64.tar.gz https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-linux-x86_64.tar.gz
+          echo "eaf1fb58d038d7260473343ab3bb64a3101ab5d180c09020af80b08929343f01  LightTable-0.5.0-linux-x86_64.tar.gz" > baseline/baseline.sha256
+          curl --fail --location --retry 2 --max-time 180 -o candidate/LightTable-0.6.0-linux-x86_64.tar.gz https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz
+          curl --fail --location --retry 2 --max-time 30 -o candidate/LightTable-0.6.0-linux-x86_64.tar.gz.sha256 https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz.sha256
+          curl --fail --location --retry 2 --max-time 30 -o evidence/linux-x86_64.json https://github.com/reville/lighttable-digital-darkroom/releases/download/desktop-updates/linux-x86_64.json
+          (cd candidate && sha256sum -c *.sha256)
+          (cd baseline && sha256sum -c *.sha256)
+          tar -xzf candidate/*.tar.gz -C candidate
+          tar -xzf baseline/*.tar.gz -C baseline
+      - name: Validate the downloaded release runtime on a fresh VM
+        run: |
+          candidate/LightTable/Python/bin/python3 -B candidate/LightTable/runtime-smoke.py candidate/LightTable > evidence/public-runtime.json
+      - name: Install a production-signed upgrade through the public HTTPS feed
+        run: |
+          timeout 480s xvfb-run -a --server-args='-screen 0 1280x900x24' dbus-run-session -- \
+            baseline/LightTable/Python/bin/python3 scripts/linux/release-update-acceptance.py baseline/LightTable \
+              --target-archive candidate/LightTable-0.6.0-linux-x86_64.tar.gz --target-feed evidence/linux-x86_64.json --live-download \
+              > evidence/public-upgrade.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Linux-public-release-acceptance
+          path: evidence
+          if-no-files-found: error

--- a/packaging/linux/arch/release/.SRCINFO
+++ b/packaging/linux/arch/release/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lighttable-bin
 	pkgdesc = Photo editing and film simulation
-	pkgver = 0.5.0
+	pkgver = 0.6.0
 	pkgrel = 1
 	url = https://github.com/reville/lighttable-digital-darkroom
 	arch = x86_64
@@ -26,13 +26,13 @@ pkgbase = lighttable-bin
 	optdepends = xdg-desktop-portal-hyprland: Hyprland and Omarchy desktop portal
 	optdepends = xdg-desktop-portal-gtk: file chooser portal for desktops without one
 	optdepends = vulkan-driver: hardware acceleration with the driver for your GPU
-	provides = lighttable=0.5.0
+	provides = lighttable=0.6.0
 	conflicts = lighttable
 	options = !strip
 	options = !debug
-	source = https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-linux-x86_64.tar.gz
+	source = https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz
 	source = app.lighttable.LightTable.desktop
-	sha256sums = eaf1fb58d038d7260473343ab3bb64a3101ab5d180c09020af80b08929343f01
+	sha256sums = 4b116ac098df209a3c755ef751e19ed226da5621d9238f9c2bb3dbe94fe020f5
 	sha256sums = 7da0e45fb5201961f26b9227f29b3d46f6ef38604158c3f4f7fb4f80c7d0c7dd
 
 pkgname = lighttable-bin

--- a/packaging/linux/arch/release/PKGBUILD
+++ b/packaging/linux/arch/release/PKGBUILD
@@ -1,6 +1,6 @@
 # Generated from a verified official release archive; SHA-256 pins its exact bytes.
 pkgname=lighttable-bin
-pkgver=0.5.0
+pkgver=0.6.0
 pkgrel=1
 pkgdesc='Photo editing and film simulation'
 arch=(x86_64)
@@ -16,8 +16,8 @@ provides=("lighttable=$pkgver")
 conflicts=('lighttable')
 # Preserve the exact Python and native binaries that passed bundle validation.
 options=('!strip' '!debug')
-source=(https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-linux-x86_64.tar.gz 'app.lighttable.LightTable.desktop')
-sha256sums=(eaf1fb58d038d7260473343ab3bb64a3101ab5d180c09020af80b08929343f01 7da0e45fb5201961f26b9227f29b3d46f6ef38604158c3f4f7fb4f80c7d0c7dd)
+source=(https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz 'app.lighttable.LightTable.desktop')
+sha256sums=(4b116ac098df209a3c755ef751e19ed226da5621d9238f9c2bb3dbe94fe020f5 7da0e45fb5201961f26b9227f29b3d46f6ef38604158c3f4f7fb4f80c7d0c7dd)
 
 check() {
   desktop-file-validate "$srcdir/app.lighttable.LightTable.desktop"

--- a/scripts/linux/arch-release-desktop.sh
+++ b/scripts/linux/arch-release-desktop.sh
@@ -53,6 +53,6 @@ else
   python -c 'import json; errors=json.load(open("evidence/hyprland/config-errors.json")); assert isinstance(errors,list) and not any(str(error).strip() for error in errors), errors'
 fi
 /opt/lighttable/Python/bin/python3 -B scripts/linux/arch-desktop-acceptance.py /opt/lighttable \
-  --source be537f2f3e2e431ae6b42af716c2a8b365f57bab --backend "$backend" --film \
-  --package /work/dist/lighttable-bin-0.5.0-1-x86_64.pkg.tar.zst \
+  --source 0ae5e9aaf90b3554ad1d027d5b6b10667cd61ae2 --backend "$backend" --film \
+  --package /work/dist/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst \
   --fixtures demo-assets/cc0-raw/files --output "evidence/$backend"

--- a/scripts/linux/arch-release-vm.sh
+++ b/scripts/linux/arch-release-vm.sh
@@ -2,13 +2,10 @@
 # Disposable full-system VM; its SSH port listens only on runner loopback.
 set -euo pipefail
 mkdir -p evidence baseline/dist /tmp/lighttable-vm
-package=lighttable-bin-0.5.0-1-x86_64.pkg.tar.zst
-release=https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0
-curl -fsSL --retry 2 --max-time 180 "$release/$package" -o "baseline/dist/$package"
-curl -fsSL --retry 2 --max-time 30 "$release/$package.sha256" -o "baseline/dist/$package.sha256"
-(cd baseline/dist && sha256sum -c "$package.sha256")
-printf '28cfccff38e2de1955c1b899d64c6066fef1fc64f2f97de4437657e2285f84d8  %s\n' "baseline/dist/$package" | sha256sum -c -
-cp "baseline/dist/$package.sha256" evidence/public-package.sha256
+package=lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst
+test -f "baseline/dist/$package"
+(cd baseline && sha256sum -c dist/SHA256SUMS)
+sha256sum "baseline/dist/$package" > evidence/tested-package.sha256
 vm=/tmp/lighttable-vm
 image=Arch-Linux-x86_64-cloudimg.qcow2
 curl -fsSL --retry 2 --max-time 180 "https://geo.mirror.pkgbuild.com/images/latest/$image" -o "$vm/$image"
@@ -54,5 +51,5 @@ for attempt in $(seq 1 90); do
 done
 "${remote[@]}" 'cloud-init status --wait; mkdir -p /work/dist /work/evidence; ls -l /dev/dri; uname -a'
 tar -czf - --exclude=.git --exclude=baseline --exclude=evidence . | "${remote[@]}" 'tar -xzf - -C /work'
-cat baseline/dist/lighttable-bin-0.5.0-1-x86_64.pkg.tar.zst | "${remote[@]}" 'cat > /work/dist/lighttable-bin-0.5.0-1-x86_64.pkg.tar.zst'
+cat baseline/dist/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst | "${remote[@]}" 'cat > /work/dist/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst'
 "${remote[@]}" "cd /work && DISTRIBUTION=$DISTRIBUTION VM_GPU=1 REUSE_PACKAGE=1 bash scripts/linux/arch-release-container.sh" > evidence/guest.log 2>&1

--- a/scripts/linux/release-desktop-acceptance.py
+++ b/scripts/linux/release-desktop-acceptance.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Temporary release tester; the downloaded application bytes remain unchanged."""
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+from urllib.parse import urlencode
+
+
+def load(path):
+    spec = importlib.util.spec_from_file_location('acceptance', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('bundle', type=Path)
+    parser.add_argument('--source', required=True)
+    parser.add_argument('--backend', choices=['x11', 'wayland'], required=True)
+    parser.add_argument('--fixtures', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--film', action='store_true')
+    args = parser.parse_args()
+    bundle, output = args.bundle.resolve(), args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    a = load(Path(__file__).with_name('desktop-acceptance.py'))
+    build = a.validate_bundle(bundle, args.source)
+    environment = a.isolated_environment
+    def env(root):
+        values = environment(root)
+        values['GDK_BACKEND'] = args.backend
+        if args.backend == 'wayland':
+            values.pop('DISPLAY', None)
+        return values
+    a.isolated_environment = env
+    def screenshot(path):
+        if args.backend == 'wayland':
+            subprocess.run(['grim', str(path)], check=True, timeout=10)
+        else:
+            subprocess.run(['import', '-window', 'root', str(path)], check=True, timeout=10)
+    if args.backend == 'wayland':
+        def normal_close(process, server_pid, deadline):
+            tree = json.loads(subprocess.check_output(['swaymsg', '-t', 'get_tree', '-r'], timeout=5))
+            pending, matches = [tree], []
+            while pending:
+                node = pending.pop()
+                if node.get('pid') == process.pid and node.get('name', '').startswith('LightTable'):
+                    matches.append(node)
+                pending.extend(node.get('nodes', []) + node.get('floating_nodes', []))
+            a.require(len(matches) == 1, 'Expected one owned Wayland window')
+            receipt = json.loads(subprocess.check_output(['swaymsg', '-r', f'[con_id={matches[0]["id"]}] kill'], timeout=5))
+            a.require(all(r.get('success') for r in receipt), 'Compositor close failed')
+            process.wait(timeout=min(25, deadline-time.monotonic()))
+            a.require(process.returncode == 0, 'Wayland normal close failed')
+            a.require(not Path(f'/proc/{server_pid}/exe').exists(), 'Wayland close left its server alive')
+            return {'protocol': 'xdg_toplevel.close', 'pid': process.pid, 'window': matches[0]['id']}
+        a.normal_close = normal_close
+    # Retain the existing precision gate, including normal close and persistence,
+    # and take an actual desktop screenshot before its first normal close.
+    original_close = a.normal_close
+    def capture_close(process, pid, deadline):
+        screenshot(output/'precision.png')
+        return original_close(process, pid, deadline)
+    a.normal_close = capture_close
+    precision = output/'precision'
+    precision.mkdir()
+    if not args.film:
+        a.run(bundle, args.source, 240, precision)
+        precision_report = json.loads((precision/'report.json').read_text())
+        precision_report['backend'] = args.backend
+        (precision/'report.json').write_text(json.dumps(precision_report,indent=2)+'\n')
+    a.normal_close = original_close
+    report = {'build': build, 'backend': args.backend, 'graphics': 'software VM', 'cases': []}
+    for fixture in sorted(args.fixtures.glob('*')):
+        if fixture.suffix.upper() not in ('.CR2', '.RAF'):
+            continue
+        case = {'fixture': fixture.name, 'ok': False}
+        report['cases'].append(case)
+        children, tokens = [], set()
+        deadline = time.monotonic()+480
+        with tempfile.TemporaryDirectory(prefix='LightTable release photos ') as temporary:
+            root = Path(temporary)
+            for name in ('runtime', 'photos', 'config/lighttable'):
+                (root/name).mkdir(parents=True, mode=0o700)
+            source = root/'photos'/fixture.name
+            shutil.copy2(fixture, source)
+            digest = hashlib.sha256(source.read_bytes()).hexdigest()
+            (root/'config/lighttable/prefs.json').write_text(json.dumps({
+                'locale':'en','localeChosen':True,'allowAutomation':True,'viewMode':'detail',
+                'firstRunSetup':{'version':1,'status':'completed','source':'folder'},
+                'newPhotoDefaults':{'filmEnabled':False},'automaticUpdateChecks':False,
+                'writeSidecars':False,'backupDirectory':str(root/'backups')}))
+            subprocess.run([str(bundle/'install.sh'), '--bin-dir', str(root/'commands')], env=env(root), check=True, timeout=30)
+            a.require((root/'commands/lighttable-desktop').resolve()==bundle/'bin/lighttable-desktop', 'Install did not register the owned launcher')
+            def launch():
+                with (root/'desktop.log').open('a') as log:
+                    process = subprocess.Popen([str(root/'commands/lighttable-desktop')], env=env(root), stdout=log, stderr=log, start_new_session=True)
+                children.append(process)
+                api, health = a.connect(bundle, process, root, deadline, tokens)
+                name = a.render_photo(process, api, deadline, source)
+                return process, api, health, name
+            try:
+                process, api, health, name = launch()
+                a.send_ui(api, 'slider', {'key':'exposure','value':0.5})
+                a.send_ui(api, 'rating:4')
+                route = '/api/state?'+urlencode({'name':name})
+                a.wait_for(process, deadline, 'saved RAW edit', lambda: a.edits_saved(api.request(route)))
+                if args.film:
+                    a.send_ui(api, 'filmToggle')
+                    a.wait_for(process, deadline, 'saved film enabled state', lambda: api.request(route).get('params',{}).get('profile_enabled') is True)
+                    a.wait_for(process, deadline, 'film rendering in native window', lambda: api.request('/api/ui/state').get('render',{}).get('state')=='ready')
+                screenshot(output/(fixture.stem+'-edited.png'))
+                result = api.request('/api/export', {'names':[name],'format':'tif','outputSpace':'srgb','destination':str(root/'exports'),'metadata':'none','sidecar':False,'collision':'rename'})
+                a.require(result.get('queued'), 'RAW export was not queued')
+                def exported():
+                    status = api.request('/api/export/status')
+                    a.require(not status.get('error') and not status.get('errors'), 'RAW export failed')
+                    return not status.get('running') and status.get('done') == 1
+                a.wait_for(process, deadline, 'RAW RGB16 export', exported)
+                import tifffile
+                paths = list((root/'exports').rglob('*.tif'))
+                a.require(len(paths)==1, 'Expected one RAW export')
+                with tifffile.TiffFile(paths[0]) as image:
+                    a.SHAPE = image.series[0].shape
+                import rawpy
+                with rawpy.imread(str(source)) as raw:
+                    dimensions = sorted((raw.sizes.iheight, raw.sizes.iwidth))
+                a.require(sorted(a.SHAPE[:2]) == dimensions and a.SHAPE[-1]==3,
+                          'RAW export did not preserve full decoded dimensions')
+                case['export'] = a.verify_export(paths[0])
+                case['first_close'] = a.normal_close(process, health['pid'], deadline)
+                a.cleanup(process); children.remove(process)
+                process, api, second, reopened_name = launch()
+                a.require(second['pid']!=health['pid'] and name==reopened_name, 'RAW reopen identity failed')
+                def saved():
+                    value = api.request(route)
+                    return value.get('rating')==4 and value.get('grade',{}).get('exposure')==0.5 and value.get('params',{}).get('profile_enabled') is args.film
+                a.wait_for(process, deadline, 'RAW edit persistence', saved)
+                screenshot(output/(fixture.stem+'-reopened.png'))
+                case['final_close'] = a.normal_close(process, second['pid'], deadline)
+                a.require(hashlib.sha256(source.read_bytes()).hexdigest()==digest, 'Source RAW changed')
+                a.cleanup(process); children.remove(process)
+                catalog = root/'catalog/library.sqlite3'
+                catalog_digest = hashlib.sha256(catalog.read_bytes()).hexdigest()
+                subprocess.run([str(bundle/'uninstall.sh'), '--bin-dir', str(root/'commands')], env=env(root), check=True, timeout=30)
+                a.require(not (root/'commands/lighttable-desktop').is_symlink(), 'Uninstall left its launcher')
+                a.require(hashlib.sha256(catalog.read_bytes()).hexdigest()==catalog_digest and hashlib.sha256(source.read_bytes()).hexdigest()==digest, 'Uninstall changed user data')
+                case.update(ok=True, original_sha256=digest, saved_exposure=0.5, saved_rating=4, film_enabled=args.film, install_and_uninstall_preserved_data=True)
+            finally:
+                for process in reversed(children): a.cleanup(process)
+                for path in (root/'desktop.log',root/'state/lighttable/logs/server.log'):
+                    if path.exists():
+                        (output/(fixture.stem+'-'+path.name)).write_text(a.redact(path.read_text(errors='replace')[-24000:],tokens))
+                (output/'raw-report.json').write_text(json.dumps(report,indent=2)+'\n')
+    a.require(len(report['cases'])==2 and all(c['ok'] for c in report['cases']), 'Both RAW fixtures must pass')
+    print(json.dumps(report,indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/linux/release-update-acceptance.py
+++ b/scripts/linux/release-update-acceptance.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Verify an actual public Linux upgrade, native persistence and recovery.
+
+Run with the old public bundle's Python under Xvfb and a private D-Bus session.
+Both release manifests and production signing keys remain unchanged. Only copies
+inside a temporary directory are installed or used for deliberate failure tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import signal
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def isolated_environment(root: Path) -> dict[str, str]:
+    environment = {key: value for key, value in os.environ.items()
+                   if not key.startswith(("LIGHTTABLE_", "PYTHON", "XDG_"))}
+    environment.update({
+        "XDG_DATA_HOME": str(root / "data"), "XDG_CONFIG_HOME": str(root / "config"),
+        "XDG_CACHE_HOME": str(root / "cache"), "XDG_STATE_HOME": str(root / "state"),
+        "XDG_RUNTIME_DIR": str(root / "runtime"), "LIGHTTABLE_DIR": str(root / "photos"),
+        "LIGHTTABLE_CATALOG_FILE": str(root / "data/lighttable/Catalog/library.sqlite3"),
+        "LIGHTTABLE_INSTANCE_DIR": str(root / "instances"),
+        "NUMBA_CACHE_DIR": str(root / "compiled"), "MPLCONFIGDIR": str(root / "matplotlib"),
+        "SPEKTRAFILM_BACKEND": "cpu", "LIBGL_ALWAYS_SOFTWARE": "1", "GDK_BACKEND": "x11",
+    })
+    return environment
+
+
+def stop_group(process: subprocess.Popen) -> None:
+    # A failed shell can exit before its server/WebKit children do. Always reap
+    # the entire group we created, even when the original Popen has exited.
+    for number, duration in ((signal.SIGTERM, 5), (signal.SIGKILL, 3)):
+        try:
+            os.killpg(process.pid, number)
+        except ProcessLookupError:
+            break
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline:
+            process.poll()
+            try:
+                os.killpg(process.pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            continue
+        break
+    process.wait(timeout=3)
+
+
+def request(port: int, route: str, body=None, token: str = "") -> dict:
+    headers = {"Content-Type": "application/json", "X-LightTable-Token": token}
+    query = urllib.request.Request(f"http://127.0.0.1:{port}{route}",
+        data=json.dumps(body).encode() if body is not None else None, headers=headers)
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    with opener.open(query, timeout=3) as response:
+        require(response.status == 200, "Native server did not return HTTP 200")
+        return json.load(response)
+
+
+def verify_processes(bundle: Path, desktop_pid: int, health: dict) -> None:
+    server_pid = health.get("pid")
+    require(type(server_pid) is int and server_pid > 1, "Health has no server process identity")
+    require(Path(f"/proc/{desktop_pid}/exe").resolve() ==
+            (bundle / "bin/lighttable-desktop-shell").resolve(), "Unexpected native shell executable")
+    require(Path(f"/proc/{server_pid}/exe").resolve() ==
+            (bundle / "Python/bin/python3").resolve(), "Server is not using the updated bundled Python")
+    command = Path(f"/proc/{server_pid}/cmdline").read_bytes().split(b"\0")
+    require(os.fsencode(bundle / "Resources/LightTable/server.py") in command,
+            "Server is not running the expected bundle's code")
+    require(os.getpgid(server_pid) == desktop_pid, "Server is outside the owned desktop process group")
+
+
+def rendered_photo(state: dict) -> bool:
+    current, render = state.get("current"), state.get("render") or {}
+    return bool(state.get("client") and state.get("age", 999) < 10
+                and current and current.endswith("updater-smoke.jpg")
+                and render.get("name") == current and render.get("state") == "ready")
+
+
+def native_ready(bundle: Path, process: subprocess.Popen, root: Path, timeout: int) -> dict:
+    deadline = time.monotonic() + timeout
+    state, selected = {}, False
+    while time.monotonic() < deadline:
+        require(process.poll() is None, f"Native desktop exited with {process.returncode}")
+        for path in (root / "instances").glob("[0-9]*.json"):
+            try:
+                instance = json.loads(path.read_text())
+                if instance.get("folder") != str(root / "photos"):
+                    continue
+                health = request(int(instance["port"]), "/api/health")
+                # Ignore a stale old-instance file, never mistake its server for
+                # the newly launched native application.
+                if health.get("pid") != instance.get("pid"):
+                    continue
+                require(health.get("ok") and health.get("folder") == str(root / "photos")
+                        and health.get("catalog") == str(root / "data/lighttable/Catalog/library.sqlite3")
+                        and not health.get("headless"), "Native app opened unexpected data or ran headless")
+                verify_processes(bundle, process.pid, health)
+                state = request(instance["port"], "/api/ui/state")
+                if health.get("windowConnected") and rendered_photo(state):
+                    return {"desktop_pid": process.pid, "server_pid": health["pid"],
+                            "http": 200, "current": state["current"], "render": state["render"]}
+                if state.get("client") and not selected:
+                    photos = request(instance["port"], "/api/images").get("images", [])
+                    photo = next((item for item in photos if item["name"].endswith("updater-smoke.jpg")), None)
+                    if photo:
+                        selected = True
+                        request(instance["port"], "/api/ui/command", {
+                            "command": "goto", "args": {"name": photo["name"]}, "timeout": 1,
+                        }, instance.get("token", ""))
+            except (OSError, ValueError, KeyError, urllib.error.URLError):
+                pass  # Native startup, instance registration and rendering are asynchronous.
+        time.sleep(0.2)
+    raise RuntimeError(f"Native update timed out before a connected window rendered the photo: {state}")
+
+
+def make_archive(source: Path, output: Path, manifest: dict) -> None:
+    """Archive unchanged package contents with a test-only version manifest."""
+    with tarfile.open(output, "w:gz", compresslevel=1, dereference=False) as archive:
+        archive.add(source, arcname="LightTable",
+                    filter=lambda member: None if member.name == "LightTable/build-manifest.json" else member)
+        content = (json.dumps(manifest) + "\n").encode()
+        entry = tarfile.TarInfo("LightTable/build-manifest.json")
+        entry.size, entry.mode = len(content), 0o644
+        archive.addfile(entry, io.BytesIO(content))
+
+
+def signed_release(update, key, archive: Path, manifest: dict) -> dict:
+    now = int(time.time())
+    with archive.open("rb") as stream:
+        digest = hashlib.file_digest(stream, "sha256").hexdigest()
+    signed = {**{field: manifest[field] for field in ("version", "platform", "architecture", "source_revision")},
+              "schema": 1, "issued_at": now, "expires_at": now + 86400,
+              "url": "https://updates.invalid/release.tar.gz", "size": archive.stat().st_size,
+              "sha256": digest, "release_notes_url": "https://updates.invalid/notes"}
+    return {"signed": signed, "signature": base64.b64encode(key.sign(update.canonical_json(signed))).decode()}
+
+
+def expect_rejected(update, updater, arguments: dict, text: str) -> None:
+    try:
+        updater.apply(**arguments)
+    except update.UpdateError as error:
+        require(text in str(error), f"Wrong update rejection: {error}")
+    else:
+        raise RuntimeError(f"Updater accepted a release that should fail with {text}")
+
+
+def run(bundle: Path, timeout: int, target_archive: Path, target_feed: Path, live_download: bool = False) -> dict:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from PIL import Image
+
+    original_manifest = json.loads((bundle / "build-manifest.json").read_text())
+    require(original_manifest.get("source_dirty") is False and original_manifest.get("platform") == "linux",
+            "The gate requires an actual clean Linux release package")
+    # Import the code shipped in this package, never a source checkout's updater.
+    update = load("packaged_linux_updater", bundle / "Resources/LightTable/desktop_updater.py")
+    children = []
+
+    class ObservedUpdater(update.LinuxUpdater):
+        def _restart(self, *args, **kwargs):
+            process = super()._restart(*args, **kwargs)
+            children.append(process)
+            return process
+
+    with tempfile.TemporaryDirectory(prefix="lighttable-native-update-") as temporary:
+        root = Path(temporary).resolve()
+        environment = isolated_environment(root)
+        for name in ("runtime", "photos"):
+            (root / name).mkdir(mode=0o700)
+        prefs = root / "config/lighttable/prefs.json"
+        prefs.parent.mkdir(parents=True)
+        prefs.write_text(json.dumps({"locale": "en", "localeChosen": True,
+            "allowAutomation": True, "viewMode": "detail",
+            "firstRunSetup": {"version": 1, "status": "completed", "source": "folder"}}))
+        source = root / "photos/updater-smoke.jpg"
+        Image.linear_gradient("L").resize((160, 120)).convert("RGB").save(source)
+        source_digest = hashlib.sha256(source.read_bytes()).hexdigest()
+        # Copy rather than hard-link: a temporary test must not mutate the release.
+        old = root / "original bundle/LightTable"
+        shutil.copytree(bundle, old, symlinks=True)
+        envelope = json.loads(target_feed.read_text())
+        require(envelope['signed']['source_revision'] != original_manifest['source_revision'],
+                'Cross-revision test requires two different source commits')
+        previous_environment = dict(os.environ)
+        os.environ.clear()
+        os.environ.update(environment)
+        try:
+            installer = load("packaged_smoke_integration", old / "desktop-integration.py")
+            commands = root / "commands"
+            with contextlib.redirect_stdout(sys.stderr):
+                installer.integrate("install", old, commands)
+            updater = ObservedUpdater(old)
+            require(updater.status().get("supported"), f"Packaged updater is disabled: {updater.status()}")
+            updater.state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            if live_download:
+                checked = updater.check()
+                require(checked.get('state')=='available', 'Public update feed did not offer the release')
+                downloaded = updater.download()
+                require(downloaded.get('state')=='ready', 'Public HTTPS archive download did not verify')
+                delivered = json.loads(updater.envelope_file.read_text())
+                require(delivered['signed']['sha256']==envelope['signed']['sha256'] and
+                        delivered['signed']['source_revision']==envelope['signed']['source_revision'],
+                        'Public feed delivered different release bytes')
+                envelope = delivered
+            else:
+                shutil.copy2(target_archive, updater.archive_file)
+            authorization = root / "cache/lighttable/updates/pending-0123456789abcdef"
+            authorization.mkdir(mode=0o700, parents=True)
+            (authorization / "authorized").write_text("isolated native smoke\n")
+
+            with (root / "original-desktop.log").open("w") as log:
+                original = subprocess.Popen([str(commands / "lighttable-desktop")],
+                    stdout=log, stderr=log, start_new_session=True)
+            children.append(original)
+            before = native_ready(old, original, root, timeout)
+            instance = next(json.loads(p.read_text()) for p in (root/'instances').glob('*.json')
+                            if json.loads(p.read_text()).get('pid') == before['server_pid'])
+            request(instance['port'], '/api/state', {'name': before['current'],
+                    'grade': {'exposure': 0.5}, 'rating': 4, 'params': {'profile_enabled':False},
+                    'origin':'release-validation','historyLabel':'Release upgrade persistence'}, instance['token'])
+            arguments = {"wait_pids": [before["desktop_pid"], before["server_pid"]],
+                         "authorization_directory": authorization,
+                         "launch_env": {key: environment[key] for key in update.LAUNCH_ENV if key in environment}}
+
+            tampered = {**envelope, "signed": {**envelope["signed"], "version": "9.9.9"}}
+            update.atomic_json(updater.envelope_file, tampered)
+            expect_rejected(update, updater, arguments, "signature")
+            require((commands / "lighttable-desktop").resolve() == old / "bin/lighttable-desktop",
+                    "Rejected metadata changed the desktop launcher")
+            backup_verified = False
+            if live_download:
+                from urllib.error import HTTPError
+                for attempt in range(50):
+                    try:
+                        prepared = request(instance['port'], '/api/updates/prepare', {}, instance['token'])
+                        break
+                    except HTTPError as error:
+                        if error.code != 409 or attempt == 49: raise
+                        time.sleep(0.2)
+                backup = Path(prepared.get('backup') or '')
+                require(backup.is_file() and backup.is_relative_to(root), 'Update preparation did not create an isolated catalog backup')
+                backup_verified = backup.stat().st_size > 0
+                request(instance['port'], '/api/updates/cancel', {}, instance['token'])
+                native = load('live_native_acceptance', Path(__file__).with_name('desktop-acceptance.py'))
+                native.normal_close(original, before['server_pid'], time.monotonic()+35)
+            stop_group(original)
+            children.remove(original)
+            require(all(update.process_identity(pid) is None for pid in arguments["wait_pids"]),
+                    "The original desktop/server did not exit before applying the update")
+            update.atomic_json(updater.envelope_file, envelope)
+            with updater.archive_file.open("r+b") as archive:
+                first = archive.read(1)
+                archive.seek(0)
+                archive.write(bytes([first[0] ^ 1]))
+            try:
+                expect_rejected(update, updater, arguments, "checksum")
+            finally:
+                with updater.archive_file.open("r+b") as archive:
+                    archive.write(first)
+            require((commands / "lighttable-desktop").resolve() == old / "bin/lighttable-desktop",
+                    "Rejected archive changed the desktop launcher")
+
+            result = updater.apply(**arguments)
+            require(result.get("state") == "installed", f"Update was not installed: {result}")
+            installed = Path(result["installed_bundle"])
+            require(installed.is_relative_to(root / "data/lighttable/versions") and installed != old,
+                    "Updater did not install a separate version in the isolated data directory")
+            require((commands / "lighttable-desktop").resolve() == installed / "bin/lighttable-desktop"
+                    and (commands / "lighttable").resolve() == installed / "bin/lighttable",
+                    "Owned launchers did not move to the new bundle")
+            after = native_ready(installed, children[-1], root, timeout)
+            instance = next(json.loads(p.read_text()) for p in (root/'instances').glob('*.json')
+                            if json.loads(p.read_text()).get('pid') == after['server_pid'])
+            from urllib.parse import urlencode
+            saved = request(instance['port'], '/api/state?'+urlencode({'name':after['current']}))
+            require(saved.get('rating')==4 and saved.get('grade',{}).get('exposure')==0.5,
+                    'Cross-revision update lost saved edits')
+            installed_manifest = json.loads((installed/'build-manifest.json').read_text())
+            require(installed_manifest['source_revision']==envelope['signed']['source_revision'],
+                    'Wrong target source was installed')
+            require(after["server_pid"] != before["server_pid"], "The upgraded server did not restart")
+            trash_restore_verified = False
+            if live_download:
+                from urllib.parse import quote, unquote
+                import configparser
+                probe = root/'photos/trash-probe.jpg'
+                shutil.copy2(source, probe)
+                request(instance['port'], '/api/ui/command', {'command':'trash',
+                        'args':{'paths':[str(probe)]},'timeout':3}, instance['token'])
+                trashed = None
+                for attempt in range(100):
+                    for info in (root/'data/Trash/info').glob('*.trashinfo'):
+                        metadata = configparser.ConfigParser(interpolation=None)
+                        metadata.read(info)
+                        if unquote(metadata['Trash Info']['Path']) == str(probe):
+                            trashed = root/'data/Trash/files'/info.name.removesuffix('.trashinfo')
+                    if not probe.exists() and trashed is not None and trashed.is_file(): break
+                    time.sleep(0.1)
+                require(trashed is not None and trashed.is_file() and not probe.exists(),
+                        'Native Trash did not retain a recoverable file and original-path metadata')
+                require(hashlib.sha256(trashed.read_bytes()).hexdigest()==source_digest, 'Trashing changed the photo')
+                subprocess.run(['dbus-run-session','--','gio','trash','--restore','trash:///'+quote(trashed.name)],
+                               env=environment,check=True,timeout=25)
+                require(probe.is_file() and hashlib.sha256(probe.read_bytes()).hexdigest()==source_digest,
+                        'System Trash restore did not return the original bytes')
+                trash_restore_verified = True
+                screenshot = Path.cwd()/'evidence/public-upgraded-desktop.png'
+                screenshot.parent.mkdir(parents=True,exist_ok=True)
+                subprocess.run(['import','-window','root',str(screenshot)],check=True,timeout=15)
+            stop_group(children[-1])
+            children.pop()
+
+            # Repeat the same update from the original install while making GTK
+            # fail to open a display. The real packaged launcher/shell still run;
+            # no stub executable or fake readiness server supplies this failure.
+            with contextlib.redirect_stdout(sys.stderr):
+                installer.integrate("install", old, commands)
+            saved_integration = updater.integration_file.read_bytes()
+            os.environ["DISPLAY"] = str(root / "missing-x11-display")
+            count = len(children)
+            expect_rejected(update, updater, arguments, "exited before it was ready")
+            require(len(children) == count + 1 and children[-1].poll() is not None,
+                    "The deliberate GTK startup failure did not execute and exit")
+            stop_group(children[-1])
+            children.pop()
+            status = updater.status()
+            require(status.get("launchers_restored") is True
+                    and updater.integration_file.read_bytes() == saved_integration,
+                    "Failed startup did not restore the original owned integrations")
+            require((commands / "lighttable-desktop").resolve() == old / "bin/lighttable-desktop"
+                    and (commands / "lighttable").resolve() == old / "bin/lighttable",
+                    "Failed startup left a launcher pointing to the failed version")
+            require(hashlib.sha256(source.read_bytes()).hexdigest() == source_digest,
+                    "The native update changed the original photo")
+            return {"ok": True, "source_revision": original_manifest["source_revision"],
+                    "source_package_version": original_manifest["version"], "test_versions": [original_manifest["version"], envelope["signed"]["version"]],
+                    "target_source": envelope["signed"]["source_revision"], "production_signature": True,
+                    "saved_edit_persistence": True, "baseline_version_override": False,
+                    "desktop": "GTK/WebKitGTK", "display_backend": "x11", "archive_delivery": "public HTTPS" if live_download else "locally staged",
+                    "catalog_backup_verified": backup_verified, "normal_original_close": live_download,
+                    "native_trash_and_system_restore": trash_restore_verified,
+                    "signature_rejection": True, "checksum_rejection": True,
+                    "owned_launchers_retargeted": True, "native_before": before, "native_after": after,
+                    "failed_native_startup_rollback": True, "original_photo_preserved": True}
+        except BaseException:
+            for log in (root / "original-desktop.log", root / "state/lighttable/logs/server.log"):
+                if log.exists():
+                    print(f"{log.name}:\n{log.read_text(errors='replace')[-5000:]}", file=sys.stderr)
+            raise
+        finally:
+            try:
+                for process in reversed(children):
+                    stop_group(process)
+            finally:
+                os.environ.clear()
+                os.environ.update(previous_environment)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", type=Path)
+    parser.add_argument("--target-archive", type=Path, required=True)
+    parser.add_argument("--target-feed", type=Path, required=True)
+    parser.add_argument("--live-download", action="store_true")
+    parser.add_argument("--timeout", type=int, default=90, help="Seconds allowed for each native UI to render (10–105)")
+    args = parser.parse_args()
+    if sys.platform != "linux" or not os.environ.get("DISPLAY") or not os.environ.get("DBUS_SESSION_BUS_ADDRESS"):
+        parser.error("Run on Linux under Xvfb and a private dbus-run-session")
+    if not 10 <= args.timeout <= 105:
+        parser.error("--timeout must be between 10 and 105 seconds")
+    bundle = args.bundle.resolve()
+    if Path(sys.prefix).resolve() != bundle / "Python":
+        parser.error("Run this gate with the package's own Python runtime")
+    signal.signal(signal.SIGTERM, lambda number, _frame: sys.exit(128 + number))
+    print(json.dumps(run(bundle, args.timeout, args.target_archive.resolve(), args.target_feed.resolve(), args.live_download)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Update the checksum-pinned Arch recipe to the public 0.6.0 Linux archive and exercise that package in Arch/Omarchy desktop checks. The virtual-GPU workflow now consumes the exact package artifacts from an acceptance run instead of downloading a hardcoded older release.

Bring forward the completed Linux release journey harness and validate an actual public 0.5.0 → 0.6.0 HTTPS upgrade using unchanged production manifests and signing keys. Check catalog backup, edit persistence, normal close/reopen, recoverable Trash and failed-startup rollback.

Validation: AUR generator validates source/version/archive and 7 recipe tests pass; Python/shell syntax and diff checks pass. Public upgrade and downstream native checks are running. These are VM/software-rendering checks, not physical GPU coverage. App release source remains the immutable v0.6.0 tag.
