### PR TITLE
Make platform releases immutable, resumable, and evidence-gated

### DIFF
--- a/.github/workflows/linux-release-acceptance.yml
+++ b/.github/workflows/linux-release-acceptance.yml
@@ -1,6 +1,25 @@
 name: Linux release acceptance
 on:
   workflow_dispatch:
+    inputs:
+      baseline_version:
+        description: Previous public version to install first
+        required: true
+        default: '0.5.0'
+        type: string
+      target_version:
+        description: Public version currently advertised by the signed feed
+        required: true
+        default: '0.6.0'
+        type: string
+  workflow_call:
+    inputs:
+      baseline_version:
+        required: true
+        type: string
+      target_version:
+        required: true
+        type: string
 permissions:
   contents: read
   actions: read
@@ -8,6 +27,10 @@ jobs:
   public-upgrade:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    env:
+      BASELINE_VERSION: ${{ inputs.baseline_version }}
+      TARGET_VERSION: ${{ inputs.target_version }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - name: Prepare a fresh Ubuntu VM and download the public release
@@ -16,13 +39,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libgtk-3-0 libwebkit2gtk-4.1-0 libxdo3 libopenblas0 libgfortran5 libvulkan1 mesa-vulkan-drivers liblcms2-2 xvfb xauth dbus-x11 imagemagick xdg-utils desktop-file-utils gvfs
           mkdir -p baseline candidate evidence
-          curl --fail --location --retry 2 --max-time 180 -o baseline/LightTable-0.5.0-linux-x86_64.tar.gz https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-linux-x86_64.tar.gz
-          echo "eaf1fb58d038d7260473343ab3bb64a3101ab5d180c09020af80b08929343f01  LightTable-0.5.0-linux-x86_64.tar.gz" > baseline/baseline.sha256
-          curl --fail --location --retry 2 --max-time 180 -o candidate/LightTable-0.6.0-linux-x86_64.tar.gz https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz
-          curl --fail --location --retry 2 --max-time 30 -o candidate/LightTable-0.6.0-linux-x86_64.tar.gz.sha256 https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz.sha256
-          curl --fail --location --retry 2 --max-time 30 -o evidence/linux-x86_64.json https://github.com/reville/lighttable-digital-darkroom/releases/download/desktop-updates/linux-x86_64.json
-          (cd candidate && sha256sum -c *.sha256)
-          (cd baseline && sha256sum -c *.sha256)
+          python3 scripts/release/download_upgrade.py --baseline "$BASELINE_VERSION" --target "$TARGET_VERSION"
           tar -xzf candidate/*.tar.gz -C candidate
           tar -xzf baseline/*.tar.gz -C baseline
       - name: Validate the downloaded release runtime on a fresh VM
@@ -32,7 +49,7 @@ jobs:
         run: |
           timeout 480s xvfb-run -a --server-args='-screen 0 1280x900x24' dbus-run-session -- \
             baseline/LightTable/Python/bin/python3 scripts/linux/release-update-acceptance.py baseline/LightTable \
-              --target-archive candidate/LightTable-0.6.0-linux-x86_64.tar.gz --target-feed evidence/linux-x86_64.json --live-download \
+              --target-archive "candidate/LightTable-$TARGET_VERSION-linux-x86_64.tar.gz" --target-feed evidence/linux-x86_64.json --live-download \
               > evidence/public-upgrade.json
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,70 @@
+name: Prepare an existing release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Exact platform to prepare independently
+        type: choice
+        options: [linux-x86_64, windows-x64, macos-arm64]
+        required: true
+      version:
+        description: Version already embedded in the original build
+        type: string
+        required: true
+      build_run_id:
+        description: Original run with a successful selected platform package job; never rebuilt
+        type: string
+        required: true
+      source_revision:
+        description: Expected full original build commit
+        type: string
+        required: true
+      native_run_id:
+        description: Optional exact-candidate native acceptance run (promotion verifies it)
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: prepare-${{ inputs.platform }}-${{ inputs.version }}-${{ inputs.build_run_id }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install the existing Linux metadata signing dependency
+        if: inputs.platform == 'linux-x86_64'
+        run: python3 -m pip install cryptography==50.0.1
+      - name: Download and prepare the exact candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PLATFORM: ${{ inputs.platform }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          BUILD_RUN_ID: ${{ inputs.build_run_id }}
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          NATIVE_RUN_ID: ${{ inputs.native_run_id }}
+          LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY: ${{ inputs.platform == 'linux-x86_64' && secrets.LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY || '' }}
+        run: |
+          args=(--platform "$RELEASE_PLATFORM" --version "$RELEASE_VERSION" --build-run-id "$BUILD_RUN_ID" --source-revision "$SOURCE_REVISION" --output-dir prepared)
+          if [[ -n "$NATIVE_RUN_ID" ]]; then args+=(--native-run-id "$NATIVE_RUN_ID"); fi
+          python3 scripts/release/prepare_candidate.py "${args[@]}" > preparation-summary.json
+          cat preparation-summary.json >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: LightTable-${{ inputs.platform }}-promotion
+          path: prepared/*
+          if-no-files-found: error
+          retention-days: 30
+      - name: Explain the next independent step
+        run: |
+          echo 'Candidate prepared only. Use this preparation run and original build run in Promote a verified release candidate. Default promotion is a read-only plan; no release or feed was published here.' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,111 @@
+name: Promote verified release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: One platform; other platforms and updater feeds are preserved
+        type: choice
+        options: [linux-x86_64, windows-x64, macos-arm64]
+        required: true
+      version:
+        description: Exact candidate version (for example 0.7.0)
+        type: string
+        required: true
+      source_revision:
+        description: Full immutable release source commit
+        type: string
+        required: true
+      build_run_id:
+        description: Successful original platform build run
+        type: string
+        required: true
+      preparation_run_id:
+        description: Successful release preparation run containing the promotion artifact
+        type: string
+        required: true
+      native_run_id:
+        description: Windows client VM run (both Windows 10 and 11 native x64); otherwise leave blank
+        type: string
+        required: false
+      dry_run:
+        description: Verify and plan only; no release or feed changes
+        type: boolean
+        default: true
+      make_public:
+        description: Publish the verified draft, creating it if missing, after all evidence passes
+        type: boolean
+        default: false
+      advance_feed:
+        description: Advance only this platform's signed feed after verifying public downloads
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # Share the original release lock to prevent cross-workflow pointer races.
+  group: lighttable-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install signature verification dependency
+        run: python -m pip install cryptography==50.0.1
+      - name: Verify exact artifacts and native receipts, then plan or promote
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLATFORM: ${{ inputs.platform }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          BUILD_RUN_ID: ${{ inputs.build_run_id }}
+          PREPARATION_RUN_ID: ${{ inputs.preparation_run_id }}
+          NATIVE_RUN_ID: ${{ inputs.native_run_id }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MAKE_PUBLIC: ${{ inputs.make_public }}
+          ADVANCE_FEED: ${{ inputs.advance_feed }}
+          LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY: ${{ vars.LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p .build/release-promotion
+          arguments=(--platform "$PLATFORM" --version "$VERSION" --source-revision "$SOURCE_REVISION"
+            --build-run-id "$BUILD_RUN_ID" --manifest-run-id "$PREPARATION_RUN_ID"
+            --manifest-artifact "LightTable-$PLATFORM-promotion"
+            --output .build/release-promotion/result.json)
+          if [[ -n "$NATIVE_RUN_ID" ]]; then arguments+=(--native-run-id "$NATIVE_RUN_ID"); fi
+          if [[ "$DRY_RUN" == false ]]; then arguments+=(--apply); fi
+          if [[ "$MAKE_PUBLIC" == true ]]; then arguments+=(--make-public); fi
+          if [[ "$ADVANCE_FEED" == true ]]; then arguments+=(--advance-feed); fi
+          python scripts/release/promote_candidate.py "${arguments[@]}"
+      - name: Prepare the canonical index and website handoff
+        if: inputs.dry_run == false
+        run: |
+          if python -c 'import json; r=json.load(open(".build/release-promotion/result.json")); raise SystemExit(not (r.get("published_release") and r.get("public_bytes_verified")))'; then
+            python scripts/release/update_index.py --index release/manifest.json \
+              --promotion-result .build/release-promotion/result.json \
+              --output .build/release-promotion/manifest.json
+            echo "Verified manifest.json is attached to the promotion result. Review and merge it into release/manifest.json, then run the website metadata sync workflow and deploy." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Retain promotion or blocking receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: LightTable-${{ inputs.platform }}-promotion-result
+          path: .build/release-promotion/
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,29 @@
-name: Release
+name: Release build
 
 on:
-  push:
-    tags: ["v*"]
   workflow_dispatch:
     inputs:
       version:
         description: "Existing release tag version, such as 0.5.0 (LightTable 0.5)"
         required: true
-        default: '0.5.0'
         type: string
       platforms:
-        description: "Platforms to publish"
+        description: "Platforms to build independently; promotion is a separate verified step"
         type: choice
-        options: [all, linux, macos, windows, both]
+        options: [all, linux, macos, windows]
         default: all
+      macos_channel:
+        description: Explicit macOS signing/channel choice; never downgraded automatically
+        type: choice
+        options: [stable, beta]
+        default: stable
 
 permissions:
   contents: read
 
 concurrency:
-  # Serialize tag-triggered and manually dispatched publication together.
-  # Otherwise the same tag can race under two differently formatted keys.
-  group: lighttable-release
+  # Candidate builds never publish; different platform runs can proceed independently.
+  group: lighttable-release-build-${{ inputs.version }}-${{ inputs.platforms }}
   cancel-in-progress: false
 
 jobs:
@@ -36,6 +37,7 @@ jobs:
       windows: ${{ steps.version.outputs.windows }}
       linux: ${{ steps.version.outputs.linux }}
       title: ${{ steps.version.outputs.title }}
+      macos_version: ${{ steps.version.outputs.macos_version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +46,8 @@ jobs:
         name: Validate the immutable release tag
         env:
           REQUESTED_VERSION: ${{ inputs.version }}
-          PLATFORMS: ${{ inputs.platforms || vars.LIGHTTABLE_RELEASE_PLATFORMS || 'all' }}
+          PLATFORMS: ${{ inputs.platforms }}
+          MACOS_CHANNEL: ${{ inputs.macos_channel }}
         run: |
           version="${REQUESTED_VERSION:-${GITHUB_REF_NAME#v}}"
           [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo 'Use a stable version such as 0.5.0'; exit 1; }
@@ -53,33 +56,21 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
           echo "title=LightTable ${version%.0}" >> "$GITHUB_OUTPUT"
+          if [[ "$MACOS_CHANNEL" == beta ]]; then
+            echo "macos_version=$version-beta.1" >> "$GITHUB_OUTPUT"
+          else
+            echo "macos_version=$version" >> "$GITHUB_OUTPUT"
+          fi
+          echo "### Pinned release source" >> "$GITHUB_STEP_SUMMARY"
+          echo "Version $version; source $source_ref; selected $PLATFORMS. Each platform retains its own artifacts and gates. Use Release promotion after exact-artifact acceptance; this run never publishes." >> "$GITHUB_STEP_SUMMARY"
           case "$PLATFORMS" in
             all) printf 'macos=true\nwindows=true\nlinux=true\n' >> "$GITHUB_OUTPUT" ;;
-            both) printf 'macos=true\nwindows=true\nlinux=false\n' >> "$GITHUB_OUTPUT" ;;
             macos) printf 'macos=true\nwindows=false\nlinux=false\n' >> "$GITHUB_OUTPUT" ;;
             windows) printf 'macos=false\nwindows=true\nlinux=false\n' >> "$GITHUB_OUTPUT" ;;
             linux) printf 'macos=false\nwindows=false\nlinux=true\n' >> "$GITHUB_OUTPUT" ;;
             *) echo 'Unknown platform selection' >&2; exit 1 ;;
           esac
 
-      - name: Check desktop update signing configuration
-        env:
-          RELEASE_WINDOWS: ${{ steps.version.outputs.windows }}
-          RELEASE_LINUX: ${{ steps.version.outputs.linux }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY: ${{ vars.LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY }}
-          LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY: ${{ secrets.LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY }}
-        run: |
-          if [[ "$RELEASE_WINDOWS" == true && -z "$SPARKLE_PRIVATE_KEY" ]]; then
-            echo 'Configure SPARKLE_PRIVATE_KEY before publishing Windows updates.' >&2
-            exit 1
-          fi
-          if [[ "$RELEASE_LINUX" == true ]]; then
-            [[ -n "$LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY" && -n "$LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY" ]] || {
-              echo 'Configure Linux update signing before publishing a portable release.' >&2
-              exit 1
-            }
-          fi
 
   macos:
     needs: prepare
@@ -92,7 +83,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.tag }}
-      - name: Check release credentials and architecture
+      - name: Verify the beta tag before building
+        if: inputs.macos_channel == 'beta'
+        env:
+          BETA_VERSION: ${{ needs.prepare.outputs.macos_version }}
+          SOURCE_REVISION: ${{ needs.prepare.outputs.source_ref }}
+        run: |
+          [[ "$(uname -m)" == arm64 ]] || { echo 'An Apple silicon runner is required'; exit 1; }
+          actual="$(gh api "repos/$GITHUB_REPOSITORY/commits/macos-v$BETA_VERSION" --jq .sha)"
+          [[ "$actual" == "$SOURCE_REVISION" ]] || { echo 'Beta tag must select the exact release source'; exit 1; }
+      - name: Check stable release credentials and architecture
+        if: inputs.macos_channel == 'stable'
         env:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -109,6 +110,7 @@ jobs:
           done
           [[ "$APPLE_SIGNING_IDENTITY" == 'Developer ID Application:'* ]] || { echo 'A Developer ID Application certificate is required'; exit 1; }
       - name: Import the release certificate
+        if: inputs.macos_channel == 'stable'
         env:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -132,23 +134,25 @@ jobs:
           uv pip install --python .build/model-conversion/bin/python -r scripts/models/requirements-convert.txt
           .build/model-conversion/bin/python scripts/fetch-models.py
           .build/model-conversion/bin/python scripts/convert-models.py
-      - name: Build the signed application
+      - name: Build the selected application channel
         env:
-          LIGHTTABLE_VERSION: ${{ needs.prepare.outputs.version }}
+          LIGHTTABLE_VERSION: ${{ needs.prepare.outputs.macos_version }}
           LIGHTTABLE_BUILD_NUMBER: ${{ github.run_number }}
-          LIGHTTABLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          LIGHTTABLE_SIGN_IDENTITY: ${{ inputs.macos_channel == 'stable' && secrets.APPLE_SIGNING_IDENTITY || '-' }}
         run: scripts/build-release.sh
       - name: Verify bundled CLI and real-photo journey
         run: |
           (cd "$RUNNER_TEMP" && "$GITHUB_WORKSPACE/dist/LightTable.app/Contents/MacOS/lighttable-cli" --help)
-          python3 scripts/native-app-smoke.py --app dist/LightTable.app --layer package
+          python3 scripts/native-app-smoke.py --app dist/LightTable.app --layer package --output dist/macos-native-acceptance.json
       - name: Notarize and staple the application
+        if: inputs.macos_channel == 'stable'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: scripts/notarize-app.sh dist/LightTable.app
       - name: Package and verify the update
+        if: inputs.macos_channel == 'stable'
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -170,13 +174,38 @@ jobs:
           xcrun stapler validate "$dmg"
           cp "dist/appcast/LightTable-$VERSION-macos-arm64.zip" dist/
           cp dist/appcast/appcast.xml dist/
+      - name: Package the explicitly selected manual beta
+        if: inputs.macos_channel == 'beta'
+        env:
+          VERSION: ${{ needs.prepare.outputs.macos_version }}
+        run: |
+          /usr/libexec/PlistBuddy -c 'Set :SUEnableAutomaticChecks false' dist/LightTable.app/Contents/Info.plist
+          scripts/sign-app.sh dist/LightTable.app -
+          codesign --verify --deep --strict dist/LightTable.app
+          scripts/package-dmg.sh dist/LightTable.app "dist/LightTable-$VERSION-macos-arm64.dmg"
+          (cd dist && shasum -a 256 "LightTable-$VERSION-macos-arm64.dmg" > "LightTable-$VERSION-macos-arm64.dmg.sha256")
+          echo 'Manual beta: ad-hoc signed; automatic updates, Developer ID and notarization are not claimed.' >> "$GITHUB_STEP_SUMMARY"
+      - name: Bind final Mac artifacts to native and signing proof
+        env:
+          CHANNEL: ${{ inputs.macos_channel }}
+        run: |
+          arguments=()
+          for artifact in dist/LightTable-*-macos-arm64.dmg dist/LightTable-*-macos-arm64.zip dist/appcast.xml; do
+            [[ ! -f "$artifact" ]] || arguments+=(--artifact "$artifact")
+          done
+          python3 scripts/release/macos_receipt.py --app dist/LightTable.app \
+            --native dist/macos-native-acceptance.json --channel "$CHANNEL" \
+            --output dist/macos-release-proof.json "${arguments[@]}"
       - uses: actions/upload-artifact@v4
         with:
           name: LightTable-macos-arm64
           path: |
             dist/LightTable-*-macos-arm64.dmg
             dist/LightTable-*-macos-arm64.zip
+            dist/LightTable-*-macos-arm64.dmg.sha256
             dist/appcast.xml
+            dist/macos-release-proof.json
+            dist/macos-native-acceptance.json
       - name: Remove the temporary signing keychain
         if: always()
         run: |
@@ -195,129 +224,47 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       source_ref: ${{ needs.prepare.outputs.source_ref }}
       require_signing: true
+      store_candidate: true
     secrets: inherit
 
-  linux:
+  linux-preflight:
     needs: prepare
+    if: needs.prepare.outputs.linux == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Linux production update signing before the build
+        env:
+          UPDATE_PUBLIC: ${{ vars.LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY }}
+          UPDATE_PRIVATE: ${{ secrets.LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY }}
+        run: |
+          [[ -n "$UPDATE_PUBLIC" && -n "$UPDATE_PRIVATE" ]] || {
+            echo 'Linux build blocked: configure both production update signing keys.' >&2; exit 1;
+          }
+          echo 'Linux signing configuration present. Final artifact signatures still require verification.' >> "$GITHUB_STEP_SUMMARY"
+
+  linux:
+    needs: [prepare, linux-preflight]
     if: needs.prepare.outputs.linux == 'true'
     uses: ./.github/workflows/linux-build.yml
     with:
       version: ${{ needs.prepare.outputs.version }}
       source_ref: ${{ needs.prepare.outputs.source_ref }}
 
-  publish:
+  summary:
     needs: [prepare, macos, windows, linux]
-    if: >-
-      always() && needs.prepare.result == 'success' &&
-      (needs.macos.result == 'success' || needs.macos.result == 'skipped') &&
-      (needs.windows.result == 'success' || needs.windows.result == 'skipped') &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+    if: always()
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      VERSION: ${{ needs.prepare.outputs.version }}
-      TAG: ${{ needs.prepare.outputs.tag }}
-      TITLE: ${{ needs.prepare.outputs.title }}
-      SOURCE_REVISION: ${{ needs.prepare.outputs.source_ref }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.tag }}
-      - uses: actions/download-artifact@v4
-        if: needs.prepare.outputs.macos == 'true'
-        with:
-          name: LightTable-macos-arm64
-          path: dist
-      - uses: actions/download-artifact@v4
-        if: needs.prepare.outputs.windows == 'true'
-        with:
-          name: LightTable-windows-x64
-          path: dist
-      - uses: actions/download-artifact@v4
-        if: needs.prepare.outputs.linux == 'true'
-        with:
-          name: LightTable-linux-x86_64
-          path: dist
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-      - name: Sign the Linux portable update feed
-        if: needs.prepare.outputs.linux == 'true'
+      - name: Report independent platform results
         env:
-          LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY: ${{ secrets.LIGHTTABLE_LINUX_UPDATE_PRIVATE_KEY }}
+          MACOS: ${{ needs.macos.result }}
+          WINDOWS: ${{ needs.windows.result }}
+          LINUX: ${{ needs.linux.result }}
         run: |
-          python3 -m pip install cryptography==50.0.1
-          python3 scripts/generate-linux-update.py \
-            --archive "dist/LightTable-$VERSION-linux-x86_64.tar.gz" \
-            --output dist/linux-x86_64.json \
-            --download-url "https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG/LightTable-$VERSION-linux-x86_64.tar.gz" \
-            --release-notes-url "https://github.com/$GITHUB_REPOSITORY/releases/tag/$TAG"
-      - name: Generate checksums and installer definitions
-        run: |
-          python3 scripts/generate-installers.py --version "$VERSION" --source-revision "$SOURCE_REVISION" --artifacts-dir dist --output-dir dist/installers --license GPL-3.0-only --license-url "https://github.com/$GITHUB_REPOSITORY/blob/$TAG/LICENSE"
-          cp dist/installers/SHA256SUMS dist/SHA256SUMS
-          tar -czf "dist/LightTable-$VERSION-installers.tar.gz" -C dist/installers .
-          # npm currently installs macOS/Windows. A Linux-only release must not
-          # fail on that unrelated channel or claim that npm supports Linux.
-          if [[ -f "dist/LightTable-$VERSION-macos-arm64.zip" || -f "dist/LightTable-$VERSION-windows-x64-setup.exe" ]]; then
-            node packaging/npm/scripts/prepare-release.mjs "$VERSION" dist
-            (cd packaging/npm && npm pack --pack-destination ../../dist)
-            (cd dist && sha256sum "lighttable-$VERSION.tgz") >> dist/SHA256SUMS
-          fi
-          (cd dist && sha256sum "LightTable-$VERSION-installers.tar.gz") >> dist/SHA256SUMS
-          for feed in appcast-windows-x64.xml linux-x86_64.json; do
-            if [[ -f "dist/$feed" ]]; then (cd dist && sha256sum "$feed") >> dist/SHA256SUMS; fi
-          done
-      - name: Publish immutable release assets
-        run: |
-          draft="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft 2>/dev/null || true)"
-          if [[ "$draft" == false ]]; then
-            echo 'This release is already public. Use a new version; do not replace published artifacts.' >&2
-            exit 1
-          fi
-          if [[ "$draft" != true ]]; then
-            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --title "$TITLE" --generate-notes --draft
-          fi
-          shopt -s nullglob
-          assets=(dist/LightTable-* dist/SHA256SUMS dist/lighttable-*.tgz)
-          if [[ -f dist/appcast.xml ]]; then assets+=(dist/appcast.xml); fi
-          if [[ -f dist/appcast-windows-x64.xml ]]; then assets+=(dist/appcast-windows-x64.xml); fi
-          if [[ -f dist/linux-x86_64.json ]]; then assets+=(dist/linux-x86_64.json); fi
-          gh release upload "$TAG" "${assets[@]}" --repo "$GITHUB_REPOSITORY" --clobber
-          # Releases without macOS must not replace the latest Mac updater feed.
-          # The website discovers compatible Linux assets across public releases.
-          if [[ -f dist/appcast.xml ]]; then
-            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
-          else
-            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest=false
-          fi
-      - name: Advance the independent desktop update feeds
-        run: |
-          feeds=()
-          if [[ -f dist/appcast-windows-x64.xml ]]; then feeds+=(dist/appcast-windows-x64.xml); fi
-          if [[ -f dist/linux-x86_64.json ]]; then feeds+=(dist/linux-x86_64.json); fi
-          if [[ ${#feeds[@]} -eq 0 ]]; then exit 0; fi
-          # Publish pointers only after the versioned artifacts are public.
-          # This dedicated prerelease never replaces the Mac latest release.
-          if ! gh release view desktop-updates --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release create desktop-updates --repo "$GITHUB_REPOSITORY" \
-              --target "$SOURCE_REVISION" --title 'Desktop update feeds' \
-              --notes 'Signed Windows and Linux update metadata. Download applications from the versioned releases.' \
-              --prerelease --latest=false
-          fi
-          gh release upload desktop-updates "${feeds[@]}" --repo "$GITHUB_REPOSITORY" --clobber
-
-  npm:
-    needs: [prepare, publish]
-    if: >-
-      needs.publish.result == 'success' && vars.NPM_PUBLISH_ENABLED == 'true' &&
-      (needs.prepare.outputs.macos == 'true' || needs.prepare.outputs.windows == 'true')
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/npm-publish.yml
-    with:
-      version: ${{ needs.prepare.outputs.version }}
-    secrets: inherit
+          {
+            echo '## Candidate builds'
+            echo "macOS: $MACOS"
+            echo "Windows: $WINDOWS"
+            echo "Linux: $LINUX"
+            echo 'Successful artifacts remain available even if another platform is blocked. Resume verification/promotion from the existing build run; do not rebuild successful candidates.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -146,6 +146,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_packaging.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_windows_release_process.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_updater.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_store_packaging.py -v
@@ -275,6 +277,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_packaging.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m unittest discover -s tests -p test_windows_release_process.py -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_updater.py -v
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python -m unittest discover -s tests -p test_windows_store_packaging.py -v
@@ -340,4 +344,12 @@ jobs:
         with:
           name: Windows-native-acceptance
           path: .build/windows-desktop-evidence/
+          if-no-files-found: ignore
+
+      - name: Retain Windows build-stage timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows-build-timings
+          path: .build/windows-build-timings.json
           if-no-files-found: ignore

--- a/.github/workflows/windows-client-vm.yml
+++ b/.github/workflows/windows-client-vm.yml
@@ -7,6 +7,11 @@ on:
         description: Completed signed Windows candidate build
         required: true
         type: string
+      source_revision:
+        description: Exact package source when the producer workflow revision differs
+        required: false
+        default: ''
+        type: string
       installer_sha256:
         description: Independently verified exact installer SHA-256
         required: true
@@ -32,20 +37,25 @@ jobs:
       - name: Verify the selected release build
         id: candidate
         env:
+          GH_TOKEN: ${{ github.token }}
           BUILD_RUN_ID: ${{ inputs.build_run_id }}
+          SOURCE_REVISION: ${{ inputs.source_revision }}
           INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (!/^[1-9][0-9]{0,14}$/.test(process.env.BUILD_RUN_ID)
-                || !/^[a-f0-9]{64}$/.test(process.env.INSTALLER_SHA256)) throw new Error('Exact candidate inputs required');
-            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: Number(process.env.BUILD_RUN_ID)});
-            if (run.conclusion !== 'success' || run.head_repository?.full_name !== `${context.repo.owner}/${context.repo.repo}`
-                || run.path !== '.github/workflows/windows-build.yml' || !/^[a-f0-9]{40}$/.test(run.head_sha)) {
-              throw new Error('Select a successful Windows candidate from this repository');
-            }
-            core.setOutput('source_sha', run.head_sha);
-
+        run: |
+          python3 - <<'PYCODE'
+          import os, re, sys
+          sys.path.insert(0, 'scripts/release')
+          from prepare_candidate import build_run
+          if not re.fullmatch(r'[0-9a-f]{64}', os.environ['INSTALLER_SHA256']):
+              raise SystemExit('Exact installer SHA-256 required')
+          run = build_run(os.environ['BUILD_RUN_ID'], 'windows-x64')
+          source = os.environ['SOURCE_REVISION'] or run['head_sha']
+          if not re.fullmatch(r'[0-9a-f]{40}', source):
+              raise SystemExit('Exact package source required')
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+              output.write('source_sha=' + source + '\n')
+              output.write('build_workflow_revision=' + run['head_sha'] + '\n')
+          PYCODE
 
       - uses: actions/download-artifact@v4
         with:
@@ -53,6 +63,21 @@ jobs:
           path: .build/windows-client-download
           run-id: ${{ inputs.build_run_id }}
           github-token: ${{ github.token }}
+
+      - name: Verify exact candidate bytes and immutable version tag
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REVISION: ${{ steps.candidate.outputs.source_sha }}
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $Version = & ./scripts/windows/verify-native-candidate.ps1 -Directory .build/windows-client-download `
+            -SourceRevision $env:SOURCE_REVISION -InstallerSha256 $env:INSTALLER_SHA256
+          $TagSource = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/v$Version" --jq '.sha').Trim()
+          if ($LASTEXITCODE -ne 0 -or $TagSource -cne $env:SOURCE_REVISION) {
+            throw "The candidate version tag does not select this source"
+          }
 
       - name: Parse Windows test scripts
         shell: pwsh
@@ -175,5 +200,5 @@ jobs:
         with:
           name: Windows-${{ matrix.windows }}-x64-client-acceptance
           path: .build/client-vm/evidence/
-          retention-days: 7
+          retention-days: 90
           if-no-files-found: warn

--- a/.github/workflows/windows-client-vm.yml
+++ b/.github/workflows/windows-client-vm.yml
@@ -1,0 +1,179 @@
+name: Windows client VM acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: Completed signed Windows candidate build
+        required: true
+        type: string
+      installer_sha256:
+        description: Independently verified exact installer SHA-256
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  client:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        windows: ['10', '11']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify the selected release build
+        id: candidate
+        env:
+          BUILD_RUN_ID: ${{ inputs.build_run_id }}
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (!/^[1-9][0-9]{0,14}$/.test(process.env.BUILD_RUN_ID)
+                || !/^[a-f0-9]{64}$/.test(process.env.INSTALLER_SHA256)) throw new Error('Exact candidate inputs required');
+            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: Number(process.env.BUILD_RUN_ID)});
+            if (run.conclusion !== 'success' || run.head_repository?.full_name !== `${context.repo.owner}/${context.repo.repo}`
+                || run.path !== '.github/workflows/windows-build.yml' || !/^[a-f0-9]{40}$/.test(run.head_sha)) {
+              throw new Error('Select a successful Windows candidate from this repository');
+            }
+            core.setOutput('source_sha', run.head_sha);
+
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: LightTable-windows-x64
+          path: .build/windows-client-download
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Parse Windows test scripts
+        shell: pwsh
+        run: |
+          $Failed = $false
+          foreach ($File in Get-ChildItem scripts/windows -Filter *.ps1 -Recurse) {
+            $Tokens = $null; $Errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($File.FullName, [ref]$Tokens, [ref]$Errors) | Out-Null
+            if ($Errors.Count) { $Errors | Format-List; $Failed = $true }
+          }
+          if ($Failed) { throw "PowerShell test scripts contain syntax errors" }
+
+      - name: Stage a fresh Microsoft evaluation VM
+        env:
+          WINDOWS_VERSION: ${{ matrix.windows }}
+          SOURCE_SHA: ${{ steps.candidate.outputs.source_sha }}
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
+        run: |
+          set -euo pipefail
+          test -c /dev/kvm
+          # Disposable hosted runner only; reclaim unused SDKs for the VM disk.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          python3 - <<'PYCODE'
+          import json, os, re
+          from pathlib import Path
+          receipt = json.loads(Path('.build/windows-client-download/store-candidate-receipt.json').read_text(encoding='utf-8-sig'))
+          assert receipt['source_revision'] == os.environ['SOURCE_SHA']
+          assert re.fullmatch(r'(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)', receipt['version'])
+          installer = 'LightTable-' + receipt['version'] + '-windows-x64-setup.exe'
+          assert any(a['file'] == installer and a['sha256'] == os.environ['INSTALLER_SHA256'] for a in receipt['artifacts'])
+          Path('.build/candidate-version').write_text(receipt['version'])
+          PYCODE
+          python3 scripts/windows/client-vm/prepare.py "$WINDOWS_VERSION" \
+            --version "$(cat .build/candidate-version)" --source-sha "$SOURCE_SHA" --installer-sha256 "$INSTALLER_SHA256"
+          mkdir -p .build/client-vm/evidence .build/client-vm/storage
+          if [[ "$WINDOWS_VERSION" == 10 ]]; then
+            iso='https://software-static.download.prss.microsoft.com/dbazure/988969d5-f34g-4e03-ac9d-1f9786c66750/19045.2006.220908-0225.22h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso'
+            digest='ef7312733a9f5d7d51cfa04ac497671995674ca5e1058d5164d6028f0938d668'
+          else
+            iso='https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso'
+            digest='a61adeab895ef5a4db436e0a7011c92a2ff17bb0357f58b13bbc4062e535e7b9'
+          fi
+          # Microsoft throttles large single-stream downloads. Use four bounded
+          # connections and verify the complete image before starting the VM.
+          if ! command -v aria2c >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y aria2
+          fi
+          timeout 1200 aria2c --max-connection-per-server=4 --split=4 --min-split-size=16M \
+            --max-tries=3 --timeout=30 --retry-wait=5 --summary-interval=30 \
+            --file-allocation=none --dir=.build/client-vm --out=windows.iso "$iso"
+          echo "$digest  .build/client-vm/windows.iso" | sha256sum --check
+          printf '%s\n' "$iso" "$digest" > .build/client-vm/evidence/media.txt
+          df -h .
+
+      - name: Boot Windows and run offline client acceptance
+        run: |
+          set -euo pipefail
+          root="$PWD/.build/client-vm"
+          docker run --detach --name lighttable-client --stop-timeout 30 \
+            --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN \
+            -e RAM_SIZE=8G -e CPU_CORES=4 -e DISK_SIZE=64G -e DISK_FMT=qcow2 \
+            -e DISK_TYPE=sata -e ADAPTER=e1000 -e NETWORK=slirp -e IP=10.0.2.15 -e SAMBA=N \
+            -e BOOT_MODE=windows_secure -e TPM=Y -e VGA=std -e REMOVE=N -e VERSION=${{ matrix.windows }}e \
+            -v "$root/storage:/storage" -v "$root/windows.iso:/custom.iso:ro" \
+            -v "$root/custom.xml:/custom.xml:ro" -v "$root/oem:/oem:ro" \
+            -v "$root/evidence:/evidence" \
+            -v "$PWD/scripts/windows/client-vm/receive.py:/receive.py:ro" \
+            dockurr/windows@sha256:32cc92715a6c5dc1f63142d3be11059279d64d0faa7519618a07290b3076f9f2
+          # Explicit slirp subnet maps the guest gateway 10.0.2.1 to this container.
+          # NETWORK=user selected passt and did not provide the old 10.0.2.2 receiver.
+          docker exec -d lighttable-client python3 /receive.py
+          docker exec lighttable-client python3 -c "import socket,time; time.sleep(1); s=socket.create_connection(('127.0.0.1',18080),5); s.close()"
+          deadline=$((SECONDS + 2700))
+          while (( SECONDS < deadline )); do
+            if [[ -f "$root/evidence/complete" ]]; then break; fi
+            if [[ "$(docker inspect --format '{{.State.Running}}' lighttable-client)" != true ]]; then
+              docker logs --tail 80 lighttable-client
+              exit 1
+            fi
+            sleep 10
+          done
+          if [[ ! -f "$root/evidence/complete" ]]; then
+            if [[ -f "$root/evidence/bootstrap-started.json" ]]; then
+              echo 'Guest booted and evidence transport worked; client acceptance did not return a final receipt.' >&2
+            else
+              echo 'No bootstrap receipt: inspect guest startup and evidence transport before diagnosing the app.' >&2
+            fi
+            exit 1
+          fi
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('.build/client-vm/evidence')
+          host = json.loads((root / 'host.json').read_text(encoding='utf-8-sig'))
+          print(json.dumps(host, indent=2))
+          if not host.get('ok'):
+              raise SystemExit('Windows client setup failed; see host.json')
+          result = json.loads((root / 'result.json').read_text(encoding='utf-8-sig'))
+          print(json.dumps(result, indent=2))
+          if not result.get('ok'):
+              raise SystemExit('Windows client acceptance failed; see result.json')
+          if not host.get('webview2_absent_before_offline_install'):
+              raise SystemExit('Offline runtime-present checks passed, but WebView2-absent acceptance remains unproven')
+          PY
+
+      - name: Stop the disposable VM
+        if: always()
+        run: |
+          mkdir -p .build/client-vm/evidence
+          if docker inspect lighttable-client >/dev/null 2>&1; then
+            docker logs lighttable-client > .build/client-vm/evidence/vm.log 2>&1
+            docker stop --time 30 lighttable-client || true
+            docker rm -f lighttable-client || true
+          fi
+          # Do not upload account configuration, VM disks, or Windows media.
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Windows-${{ matrix.windows }}-x64-client-acceptance
+          path: .build/client-vm/evidence/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -7,11 +7,43 @@ on:
         description: Windows build run containing a successfully built LightTable-windows-x64 artifact
         required: true
         type: string
+      runner:
+        description: Windows Server x64 or Windows 11 ARM (x64 application under emulation)
+        required: false
+        default: windows-2022
+        type: choice
+        options:
+          - windows-2022
+          - windows-11-arm
+      source_revision:
+        description: Exact package source when the build workflow ran from a different revision
+        required: false
+        default: ''
+        type: string
+      installer_sha256:
+        description: Independently verified signed installer SHA-256; enables installer acceptance
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       build_run_id:
         description: Windows build run containing a successfully built LightTable-windows-x64 artifact
         required: true
+        type: string
+
+      runner:
+        required: false
+        default: windows-2022
+        type: string
+      source_revision:
+        description: Exact package source when the build workflow ran from a different revision
+        required: false
+        default: ''
+        type: string
+      installer_sha256:
+        required: false
+        default: ''
         type: string
 
 permissions:
@@ -20,8 +52,9 @@ permissions:
 
 jobs:
   native:
-    runs-on: windows-2022
-    timeout-minutes: 10
+    # Do not let workflow_call inputs select arbitrary self-hosted runners.
+    runs-on: ${{ inputs.runner == 'windows-11-arm' && 'windows-11-arm' || 'windows-2022' }}
+    timeout-minutes: 25
     steps:
       - name: Check out the dispatched native tester
         uses: actions/checkout@v4
@@ -31,42 +64,69 @@ jobs:
 
       - name: Verify selected package build
         id: selected
-        uses: actions/github-script@v7
+        shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           BUILD_RUN_ID: ${{ inputs.build_run_id }}
-        with:
-          script: |
-            const fs = require('node:fs/promises');
-            const evidence = '.build/windows-native-recheck-evidence';
-            await fs.mkdir(evidence, {recursive: true});
-            const requested = process.env.BUILD_RUN_ID;
-            const selection = {build_run_id: requested, tester_sha: context.sha,
-              tester_run_id: context.runId, selection_verified: false};
-            await fs.writeFile(`${evidence}/selection.json`, JSON.stringify(selection, null, 2) + '\n');
-            if (!/^[1-9][0-9]{0,14}$/.test(requested)) {
-              throw new Error('build_run_id must be a positive numeric workflow run ID');
-            }
-            const run_id = Number(requested);
-            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id});
-            if (run.path !== '.github/workflows/windows-build.yml'
-                || run.head_repository?.full_name !== `${context.repo.owner}/${context.repo.repo}`
-                || !/^[0-9a-f]{40}$/.test(run.head_sha)) {
-              throw new Error('Select a Windows build run from this repository with a valid source commit');
-            }
-            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun,
-              {...context.repo, run_id, filter: 'latest', per_page: 100});
-            if (!jobs.some(job => job.name === 'package' && job.steps?.some(step =>
-                step.name === 'Build and smoke-test package' && step.conclusion === 'success'))) {
-              throw new Error('The selected run did not successfully finish building and smoke-testing its package');
-            }
-            Object.assign(selection, {selection_verified: true, bundle_source_sha: run.head_sha,
-              build_run_url: run.html_url, build_run_attempt: run.run_attempt,
-              artifact_name: 'LightTable-windows-x64'});
-            await fs.writeFile(`${evidence}/selection.json`, JSON.stringify(selection, null, 2) + '\n');
-            core.setOutput('source_sha', run.head_sha);
-            core.info(`Tester ${context.sha}; package source ${run.head_sha}; build run ${run_id}`);
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          EXPECTED_RUNNER: ${{ inputs.runner || 'windows-2022' }}
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
+          TESTER_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PYCODE'
+          import json, os, re, sys
+          from pathlib import Path
+          sys.path.insert(0, 'scripts/release')
+          from prepare_candidate import build_run
+          if os.environ['EXPECTED_RUNNER'] not in ('windows-2022', 'windows-11-arm'):
+              raise SystemExit('Unsupported acceptance runner')
+          if os.environ['INSTALLER_SHA256'] and not re.fullmatch(r'[0-9a-f]{64}', os.environ['INSTALLER_SHA256']):
+              raise SystemExit('An exact lowercase installer SHA-256 is required')
+          run = build_run(os.environ['BUILD_RUN_ID'], 'windows-x64')
+          source = os.environ['SOURCE_REVISION'] or run['head_sha']
+          if not re.fullmatch(r'[0-9a-f]{40}', source):
+              raise SystemExit('A full source revision is required')
+          evidence = Path('.build/windows-native-recheck-evidence')
+          evidence.mkdir(parents=True, exist_ok=True)
+          (evidence / 'selection.json').write_text(json.dumps({
+              'build_run_id': os.environ['BUILD_RUN_ID'], 'build_workflow_revision': run['head_sha'],
+              'bundle_source_sha': source, 'tester_sha': os.environ['TESTER_SHA'],
+              'selection_verified': True, 'artifact_name': 'LightTable-windows-x64'}, indent=2) + '\n')
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+              output.write('source_sha=' + source + '\n')
+          PYCODE
+
+      - name: Record and verify Windows test host
+        shell: pwsh
+        env:
+          EXPECTED_RUNNER: ${{ inputs.runner || 'windows-2022' }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $OS = Get-CimInstance Win32_OperatingSystem
+          $Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+          @{
+            caption = $OS.Caption
+            version = $OS.Version
+            build = $OS.BuildNumber
+            product_type = $OS.ProductType
+            os_architecture = $Arch
+            application_architecture = "x64"
+            execution = $(if ($Arch -eq "Arm64") { "x64 emulation" } else { "native x64" })
+            image_version = $env:ImageVersion
+            runner = $env:EXPECTED_RUNNER
+            fresh_offline_webview2_absent_test = $false
+          } | ConvertTo-Json | Set-Content .build/windows-native-recheck-evidence/host.json
+          if ($env:EXPECTED_RUNNER -eq "windows-2022" -and
+              ($OS.ProductType -eq 1 -or $Arch -ne "X64")) {
+            throw "Expected a Windows Server x64 host"
+          }
+          if ($env:EXPECTED_RUNNER -eq "windows-11-arm" -and
+              ($OS.ProductType -ne 1 -or [int]$OS.BuildNumber -lt 22000 -or $Arch -ne "Arm64")) {
+            throw "Expected a Windows 11 ARM client host"
+          }
 
       - name: Download the selected Windows package
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: LightTable-windows-x64
@@ -75,14 +135,69 @@ jobs:
           run-id: ${{ inputs.build_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Check the signed installer on the selected host
+        if: inputs.installer_sha256 != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
+          BUNDLE_SOURCE_SHA: ${{ steps.selected.outputs.source_sha }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $Clock = [Diagnostics.Stopwatch]::StartNew()
+          $Report = @{ok = $false; installer_sha256 = $env:INSTALLER_SHA256}
+          try {
+            if ($env:INSTALLER_SHA256 -cnotmatch '^[0-9a-f]{64}$') { throw "Expected a SHA-256 digest" }
+            $Version = & ./scripts/windows/verify-native-candidate.ps1 -Directory .build/windows-native-download `
+              -SourceRevision $env:BUNDLE_SOURCE_SHA -InstallerSha256 $env:INSTALLER_SHA256
+            $TagSource = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/v$Version" --jq '.sha').Trim()
+            if ($LASTEXITCODE -ne 0 -or $TagSource -cne $env:BUNDLE_SOURCE_SHA) {
+              throw "Signed candidate version tag does not select its source"
+            }
+            $Report.bundle_source_sha = $env:BUNDLE_SOURCE_SHA
+            $Installers = @(Get-ChildItem .build/windows-native-download -Filter '*-setup.exe')
+            if ($Installers.Count -ne 1) { throw "Expected one installer" }
+            $Installer = $Installers[0]
+            if ((Get-FileHash $Installer.FullName -Algorithm SHA256).Hash.ToLowerInvariant() -cne $env:INSTALLER_SHA256) {
+              throw "Installer differs from the independently verified candidate"
+            }
+            $Signature = Get-AuthenticodeSignature $Installer.FullName
+            if ($Signature.Status -ne 'Valid') { throw "Installer signature is not valid" }
+            $Report.signer = $Signature.SignerCertificate.Subject
+            $Report.version = $Version
+            & ./scripts/windows/installer-smoke.ps1 -Installer $Installer.FullName -Version $Version -ExpectedPublisher 'Chonkers LLC' -VerifyStoreSignatures -SignatureReport .build/windows-native-recheck-evidence/installed-signatures.json
+            if ($LASTEXITCODE -ne 0) { throw "Installer acceptance failed" }
+            $Report.ok = $true
+          } catch {
+            $Report.error = $_.Exception.Message
+            throw
+          } finally {
+            $Report.elapsed_seconds = [Math]::Round($Clock.Elapsed.TotalSeconds, 3)
+            $Report | ConvertTo-Json -Depth 5 | Set-Content .build/windows-native-recheck-evidence/installer.json
+          }
+
       - name: Verify bundle identity and run native acceptance
+        if: ${{ !cancelled() && steps.download.conclusion == 'success' }}
         shell: pwsh
         env:
           BUNDLE_SOURCE_SHA: ${{ steps.selected.outputs.source_sha }}
           TESTER_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          INSTALLER_SHA256: ${{ inputs.installer_sha256 }}
         run: |
           $ErrorActionPreference = "Stop"
           Set-StrictMode -Version Latest
+          if ($env:INSTALLER_SHA256) {
+            # Still run native checks after an installer failure, but never execute
+            # an archive that failed the candidate's source/hash verification.
+            $CandidateVersion = & ./scripts/windows/verify-native-candidate.ps1 -Directory .build/windows-native-download `
+              -SourceRevision $env:BUNDLE_SOURCE_SHA -InstallerSha256 $env:INSTALLER_SHA256
+            $TagSource = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/v$CandidateVersion" --jq '.sha').Trim()
+            if ($LASTEXITCODE -ne 0 -or $TagSource -cne $env:BUNDLE_SOURCE_SHA) {
+              throw "Candidate tag/source identity did not pass"
+            }
+          }
           # Diagnostic tooling stays outside the release archive. The pinned
           # profiler reads stacks only after failure, from test-owned Python.
           $ProfilerArchive = "./.build/windows-stack-dumper.zip"
@@ -101,6 +216,12 @@ jobs:
           if ($Manifest.source_revision -cne $env:BUNDLE_SOURCE_SHA) {
             throw "The downloaded bundle source does not match the selected Windows build run"
           }
+          if ($env:SOURCE_REVISION) {
+            $TagSource = (& gh api "repos/$env:GITHUB_REPOSITORY/commits/v$($Manifest.version)" --jq '.sha').Trim()
+            if ($LASTEXITCODE -ne 0 -or $TagSource -cne $env:BUNDLE_SOURCE_SHA) {
+              throw "Explicit package source does not match its immutable version tag"
+            }
+          }
           $Tester = (& git rev-parse HEAD).Trim()
           if ($LASTEXITCODE -ne 0 -or $Tester -cne $env:TESTER_SHA) { throw "The native tester checkout has an unexpected source commit" }
           @{
@@ -110,8 +231,17 @@ jobs:
             archive = $Archive.Name
             archive_sha256 = (Get-FileHash -LiteralPath $Archive.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
           } | ConvertTo-Json | Set-Content -LiteralPath ./.build/windows-native-recheck-evidence/identity.json -Encoding utf8
-          & "$Bundle/Python/python.exe" -B ./scripts/windows/desktop-smoke.py $Bundle --timeout 240 --report-dir ./.build/windows-native-recheck-evidence/native --stack-dumper $StackDumper
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          . ./scripts/windows/build-timing.ps1
+          $Timing = New-BuildTiming -Path .build/windows-native-recheck-evidence/native-timings.json -Version $Manifest.version
+          $Succeeded = $false
+          try {
+            Start-BuildStage $Timing "native-client-smoke"
+            & "$Bundle/Python/python.exe" -B ./scripts/windows/desktop-smoke.py $Bundle --timeout 240 --report-dir ./.build/windows-native-recheck-evidence/native --stack-dumper $StackDumper
+            if ($LASTEXITCODE -ne 0) { throw "Native acceptance failed with exit code $LASTEXITCODE" }
+            $Succeeded = $true
+          } finally {
+            Complete-BuildTiming $Timing $Succeeded
+          }
 
       - name: Upload native recheck evidence
         if: always()
@@ -120,3 +250,4 @@ jobs:
           name: Windows-native-recheck
           path: .build/windows-native-recheck-evidence/
           if-no-files-found: ignore
+          retention-days: 90

--- a/docs/release-promotion.md
+++ b/docs/release-promotion.md
@@ -1,0 +1,75 @@
+# Prepare once, promote one platform at a time
+
+`release.yml` builds selected platforms. `release-prepare.yml` consumes the
+completed build artifacts and emits `LightTable-PLATFORM-promotion`, containing
+the immutable binaries, installer definitions, checksums, proof files, and a
+candidate manifest. The release source is the version tag's commit; the workflow
+revision may be newer and is recorded separately.
+
+Run **Promote verified release candidate** (`release-promote.yml`) manually with
+the exact version, source revision, original build run, preparation run, and
+platform. Its default is a dry run. It does not rebuild or sign anything. A failed
+platform in the original build does not block another platform whose required
+package and native checks passed.
+
+The promotion artifact must contain a flat, complete set of files named in
+`LightTable-VERSION-PLATFORM-release.json`. Preparation records `candidate` and
+`pending`; promotion changes these to `ready` and `passed` only after independently
+fetching and verifying the original binaries and platform evidence. The version
+tag and embedded source/version/clean-worktree identity must agree. Legacy bundles
+without the required identity fields require a separately reviewed migration;
+this workflow does not invent the missing evidence.
+
+Keep **dry_run** enabled for the first pass. If the target GitHub release is
+missing, the plan includes creating its draft. Disabling **dry_run** creates that
+draft only after all evidence passes, then adds missing assets. Existing drafts
+and public releases resume without replacing assets. Authentication or network
+failures never count as a missing release. **make_public** publishes the verified
+draft, including one created by this run.
+**advance_feed** also requires **make_public**, and changes only the selected
+platform's app-owned updater after anonymous public downloads match every
+published hash. Linux and Windows use their respective `desktop-updates` assets;
+macOS uses the latest release's appcast, matching the existing installed client.
+
+Existing assets and platform manifests are immutable. Identical retries skip
+those files; a name with different bytes fails. Separate
+`LightTable-VERSION-PLATFORM-installers.tar.gz` and
+`LightTable-VERSION-PLATFORM-SHA256SUMS` names allow another platform to join later.
+The only replaceable files are the selected platform's signed updater pointer.
+Older feed versions and different feed bytes for the same version are rejected.
+A feed repair needs a separate review.
+
+## Required proof
+
+- **Linux:** original portable archive, its production-key signed feed, and the
+  original build's `Linux-X11-native-acceptance/report.json` with the matching
+  clean source, rendered/exported photo, persistence, and normal reopen/close.
+- **Windows:** original archive and installer, matching timestamped Authenticode
+  receipt, signed appcast, and a completed `windows-client-vm.yml` run containing
+  both `Windows-10-x64-client-acceptance` and
+  `Windows-11-x64-client-acceptance`. Each requires actual native x64 client host
+  details, exact installer hash, unelevated/offline installation with WebView2
+  initially absent, a complete installed PE signature audit including the
+  uninstaller, and `native/report.json` proving edit/export/reopen. Windows Server
+  or Windows 11 ARM emulation results do not satisfy this gate.
+- **macOS:** the original `macos-release-proof.json` binds the final artifact
+  hashes to clean Apple silicon source, strict signature verification, and the
+  packaged real-photo acceptance receipt. Stable releases additionally require
+  the producer's notarization/Gatekeeper proof. Ad-hoc beta builds are manual
+  update channels.
+
+Windows native and client VM acceptance accept an optional `source_revision`
+when the build workflow ran from a different revision. Signed candidates must
+match the immutable version tag before installer execution. The workflow source
+and package source remain separate in the evidence.
+
+Client/native evidence and promotion results are retained for 90 days. Keep the
+preparation artifact and original build artifacts available through publication;
+expired evidence blocks promotion rather than triggering a new build. VM disks,
+account configuration, and Windows installation media are excluded from evidence.
+
+The promotion result includes the platform manifest, source, tag, release URL and
+publication time, and independent public-download verification state. Website
+synchronization must consume a successful public verification result, then deploy
+and verify the live affected pages before reporting website publication complete.
+The promotion workflow itself makes no website-publication claim.

--- a/release/README.md
+++ b/release/README.md
@@ -11,14 +11,21 @@ x86_64. Each platform needs its own native release validation.
 
 ## Current readiness
 
-Installer generation, the bundled CLI, npm installer code, and release workflows
-are implemented. There is no published desktop version yet. A public Mac release
-requires a Developer ID Application certificate and notarization credentials.
-Windows code signing and npm authentication must also be configured before their
-signed/npm distribution paths can be used. A failed preflight publishes nothing.
-Windows and Linux updater integration is present in source. A signed native
-upgrade, configured signing keys, and published feeds are still required before
-automatic updates can be delivered.
+See [the machine-readable release manifest](manifest.json) for exact current
+platform versions, artifacts, signing and blockers. Linux portable 0.6 and
+macOS 0.6 beta are public; Windows 0.6 remains a signed candidate pending native
+Windows 10/11 x64 clean/offline acceptance. A Mac beta is manual-update only.
+Store enrollment and review remain separate from direct distribution.
+
+## Repeatable release process
+
+Use [the release process guide](process.md): pin one source tag, build selected
+platforms independently, prepare the existing artifact bytes, then promote a
+verified platform without rebuilding successful candidates. All release
+workflows are manually dispatched, with no schedule or tag-triggered publication.
+Promotion defaults to a read-only plan and never replaces public binaries.
+Each platform gets its own immutable installer-definition archive and checksums.
+The canonical manifest drives the website's version labels and download choices.
 
 ## Validate candidates before publication
 
@@ -33,8 +40,8 @@ gh workflow run linux-build.yml --ref CANDIDATE_BRANCH
 These workflows upload CI artifacts; they do not create a public release or
 publish update feeds. Record the resolved commit from each run, and compare it
 with the downloaded package manifest. An unsigned Windows CI package cannot
-establish Authenticode or public update trust. Do not push a release tag simply
-to test packaging: the separate Release workflow publishes successful builds.
+establish Authenticode or public update trust. Release tags pin source only. The Release build workflow retains candidates;
+the separate promotion workflow validates exact evidence before publication.
 
 Portable Windows and Linux apps read their source revision from the bundled
 manifest. Extracting an app inside a Git checkout must not run that checkout's

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "version": "0.6.0",
+  "source_revision": "0ae5e9aaf90b3554ad1d027d5b6b10667cd61ae2",
+  "repository": "reville/lighttable-digital-darkroom",
+  "platforms": {
+    "linux-x86_64": {
+      "version": "0.6.0",
+      "channel": "stable",
+      "minimum_os": "Ubuntu 24.04+",
+      "update_owner": "app",
+      "state": "published",
+      "signing": "ed25519",
+      "validation": {
+        "status": "passed",
+        "receipts": [
+          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34435011848"
+        ]
+      },
+      "gates": [],
+      "artifacts": [
+        {
+          "name": "LightTable-0.6.0-linux-x86_64.tar.gz",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz",
+          "bytes": 363504544,
+          "sha256": "4b116ac098df209a3c755ef751e19ed226da5621d9238f9c2bb3dbe94fe020f5"
+        },
+        {
+          "name": "LightTable-0.6.0-linux-x86_64.tar.gz.sha256",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz.sha256",
+          "bytes": 103,
+          "sha256": "9ee243d24344a8448feaa916fc7c1a0761acd113e171d58b5ff247118c0b6f33"
+        },
+        {
+          "name": "lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst",
+          "bytes": 343675816,
+          "sha256": "0a2f964ec1be558cd92537484e4d0f8c0789d4b79f5af967f7de58865e3c8565"
+        },
+        {
+          "name": "lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst.sha256",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst.sha256",
+          "bytes": 108,
+          "sha256": "2690a6412aba7ce048f074d3b166ea64f6bb8eb2035e202211de2663d0d3bd46"
+        }
+      ],
+      "published_at": "2026-09-10T03:51:06Z",
+      "tag": "v0.6.0"
+    },
+    "macos-arm64": {
+      "version": "0.6.0-beta.1",
+      "channel": "beta",
+      "minimum_os": "macOS 14+",
+      "update_owner": "manual",
+      "state": "published",
+      "signing": "ad-hoc",
+      "validation": {
+        "status": "passed",
+        "receipts": [
+          "https://github.com/reville/lighttable-digital-darkroom/releases/tag/macos-v0.6.0-beta.1"
+        ]
+      },
+      "gates": [],
+      "artifacts": [
+        {
+          "name": "LightTable-0.6.0-beta.1-macos-arm64.dmg",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/macos-v0.6.0-beta.1/LightTable-0.6.0-beta.1-macos-arm64.dmg",
+          "bytes": 349428501,
+          "sha256": "cd1beafccfe2f455e91a5377d6ba4ca61394094bf34acb2521dda9627eb31b20"
+        },
+        {
+          "name": "LightTable-0.6.0-beta.1-macos-arm64.dmg.sha256",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/macos-v0.6.0-beta.1/LightTable-0.6.0-beta.1-macos-arm64.dmg.sha256",
+          "bytes": 106,
+          "sha256": "e33333701e501afd902b3f08e235eb5a69e69e34f37b5e0487826a8aca525dbd"
+        }
+      ],
+      "published_at": "2026-09-10T03:46:23Z",
+      "tag": "macos-v0.6.0-beta.1",
+      "build_source_revision": "438bb12693a1d117cc3c5cbce56ec05252b243ee",
+      "source_tree": "a8b776446890dd88ca3fc44aab0a1cad7544633e"
+    },
+    "windows-x64": {
+      "version": "0.6.0",
+      "channel": "stable",
+      "minimum_os": "Windows 10/11 x64",
+      "update_owner": "manual",
+      "state": "blocked",
+      "signing": "authenticode",
+      "validation": {
+        "status": "pending",
+        "receipts": [
+          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34434174967"
+        ]
+      },
+      "gates": [
+        "Native Windows 10/11 x64 offline acceptance"
+      ],
+      "artifacts": []
+    }
+  }
+}

--- a/release/process.md
+++ b/release/process.md
@@ -1,0 +1,205 @@
+# Build once, promote each platform independently
+
+A release has one immutable source cutoff and independently verified platform
+artifacts. A blocked Windows or store channel does not prevent an accepted Linux
+or macOS channel from progressing. No recurring release scheduler is required.
+
+The manual build, preparation and promotion workflows have separate jobs:
+
+1. **Build:** select platforms and the existing immutable release tag. Run the
+   credential/source/environment preflight before expensive native builds. Keep
+   the successful original build artifacts, even when another platform fails.
+2. **Prepare:** dispatch `release-prepare.yml` with the original build run,
+   expected source revision, platform and embedded version. It downloads the
+   original bytes, generates installer definitions and a platform manifest, and
+   retains `LightTable-PLATFORM-promotion`. It never rebuilds an app or publishes
+   a release. Optional `native_run_id` identifies separate acceptance evidence;
+   preparation does not declare that evidence passed.
+3. **Verify and plan:** promotion resolves the original build and native evidence,
+   verifies the exact candidate, and prints missing versus already matching
+   release assets. The default is read-only. A manifest's own `ready` label is
+   not independent signature or native acceptance proof.
+4. **Promote:** explicitly apply the verified plan, independently download and
+   verify the public assets, then advance only that platform's signed update
+   feed. Synchronize the reviewed aggregate manifest to the website and package
+   channels. Verify live versions, links and checksums before reporting success.
+
+The original build's `head_sha` identifies the workflow revision; a manual build
+may check out a different pinned release tag. The manifest's `source_revision`
+must match the immutable release tag and bundled build identity. Record
+`build_workflow_revision` separately. Preparation accepts a completed build with
+an unrelated failed platform only when the selected package job and its required
+native/proof step passed. Fork and pull-request runs are rejected.
+
+For an ad-hoc Mac beta, explicitly select the beta channel and manual update
+owner, and create its `macos-vVERSION-beta.N` tag at the verified source before
+preparation. Stable Mac publication always requires Developer ID, notarization,
+native acceptance and Sparkle signing; no missing credential selects a weaker
+channel automatically.
+
+## One versioned data contract
+
+[`release-manifest.schema.json`](../scripts/release/release-manifest.schema.json)
+defines schema version 1. `release_process.py validate_manifest()` additionally
+checks version/channel agreement, exact GitHub repository/tag/asset ownership,
+safe unique filenames and platform policy. This is public metadata: no keys,
+tokens, passwords or secret values belong in it.
+
+```json
+{
+  "schema_version": 1,
+  "repository": "reville/lighttable-digital-darkroom",
+  "tag": "v1.2.3",
+  "version": "1.2.3",
+  "source_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "platforms": {
+    "linux-x86_64": {
+      "version": "1.2.3",
+      "channel": "stable",
+      "minimum_os": "Ubuntu 24.04+; current Arch Linux/Omarchy",
+      "update_owner": "app",
+      "state": "candidate",
+      "signing": "ed25519",
+      "build_run_id": "123456",
+      "gates": ["Exact-artifact native acceptance is pending"],
+      "validation": {"status": "pending", "receipts": []},
+      "artifacts": []
+    }
+  }
+}
+```
+
+Platform keys are `linux-x86_64`, `windows-x64` and `macos-arm64`. Platform states
+are `candidate`, `blocked`, `ready` and `published`. Artifact records contain
+`name`, canonical public `url`, positive `bytes` and lowercase `sha256`. Optional
+artifact `update_owner` can distinguish a package manager archive from a portable
+app. Empty artifacts are valid only for planning a candidate or blocked channel.
+
+Each published platform keeps its own immutable manifest:
+`LightTable-VERSION-PLATFORM-release.json`. A manifest cannot hash itself. The
+website's aggregate uses the same schema, includes all three platform entries,
+and records independently verified publication state. An aggregate may contain
+different platform versions, so advancing Linux to 0.7 does not remove a still
+supported Mac 0.6 beta. Entries outside the top-level release version must provide
+their own `source_revision` and `tag`; same-base beta/stable entries may share the
+top-level source but still need their own tag. A historical same-tree build can record
+`build_source_revision` plus `source_tree`; new promotion requires the exact
+source revision and does not use that historical exception.
+
+Do not modify an immutable platform manifest merely to update a receipt link or
+to add another platform. Update the reviewed aggregate instead. The website
+publishes download links only for accepted, published entries; a blocked entry
+does not need a guessed future URL.
+
+## Read-only preflight
+
+Create a candidate manifest without `--artifact` before building. Pass the
+following **presence metadata**, collected from source/tag checks, configured
+runner/environment access and secret names. Credential values are never read or
+printed by this CLI.
+
+```json
+{
+  "source_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source_clean": true,
+  "tag_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "platforms": {
+    "linux-x86_64": {
+      "release_environment_allowed": true,
+      "build_runner_ready": true,
+      "native_acceptance_ready": true,
+      "credentials": {"linux_update_signing": true}
+    }
+  }
+}
+```
+
+```sh
+python3 scripts/release/release_process.py preflight \
+  --manifest candidate.json --capabilities capabilities.json \
+  --platform linux-x86_64 --phase build
+```
+
+Credential capability keys are `linux_update_signing` for Linux;
+`windows_authenticode` and `sparkle_signing` for Windows; and
+`macos_developer_id`, `macos_notarization`, `sparkle_signing` for stable Mac.
+Only an explicitly ad-hoc, manual beta omits stable Mac credentials.
+
+The matrix separates `build_ready` from `promotion_ready`. `--phase publish`
+also requires passed acceptance receipts, no outstanding gates, correct signing
+policy and native acceptance availability. A blocked selection exits 2; malformed
+input or failed verification exits 1. Unselected platforms remain in the matrix
+but do not block the selected ones. Presence alone never proves signing validity.
+
+## Additive publication and retries
+
+The reusable CLI verifies local artifacts and, for Linux tarballs and Windows
+portable ZIPs, the embedded version/source/clean/platform metadata. It reads
+metadata directly from archives without extracting them. Windows ZIPs also need
+the declared Authenticode build marker; independent signature verification remains
+the promotion workflow's responsibility. Legacy bundles missing clean/platform
+metadata are not silently exempted.
+
+```sh
+python3 scripts/release/release_process.py verify \
+  --manifest prepared/LightTable-1.2.3-linux-x86_64-release.json \
+  --artifacts-dir prepared
+
+python3 scripts/release/release_process.py publish \
+  --manifest prepared/LightTable-1.2.3-linux-x86_64-release.json \
+  --artifacts-dir prepared --platform linux-x86_64
+```
+
+`publish` without `--apply` only reads GitHub and prints the plan. The release/tag
+must already exist. Use the promotion workflow to create a missing draft, verify
+native/signature receipts, and apply only after those gates pass.
+
+For each remote asset: matching SHA-256 **and** size means skip; absent means
+add; any mismatch aborts. Old GitHub assets without digest metadata are downloaded
+and hashed. Every upload omits `--clobber`, including on drafts. Concurrent uploads
+fail safely and can be retried. Already uploaded bytes and the platform manifest
+are checked again after an apply. Feed advancement is a separate explicit step
+after independent public download verification.
+
+Installer archives and checksum files are platform-specific:
+
+- `LightTable-VERSION-PLATFORM-installers.tar.gz`
+- `LightTable-VERSION-PLATFORM-SHA256SUMS`
+
+The installer tar archive has normalized ordering, timestamps and ownership, so
+identical definitions produce identical bytes. Existing generic `SHA256SUMS`
+and combined `LightTable-VERSION-installers.tar.gz` files remain immutable.
+Canonical Arch names, `lighttable-bin-VERSION-PKGREL-x86_64.pkg.tar.zst`, remain
+supported and retain package-manager update ownership.
+
+Retry promotion from the **same completed preparation run**. Preparation reuses
+an existing public same-version Linux feed after verifying its GitHub digest,
+size and downloaded bytes. Generating a missing Linux feed uses the configured production key and current
+validity dates; a second preparation can therefore produce different signed
+metadata despite an identical app archive. Retaining and reusing the preparation
+artifact prevents accidental feed/manifest collisions. If assets have already
+been published, conflicting metadata must not be overwritten to force a retry.
+
+## Evidence and build timing
+
+Keep original build, preparation, signature verification, native acceptance,
+public download and live website verification distinct. Windows Server and
+Windows 11 ARM emulation do not establish native Windows 10/11 x64 offline
+acceptance. Store enrollment/review and direct download readiness are separate.
+
+Windows build timing records separate compilation, runtime/native tests,
+installer construction/signing and compression. Optimize the measured expensive
+stage; never reuse a candidate with a changed source or dependency identity merely
+to make a build appear faster.
+
+Focused offline regression coverage:
+
+```sh
+python3 -m unittest discover -s tests -p test_release_process.py
+```
+
+These tests exercise tampering, source/version/tag ownership, duplicate metadata,
+partial release resume, immutable manifests, blocked platform isolation,
+credential-presence policy, independent successful jobs, byte-preserving candidate
+preparation and deterministic archive generation. They do not claim a real public
+promotion or native updater run.

--- a/scripts/release/download_upgrade.py
+++ b/scripts/release/download_upgrade.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Download exact public Linux packages, pinned to GitHub's published SHA-256."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+
+REPO = 'reville/lighttable-digital-darkroom'
+VERSION = re.compile(r'(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)')
+
+def download(version, directory):
+    if not VERSION.fullmatch(version): raise ValueError('Expected a stable version')
+    release = json.loads(subprocess.check_output(['gh', 'api', f'repos/{REPO}/releases/tags/v{version}']))
+    if release['draft'] or release['prerelease']: raise ValueError('Expected a public stable release')
+    name = f'LightTable-{version}-linux-x86_64.tar.gz'
+    assets = [a for a in release['assets'] if a['name'] == name]
+    if len(assets) != 1: raise ValueError('Expected one Linux archive')
+    item = assets[0]
+    if not re.fullmatch(r'sha256:[0-9a-f]{64}', item.get('digest', '')): raise ValueError('Published asset has no immutable SHA-256')
+    url = f'https://github.com/{REPO}/releases/download/v{version}/{name}'
+    if item['browser_download_url'] != url: raise ValueError('Unexpected release asset URL')
+    directory.mkdir(exist_ok=True)
+    path = directory/name
+    subprocess.run(['curl', '--fail', '--location', '--proto', '=https', '--proto-redir', '=https', '--retry', '2', '--max-time', '240', '--output', str(path), url], check=True)
+    with path.open('rb') as source: digest = hashlib.file_digest(source, 'sha256').hexdigest()
+    if path.stat().st_size != item['size'] or 'sha256:'+digest != item['digest']: raise ValueError('Downloaded public bytes do not match GitHub digest/size')
+    return dict(version=version, name=name, url=url, bytes=item['size'], sha256=digest)
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--baseline',required=True);parser.add_argument('--target',required=True)
+    args=parser.parse_args()
+    for v in (args.baseline,args.target):
+        if not VERSION.fullmatch(v): parser.error('Stable versions required')
+    if tuple(map(int,args.baseline.split('.'))) >= tuple(map(int,args.target.split('.'))): parser.error('Target must be newer than baseline')
+    records=[download(args.baseline,Path('baseline')),download(args.target,Path('candidate'))]
+    evidence=Path('evidence');evidence.mkdir(exist_ok=True)
+    (evidence/'public-downloads.json').write_text(json.dumps(records,indent=2)+'\n')
+    subprocess.run(['curl','--fail','--location','--proto','=https','--proto-redir','=https','--retry','2','--max-time','30','--output',str(evidence/'linux-x86_64.json'),f'https://github.com/{REPO}/releases/download/desktop-updates/linux-x86_64.json'],check=True)
+
+if __name__=='__main__':main()

--- a/scripts/release/macos_receipt.py
+++ b/scripts/release/macos_receipt.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Record native/signing evidence for the final Mac candidate, without publishing."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import plistlib
+import re
+import subprocess
+
+
+def checked(*args):
+    subprocess.run(args, check=True, capture_output=True)
+
+
+def create(app, native, artifacts, channel):
+    info = plistlib.loads((app / 'Contents/Info.plist').read_bytes())
+    assert info.get('LightTableSourceDirty') is False, 'Dirty source cannot be released'
+    assert native.get('ok') is True and native.get('layer') == 'package' and native.get('fixtureCount', 0) > 0, 'Real native package acceptance required'
+    assert native.get('machine', {}).get('machine') == 'arm64', 'Apple silicon proof required'
+    checked('codesign', '--verify', '--deep', '--strict', str(app))
+    stable = channel == 'stable'
+    version = info['CFBundleShortVersionString']
+    pattern = r'\d+\.\d+\.\d+' if stable else r'\d+\.\d+\.\d+-beta\.[1-9]\d*'
+    assert re.fullmatch(pattern, version), 'Channel does not match embedded version'
+    assert re.fullmatch(r'[a-f0-9]{40}', info['LightTableSourceRevision']), 'Exact source required'
+    if stable:
+        checked('xcrun', 'stapler', 'validate', str(app))
+        checked('spctl', '--assess', '--type', 'execute', str(app))
+    else:
+        assert info.get('SUEnableAutomaticChecks') is False, 'Manual beta must disable automatic update checks'
+    records = []
+    for path in artifacts:
+        assert path.is_file() and not path.is_symlink(), 'Missing artifact'
+        if stable and path.suffix == '.dmg':
+            checked('codesign', '--verify', '--strict', str(path))
+            checked('xcrun', 'stapler', 'validate', str(path))
+        with path.open('rb') as source:
+            digest = hashlib.file_digest(source, 'sha256').hexdigest()
+        records.append(dict(name=path.name, bytes=path.stat().st_size, sha256=digest))
+    assert any(item['name'].endswith('.dmg') for item in records), 'DMG required'
+    return dict(schema_version=1, source_revision=info['LightTableSourceRevision'], source_dirty=False,
+                version=info['CFBundleShortVersionString'], channel=channel, architecture='arm64',
+                minimum_os=info['LSMinimumSystemVersion'], update_public_key=info.get('SUPublicEDKey'), signing='developer-id-notarized' if stable else 'ad-hoc',
+                native=native, artifacts=records, code_signature_verified=True, notarization_verified=stable)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--app', required=True, type=Path)
+    parser.add_argument('--native', required=True, type=Path)
+    parser.add_argument('--artifact', required=True, type=Path, action='append')
+    parser.add_argument('--channel', choices=['stable', 'beta'], required=True)
+    parser.add_argument('--output', required=True, type=Path)
+    args = parser.parse_args()
+    result = create(args.app, json.loads(args.native.read_text()), args.artifact, args.channel)
+    args.output.write_text(json.dumps(result, indent=2) + '\n')
+
+if __name__ == '__main__': main()

--- a/scripts/release/prepare_candidate.py
+++ b/scripts/release/prepare_candidate.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Prepare an existing successful build for independent promotion; never rebuild it."""
+from __future__ import annotations
+
+import argparse
+import gzip
+import importlib.util
+import io
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+import release_process as release
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = {"linux-x86_64": {".github/workflows/linux-build.yml", ".github/workflows/release.yml"},
+             "windows-x64": {".github/workflows/windows-build.yml", ".github/workflows/release.yml"},
+             "macos-arm64": {".github/workflows/release.yml"}}
+MINIMUM_OS = {"linux-x86_64": "Ubuntu 24.04+; current Arch Linux/Omarchy", "windows-x64": "Windows 10/11 x64", "macos-arm64": "macOS 14 Sonoma or later"}
+
+
+def build_run(run_id, platform):
+    release.require(str(run_id).isdigit() and int(run_id) > 0, "build_run_id must be a positive GitHub run ID")
+    run = json.loads(release.gh("api", f"repos/{release.REPOSITORY}/actions/runs/{run_id}"))
+    release.require(run.get("status") == "completed", "original build run must have completed")
+    release.require(run.get("head_repository", {}).get("full_name") == release.REPOSITORY, "build run must originate in the canonical repository")
+    release.require(run.get("event") in ("push", "workflow_dispatch"), "pull-request or untrusted build events cannot supply release candidates")
+    release.require(run.get("path", "").split("@")[0] in WORKFLOWS[platform], "selected run is not an allowed original build workflow")
+    release.require(release.REVISION.fullmatch(run.get("head_sha", "")), "original build run has no immutable source SHA")
+    pages = json.loads(release.gh("api", f"repos/{release.REPOSITORY}/actions/runs/{run_id}/jobs?per_page=100", "--paginate", "--slurp"))
+    jobs = [job for page in pages for job in page["jobs"]]
+    prefix = {"linux-x86_64": "linux", "windows-x64": "windows", "macos-arm64": "macos"}[platform]
+    allowed = {prefix, prefix + "/package"} if platform == "macos-arm64" else {"package", prefix + "/package"}
+    matches = [job for job in jobs if "".join(job["name"].split()) in allowed]
+    release.require(len(matches) == 1 and matches[0].get("conclusion") == "success", "selected platform package job must have succeeded independently")
+    expected_step = {"linux-x86_64": "Require X11 native edit, RGB16 export and normal reopen", "windows-x64": "Require native edit, export and restart", "macos-arm64": "Bind final Mac artifacts to native and signing proof"}[platform]
+    release.require(any(step.get("name") == expected_step and step.get("conclusion") == "success" for step in matches[0].get("steps", [])), "selected platform job lacks successful native/package proof step")
+    run["selected_job_id"] = matches[0]["id"]
+    return run
+
+
+def deterministic_archive(files, destination):
+    with Path(destination).open("wb") as output:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=output, mtime=0) as compressed:
+            with tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive:
+                for name, content in sorted(files.items()):
+                    payload = content.encode("utf-8") if isinstance(content, str) else content
+                    member = tarfile.TarInfo(name)
+                    member.size = len(payload)
+                    member.mode = 0o644
+                    archive.addfile(member, io.BytesIO(payload))
+
+
+def installer_definitions(version, platform, directory, revision, tag):
+    specification = importlib.util.spec_from_file_location("release_installers", ROOT / "scripts/generate-installers.py")
+    installers = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(installers)
+    if "-beta." in version:
+        release.require(platform == "macos-arm64", "only manual macOS beta preparation is supported")
+        dmg = Path(directory) / f"LightTable-{version}-macos-arm64.dmg"
+        url = f"https://github.com/{release.REPOSITORY}/releases/download/{tag}/{dmg.name}"
+        files = installers.homebrew(version, url, release.file_identity(dmg)["sha256"])
+        files = {name.replace("lighttable.rb", "lighttable@beta.rb"): content.replace('cask "lighttable"', 'cask "lighttable@beta"').replace("auto_updates true", "auto_updates false").replace(":ventura", ":sonoma") for name, content in files.items()}
+        return files
+    channels = {"linux-x86_64": ["aur"], "windows-x64": ["scoop", "winget", "chocolatey"], "macos-arm64": ["homebrew"]}[platform]
+    files = installers.generate(version, Path(directory), channels, "GPL-3.0-only", f"https://github.com/{release.REPOSITORY}/blob/{tag}/LICENSE", False, revision)
+    if platform == "macos-arm64":
+        files = {name: content.replace(":ventura", ":sonoma") for name, content in files.items()}
+    return files
+
+
+def reuse_public_feed(tag, name, output):
+    """Reuse an already published feed verbatim; never re-sign its validity dates."""
+    try:
+        existing = json.loads(release.gh("api", f"repos/{release.REPOSITORY}/releases/tags/{tag}"))
+    except subprocess.CalledProcessError as error:
+        if "HTTP 404" in (error.stderr or ""):
+            return False
+        raise
+    if existing.get("draft"):
+        return False
+    matches = [asset for asset in existing.get("assets", []) if asset.get("name") == name]
+    if not matches:
+        return False
+    release.require(len(matches) == 1, "duplicate immutable feed assets")
+    asset = matches[0]
+    digest = asset.get("digest", "")
+    release.require(isinstance(digest, str) and digest.startswith("sha256:") and release.SHA.fullmatch(digest[7:]), "existing immutable feed requires an authoritative GitHub SHA-256 digest")
+    with tempfile.TemporaryDirectory(prefix="lighttable-existing-feed-") as temporary:
+        release.gh("release", "download", tag, "--repo", release.REPOSITORY, "--pattern", name, "--dir", temporary)
+        identity = release.file_identity(Path(temporary) / name)
+        release.require(identity["bytes"] == asset["size"] and identity["sha256"] == digest[7:], "existing immutable feed download identity mismatch")
+        shutil.copyfile(Path(temporary) / name, output)
+    return True
+
+
+def prepare(args):
+    release.require(release.VERSION.fullmatch(args.version), "invalid release version")
+    run = build_run(args.build_run_id, args.platform)
+    source = args.source_revision or run["head_sha"]
+    release.require(release.REVISION.fullmatch(source), "expected source must be a full Git commit")
+    output = Path(args.output_dir)
+    release.require(not output.exists() or not any(output.iterdir()), "output directory must be empty; reuse the completed preparation artifact for retries")
+    output.mkdir(parents=True, exist_ok=True)
+    platform, version = args.platform, args.version
+    stem = f"LightTable-{version}-{platform}"
+    beta = "-beta." in version
+    release.require(not beta or platform == "macos-arm64", "only macOS beta is supported")
+    tag = ("macos-v" if beta else "v") + version
+    tag_source = release.gh("api", f"repos/{release.REPOSITORY}/commits/{tag}", "--jq", ".sha").strip()
+    release.require(tag_source == source, "immutable platform tag does not match the expected build source")
+    receipts = [f"https://github.com/{release.REPOSITORY}/actions/runs/{args.build_run_id}"]
+    if args.native_run_id:
+        release.require(str(args.native_run_id).isdigit() and int(args.native_run_id) > 0, "native_run_id must be a positive GitHub run ID")
+        receipts.append(f"https://github.com/{release.REPOSITORY}/actions/runs/{args.native_run_id}")
+    with tempfile.TemporaryDirectory(prefix="lighttable-build-download-") as temporary:
+        release.gh("run", "download", str(args.build_run_id), "--repo", release.REPOSITORY, "--name", f"LightTable-{platform}", "--dir", temporary)
+        downloaded = Path(temporary)
+        expected = {"linux-x86_64": [stem + ".tar.gz"], "windows-x64": [stem + ".zip", stem + "-setup.exe", release.FEEDS[platform]], "macos-arm64": [stem + ".dmg"]}[platform]
+        if platform == "macos-arm64" and not beta:
+            expected.extend([stem + ".zip", release.FEEDS[platform]])
+        for name in expected:
+            release.file_identity(downloaded / name)
+        for path in sorted(downloaded.iterdir()):
+            release.require(path.is_file() and not path.is_symlink(), "original artifact must contain only regular top-level files")
+            # Keep installer/archive/feed bytes unchanged. Namespace proof files so
+            # platforms may join an existing public version without collisions.
+            name = path.name if path.name.startswith(stem) or path.name == release.FEEDS[platform] else stem + "-" + path.name
+            release.require(release.NAME.fullmatch(name), "unsafe downloaded artifact filename")
+            shutil.copyfile(path, output / name)
+    # Establish binary identity before generating or signing any derived metadata.
+    verification = {"version": version, "source_revision": source, "platforms": {platform: {"version": version, "signing": "authenticode" if platform == "windows-x64" else "ed25519"}}}
+    for path in output.iterdir():
+        release.verify_embedded(path, verification, platform)
+    if platform == "linux-x86_64" and not (output / release.FEEDS[platform]).exists() and not reuse_public_feed(tag, release.FEEDS[platform], output / release.FEEDS[platform]):
+        subprocess.run([sys.executable, str(ROOT / "scripts/generate-linux-update.py"), "--archive", str(output / (stem + ".tar.gz")), "--output", str(output / release.FEEDS[platform]), "--download-url", f"https://github.com/{release.REPOSITORY}/releases/download/{tag}/{stem}.tar.gz", "--release-notes-url", f"https://github.com/{release.REPOSITORY}/releases/tag/{tag}"], check=True)
+    if platform == "macos-arm64":
+        proof = release.read_json(output / (stem + "-macos-release-proof.json"))
+        release.require(proof.get("source_revision") == source and proof.get("version") == version and proof.get("source_dirty") is False, "Mac build proof source/version/clean identity mismatch")
+    files = installer_definitions(version, platform, output, source, tag)
+    names = release.platform_names(version, platform)
+    deterministic_archive(files, output / names["installers"])
+    identities = [release.file_identity(path) for path in sorted(output.iterdir())]
+    (output / names["checksums"]).write_text("".join(f"{item['sha256']}  {item['name']}\n" for item in identities), encoding="utf-8")
+    identity = {"schema_version": 1, "version": version, "repository": release.REPOSITORY, "tag": tag, "source_revision": source,
+                "platforms": {platform: {"version": version, "channel": "beta" if beta else "stable", "minimum_os": MINIMUM_OS[platform],
+                                         "update_owner": "manual" if beta else "app", "state": "candidate", "signing": "ad-hoc" if beta else {"linux-x86_64": "ed25519", "windows-x64": "authenticode", "macos-arm64": "developer-id-notarized"}[platform],
+                                         "build_run_id": str(args.build_run_id), "build_workflow_revision": run["head_sha"], "gates": [],
+                                         "validation": {"status": "pending", "receipts": receipts}, "artifacts": []}}}
+    entry = identity["platforms"][platform]
+    if args.native_run_id:
+        entry["native_run_id"] = str(args.native_run_id)
+    entry["artifacts"] = [{**release.file_identity(path), "url": release.asset_url(identity, path.name, platform)} for path in sorted(output.iterdir())]
+    release.verify_artifacts(identity, output)
+    release.write_json(output / names["manifest"], identity)
+    return {"manifest": str(output / names["manifest"]), "source_revision": source, "build_run_id": str(args.build_run_id), "state": "candidate", "artifact": f"LightTable-{platform}-promotion"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", required=True, choices=release.PLATFORMS)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--build-run-id", required=True)
+    parser.add_argument("--native-run-id")
+    parser.add_argument("--source-revision")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+    try:
+        print(json.dumps(prepare(args), indent=2))
+        return 0
+    except (ValueError, KeyError, OSError, subprocess.CalledProcessError) as error:
+        print("candidate preparation failed: " + ("required build, download or signing command failed" if isinstance(error, subprocess.CalledProcessError) else str(error)), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/promote_candidate.py
+++ b/scripts/release/promote_candidate.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Promote one already-built platform; dry-run unless --apply is explicit.
+
+The preparation artifact contains the immutable platform release manifest and its
+assets at its root. Original binaries and native/signing evidence are downloaded
+independently from the selected build/test runs. No compilation or signing occurs.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+from urllib.request import Request, urlopen
+import xml.etree.ElementTree as ET
+import zipfile
+
+import release_process as release
+from prepare_candidate import build_run
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+SPARKLE = 'http://www.andymatuschak.org/xml-namespaces/sparkle'
+SPARKLE_KEY = 'mrBmSL8f0FRN8j/imZxCWdCt0L4N3zP9kgOleH46eXA='
+BUILD_ARTIFACTS = {'linux-x86_64': 'LightTable-linux-x86_64',
+                   'windows-x64': 'LightTable-windows-x64', 'macos-arm64': 'LightTable-macos-arm64'}
+require = release.require
+
+
+def workflow_run(run_id, paths=None, source=None):
+    require(re.fullmatch(r'[1-9][0-9]{0,14}', str(run_id)), 'Invalid workflow run ID')
+    run = json.loads(release.gh('api', f'repos/{release.REPOSITORY}/actions/runs/{run_id}'))
+    require(run.get('conclusion') == 'success' and run.get('status') == 'completed'
+            and run.get('head_repository', {}).get('full_name') == release.REPOSITORY
+            and run.get('event') not in ('pull_request', 'pull_request_target'),
+            'Select a successful completed non-PR run in the public repository')
+    require(not paths or run.get('path') in paths, 'Unexpected producer workflow')
+    require(not source or run.get('head_sha') == source, 'Build run source differs from selected release source')
+    return run
+
+
+def download_artifact(run_id, name, directory):
+    require(re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._-]*', name), 'Unsafe artifact name')
+    directory.mkdir(parents=True, exist_ok=False)
+    release.gh('run', 'download', str(run_id), '--repo', release.REPOSITORY,
+               '--name', name, '--dir', str(directory))
+    return directory
+
+
+def check_identity(actual, expected, message):
+    require(actual.get('sha256') == expected['sha256'] and actual.get('bytes') == expected['bytes'], message)
+
+
+def primary_names(manifest, platform):
+    stem = f"LightTable-{manifest['version']}-{platform}"
+    if platform == 'linux-x86_64':
+        return [stem + '.tar.gz']
+    if platform == 'windows-x64':
+        return [stem + '.zip', stem + '-setup.exe']
+    names = [stem + '.dmg']
+    if manifest['platforms'][platform]['update_owner'] == 'app':
+        names.append(stem + '.zip')
+    return names
+
+
+def verify_original_binaries(manifest, platform, original):
+    assets = {a['name']: a for a in manifest['platforms'][platform]['artifacts']}
+    for name in primary_names(manifest, platform):
+        require(name in assets, f'Missing platform binary: {name}')
+        check_identity(release.file_identity(original / name), assets[name], 'Candidate differs from the original build artifact')
+
+
+def verify_native_report(report, manifest, platform):
+    require(report.get('ok') is True and report.get('export'), 'Native edit/export acceptance did not pass')
+    release.check_build_manifest(report.get('build', {}), manifest, platform)
+    if platform == 'windows-x64':
+        require(report.get('edit_persistence', {}).get('server_restarted') is True,
+                'Native Windows quit/reopen persistence is unproven')
+    elif platform == 'linux-x86_64':
+        require(report.get('http') == 200 and report.get('persistence') and report.get('final_close'),
+                'Native Linux quit/reopen persistence is unproven')
+
+
+def verify_windows_client(directory, windows, manifest, installer_hash):
+    host = release.read_json(directory / 'host.json')
+    result = release.read_json(directory / 'result.json')
+    build = int(host.get('build', 0))
+    require(host.get('ok') is True and host.get('product_type') == 1
+            and host.get('architecture') == 'AMD64'
+            and ((windows == '11' and build >= 22000) or (windows == '10' and 19041 <= build < 22000)),
+            f'Windows {windows} native x64 client identity is unproven')
+    require(host.get('webview2_absent_before_offline_install') is True
+            and host.get('network_adapters_disabled') is True
+            and host.get('installer_signature_before_disconnect') == 'Valid'
+            and result.get('ok') is True and result.get('offline') is True
+            and result.get('account_is_elevated') is False
+            and result.get('installer_sha256') == installer_hash,
+            f'Windows {windows} exact-installer offline, unelevated acceptance is unproven')
+    signatures = release.read_json(directory / 'installed-signatures.json')
+    entries = signatures.get('signatures', [])
+    require(signatures.get('invalid_count') == 0 and signatures.get('pe_count', 0) > 0
+            and len(entries) == signatures['pe_count'] and all(s.get('status') == 'Valid' for s in entries)
+            and any(s.get('path', '').replace('\\', '/').split('/')[-1].lower() == 'uninstall.exe' for s in entries),
+            'Installed payload signature audit, including uninstaller, did not pass')
+    verify_native_report(release.read_json(directory / 'native/report.json'), manifest, 'windows-x64')
+
+
+def verify_evidence(args, manifest, original, temporary):
+    platform = args.platform
+    if platform == 'linux-x86_64':
+        evidence = download_artifact(args.build_run_id, 'Linux-X11-native-acceptance', temporary / 'native')
+        verify_native_report(release.read_json(evidence / 'report.json'), manifest, platform)
+        return
+    if platform == 'windows-x64':
+        require(args.native_run_id, 'Windows promotion requires both native x64 client receipts')
+        workflow_run(args.native_run_id, {'.github/workflows/windows-client-vm.yml'})
+        signatures = release.read_json(original / 'windows-signatures.json')
+        assets = {a['name']: a for a in manifest['platforms'][platform]['artifacts']}
+        archive_name, installer_name = primary_names(manifest, platform)
+        installer_hash = assets[installer_name]['sha256']
+        require(signatures.get('source_revision') == manifest['source_revision']
+                and signatures.get('version') == manifest['version']
+                and signatures.get('archive_sha256') == assets[archive_name]['sha256'],
+                'Authenticode receipt source/archive identity differs')
+        rows = signatures.get('signatures', [])
+        required_names = {'LightTable.exe', 'WinSparkle.dll', 'lighttable-engine.exe', 'spektrafilm-rs.exe', installer_name}
+        require(len(rows) == len(required_names) and {r.get('file') for r in rows} == required_names
+                and all(r.get('status') == 'Valid' and r.get('timestamp_authority') for r in rows)
+                and any(r.get('file') == installer_name and r.get('sha256') == installer_hash for r in rows),
+                'Complete timestamped Authenticode proof is missing')
+        for windows in ('10', '11'):
+            evidence = download_artifact(args.native_run_id, f'Windows-{windows}-x64-client-acceptance',
+                                         temporary / f'windows-{windows}')
+            verify_windows_client(evidence, windows, manifest, installer_hash)
+        return
+    report = release.read_json(original / 'macos-release-proof.json')
+    require(report.get('schema_version') == 1 and report.get('source_revision') == manifest['source_revision']
+            and report.get('version') == manifest['version'] and report.get('source_dirty') is False
+            and report.get('architecture') == 'arm64', 'macOS proof identity mismatch')
+    required_assets = {name: release.file_identity(original / name) for name in primary_names(manifest, platform)}
+    recorded = {item['name']: item for item in report.get('artifacts', [])}
+    for name, identity in required_assets.items():
+        check_identity(recorded.get(name, {}), identity, 'macOS proof asset differs')
+    require(report.get('code_signature_verified') is True
+            and report.get('native', {}).get('ok') is True
+            and report.get('native', {}).get('layer') == 'package',
+            'macOS signature/package-render acceptance receipt is missing')
+    require(report.get('signing') == manifest['platforms'][platform]['signing'], 'macOS signing declaration differs')
+    if manifest['platforms'][platform]['update_owner'] == 'app':
+        require(report.get('update_public_key') == SPARKLE_KEY,
+                'macOS embedded update key differs from the verified signing key')
+    if manifest['platforms'][platform]['signing'] == 'developer-id-notarized':
+        require(report.get('notarization_verified') is True, 'macOS notarization/Gatekeeper receipt is missing')
+
+
+def version_key(value):
+    require(isinstance(value, str) and release.VERSION.fullmatch(value), 'Invalid feed version')
+    main, separator, beta = value.partition('-beta.')
+    return (*map(int, main.split('.')), 0 if separator else 1, int(beta) if separator else 0)
+
+
+def feed_version(data, platform):
+    if platform == 'linux-x86_64':
+        return json.loads(data)['signed']['version']
+    root = ET.fromstring(data)
+    require(root.tag == 'rss' and root.find('channel') is not None, 'Invalid appcast')
+    values = [enclosure.get(f'{{{SPARKLE}}}shortVersionString') or enclosure.get(f'{{{SPARKLE}}}version')
+              for enclosure in root.findall('./channel/item/enclosure')]
+    return max(values, key=version_key) if values else None
+
+
+def verify_signed_feed(manifest, platform, directory):
+    entry = manifest['platforms'][platform]
+    if entry['update_owner'] != 'app' and platform != 'linux-x86_64':
+        return None
+    feed = directory / release.FEEDS[platform]
+    require(feed.name in {a['name'] for a in entry['artifacts']}, 'App-owned update channel requires a verified feed asset')
+    if platform == 'linux-x86_64':
+        import desktop_updater
+        archive = directory / primary_names(manifest, platform)[0]
+        with tarfile.open(archive, 'r:gz') as stream:
+            members = [m for m in stream if m.name == 'LightTable/update-config.json']
+            require(len(members) == 1 and members[0].isfile() and members[0].size <= 65536, 'Missing embedded updater configuration')
+            config = json.load(stream.extractfile(members[0]))
+        public = os.environ.get('LIGHTTABLE_LINUX_UPDATE_PUBLIC_KEY', '')
+        require(public and config.get('public_key') == public, 'Linux update key is not the configured production key')
+        signed = desktop_updater.verify_manifest(release.read_json(feed), public, architecture='x86_64',
+                                                current_version=manifest['version'], hosts=desktop_updater.DOWNLOAD_HOSTS)
+        identity = release.file_identity(archive)
+        require(signed['version'] == manifest['version'] and signed['source_revision'] == manifest['source_revision']
+                and signed['url'] == release.asset_url(manifest, archive.name)
+                and signed['sha256'] == identity['sha256'] and signed['size'] == identity['bytes'],
+                'Signed Linux feed does not describe this exact release')
+    else:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        if platform == 'windows-x64':
+            archive = directory / primary_names(manifest, platform)[0]
+            with zipfile.ZipFile(archive) as bundle:
+                entries = [e for e in bundle.infolist() if e.filename == 'LightTable/LightTable.exe']
+                require(len(entries) == 1 and entries[0].file_size <= 128 * 1024 * 1024,
+                        'Windows updater executable is missing or ambiguous')
+                require(SPARKLE_KEY.encode('ascii') in bundle.read(entries[0]),
+                        'Windows executable does not contain the verified update public key')
+        root = ET.fromstring(feed.read_bytes())
+        entries = root.findall('./channel/item/enclosure')
+        require(len(entries) == 1, 'Candidate appcast must contain exactly this release')
+        enclosure = entries[0]
+        binary_name = primary_names(manifest, platform)[-1]
+        binary = directory / binary_name
+        require(enclosure.get('url') == release.asset_url(manifest, binary_name)
+                and enclosure.get('length') == str(binary.stat().st_size)
+                and feed_version(feed.read_bytes(), platform) == manifest['version'],
+                'Appcast version, URL or length differs from candidate')
+        signature = base64.b64decode(enclosure.get(f'{{{SPARKLE}}}edSignature', ''), validate=True)
+        Ed25519PublicKey.from_public_bytes(base64.b64decode(SPARKLE_KEY)).verify(signature, binary.read_bytes())
+    return feed
+
+
+def public_download(url, destination):
+    # Fixed canonical URLs from validated manifests, without authentication.
+    require(url.startswith(f'https://github.com/{release.REPOSITORY}/releases/'), 'Unexpected public asset URL')
+    with urlopen(Request(url, headers={'User-Agent': 'LightTable-release-verifier'}), timeout=60) as response:
+        require(response.status == 200 and response.url.startswith('https://'), 'Public asset is unavailable')
+        with destination.open('wb') as target:
+            while chunk := response.read(1024 * 1024):
+                target.write(chunk)
+
+
+def check_feed_forward(current, candidate, platform):
+    current_version = feed_version(current, platform)
+    candidate_version = feed_version(candidate, platform)
+    require(candidate_version, 'Candidate feed has no release')
+    if current_version is not None:
+        require(version_key(candidate_version) >= version_key(current_version), 'Refusing to downgrade the update feed')
+        require(version_key(candidate_version) != version_key(current_version) or current == candidate,
+                'Same-version feed bytes differ; explicit repair review is required')
+
+
+def advance_feed(manifest, platform, feed, temporary):
+    tag = manifest.get('tag', 'v' + manifest['version'])
+    if platform == 'macos-arm64':
+        latest = json.loads(release.gh('release', 'view', '--repo', release.REPOSITORY, '--json', 'tagName,assets'))
+        if any(a['name'] == feed.name for a in latest['assets']):
+            prior = temporary / 'current-feed'
+            prior.mkdir()
+            release.gh('release', 'download', latest['tagName'], '--repo', release.REPOSITORY,
+                       '--pattern', feed.name, '--dir', str(prior))
+            check_feed_forward((prior / feed.name).read_bytes(), feed.read_bytes(), platform)
+        # Existing macOS apps read releases/latest; no other platform gets to move it.
+        release.gh('release', 'edit', tag, '--repo', release.REPOSITORY, '--latest')
+        pointer = f'https://github.com/{release.REPOSITORY}/releases/latest/download/{feed.name}'
+    else:
+        current = json.loads(release.gh('release', 'view', 'desktop-updates', '--repo', release.REPOSITORY,
+                                      '--json', 'isDraft,assets'))
+        require(current['isDraft'] is False, 'Desktop update channel must already be public')
+        previous = next((a for a in current['assets'] if a['name'] == feed.name), None)
+        if previous:
+            prior = temporary / 'current-feed'
+            prior.mkdir()
+            release.gh('release', 'download', 'desktop-updates', '--repo', release.REPOSITORY,
+                       '--pattern', feed.name, '--dir', str(prior))
+            check_feed_forward((prior / feed.name).read_bytes(), feed.read_bytes(), platform)
+        # The only replaceable object is this platform's mutable signed pointer.
+        release.gh('release', 'upload', 'desktop-updates', str(feed), '--repo', release.REPOSITORY, '--clobber')
+        pointer = f'https://github.com/{release.REPOSITORY}/releases/download/desktop-updates/{feed.name}'
+    downloaded = temporary / 'public-feed'
+    public_download(pointer, downloaded)
+    require(downloaded.read_bytes() == feed.read_bytes(), 'Public updater pointer does not match the verified feed')
+
+
+def release_state(tag):
+    """A successful complete listing distinguishes absence from API/auth failure."""
+    pages = json.loads(release.gh('api', f'repos/{release.REPOSITORY}/releases?per_page=100',
+                                 '--paginate', '--slurp'))
+    require(isinstance(pages, list) and pages and all(isinstance(page, list) for page in pages),
+            'Release listing did not return complete pages')
+    matches = [entry for page in pages for entry in page if entry.get('tag_name') == tag]
+    require(len(matches) <= 1, 'Ambiguous release tag in repository listing')
+    if not matches:
+        return None
+    value = matches[0]
+    require(type(value.get('draft')) is bool and type(value.get('prerelease')) is bool,
+            'Release listing has invalid channel metadata')
+    return {'isDraft': value['draft'], 'isPrerelease': value['prerelease'],
+            'publishedAt': value.get('published_at'), 'url': value.get('html_url'), 'tagName': tag}
+
+
+def plan_or_publish(manifest_path, candidate, platform, apply):
+    """Called only after artifact and external-proof verification succeeds."""
+    manifest = release.read_json(manifest_path)
+    tag = manifest.get('tag', 'v' + manifest['version'])
+    state = release_state(tag)
+    create_draft = state is None
+    if state is not None:
+        require(state['isPrerelease'] is ('-beta.' in manifest['version']),
+                'Existing release channel metadata differs from the candidate version')
+    if create_draft and not apply:
+        assets = release.publication_plan(manifest, [], [platform])
+        assets.append({**release.file_identity(manifest_path),
+                       'url': release.asset_url(manifest, Path(manifest_path).name), 'action': 'add'})
+        result = {'applied': False, 'source_revision': manifest['source_revision'], 'assets': assets}
+        state = {'isDraft': True, 'isPrerelease': '-beta.' in manifest['version'],
+                 'publishedAt': None, 'url': None, 'tagName': tag}
+    else:
+        if create_draft:
+            options = ['--prerelease'] if '-beta.' in manifest['version'] else []
+            # --verify-tag forbids synthesizing a source tag. A concurrent creation
+            # fails safely; a later retry observes it and checks immutable assets.
+            release.gh('release', 'create', tag, '--repo', release.REPOSITORY,
+                       '--verify-tag', '--draft', '--latest=false', '--generate-notes',
+                       '--title', 'LightTable ' + manifest['version'], *options)
+            state = release_state(tag)
+            require(state is not None and state['isDraft']
+                    and state['isPrerelease'] is ('-beta.' in manifest['version']),
+                    'New draft metadata did not match the verified candidate')
+        result = release.publish(manifest_path, candidate, [platform], apply=apply)
+    result['create_draft'] = create_draft
+    result['draft_created'] = create_draft and apply
+    return result, state
+
+
+def promote(args):
+    require(not args.advance_feed or args.make_public, 'Feed advancement requires --make-public')
+    with tempfile.TemporaryDirectory(prefix='lighttable-promote-') as temporary_name:
+        temporary = Path(temporary_name)
+        original_run = build_run(args.build_run_id, args.platform)
+        workflow_run(args.manifest_run_id or args.build_run_id)
+        candidate = download_artifact(args.manifest_run_id or args.build_run_id, args.manifest_artifact, temporary / 'candidate')
+        manifest_name = release.platform_names(args.version, args.platform)['manifest']
+        manifest_path = candidate / manifest_name
+        manifest = release.validate_manifest(release.read_json(manifest_path))
+        require(manifest['version'] == args.version and manifest['source_revision'] == args.source_revision
+                and set(manifest['platforms']) == {args.platform}, 'Selected version/source/platform differs from manifest')
+        entry = manifest['platforms'][args.platform]
+        require(entry.get('build_workflow_revision', original_run['head_sha']) == original_run['head_sha'],
+                'Prepared build workflow revision differs from the selected run')
+        require(str(entry.get('build_run_id', '')) == str(args.build_run_id), 'Manifest build run does not match selection')
+        tag = manifest.get('tag', 'v' + args.version)
+        require(release.gh('api', f'repos/{release.REPOSITORY}/commits/{tag}', '--jq', '.sha').strip() == args.source_revision,
+                'Immutable tag does not select this source')
+        # Use the same CLI contract as release preparation before planning any writes.
+        release.verify_artifacts(manifest, candidate, [args.platform])
+        require(not entry.get('gates'), '; '.join(entry.get('gates', [])))
+        recorded_native = str(entry.get('native_run_id') or '')
+        require(not args.native_run_id or not recorded_native or str(args.native_run_id) == recorded_native,
+                'Native run input differs from prepared manifest')
+        args.native_run_id = args.native_run_id or recorded_native
+        original = download_artifact(args.build_run_id, BUILD_ARTIFACTS[args.platform], temporary / 'original')
+        verify_original_binaries(manifest, args.platform, original)
+        verify_evidence(args, manifest, original, temporary)
+        feed = verify_signed_feed(manifest, args.platform, candidate)
+        # The preparer records pending candidates. Only verified external receipts
+        # can turn them into a ready manifest; identical reruns produce identical bytes.
+        entry['state'] = 'ready'
+        proof_runs = [str(args.build_run_id)] + ([str(args.native_run_id)] if args.native_run_id else [])
+        entry['validation'] = {'status': 'passed', 'receipts': [
+            f'https://github.com/{release.REPOSITORY}/actions/runs/{run_id}' for run_id in proof_runs]}
+        gates = release.promotion_gates(args.platform, entry)
+        require(not gates, '; '.join(gates))
+        release.write_json(manifest_path, manifest)
+        require(not args.advance_feed or (feed is not None and entry['update_owner'] == 'app'), 'This platform channel does not support app-owned updates')
+        result, state = plan_or_publish(manifest_path, candidate, args.platform, args.apply)
+        result.update(ok=True, platform=args.platform, version=args.version, tag=tag,
+                      source_revision=args.source_revision,
+                      release_url=state.get('url'), published_release=not state['isDraft'],
+                      published_at=state.get('publishedAt'), manifest_path=manifest_name,
+                      manifest_url=release.asset_url(manifest, manifest_name), manifest=manifest,
+                      build_run_id=args.build_run_id,
+                      build_workflow_revision=original_run['head_sha'], receipts_verified=True,
+                      public_bytes_verified=False, feed_advanced=False)
+        if args.apply:
+            if state['isDraft'] and args.make_public:
+                release.gh('release', 'edit', tag, '--repo', release.REPOSITORY, '--draft=false', '--latest=false')
+                state['isDraft'] = False
+            if not state['isDraft']:
+                for asset in result['assets']:
+                    destination = temporary / ('public-' + asset['name'])
+                    public_download(asset['url'], destination)
+                    check_identity(release.file_identity(destination), asset, 'Independent public download checksum differs')
+                result['public_bytes_verified'] = True
+                if args.advance_feed:
+                    advance_feed(manifest, args.platform, feed, temporary)
+                    result['feed_advanced'] = True
+            final_state = json.loads(release.gh('release', 'view', tag, '--repo', release.REPOSITORY,
+                                               '--json', 'isDraft,publishedAt,url'))
+            result.update(published_release=not final_state['isDraft'],
+                          published_at=final_state.get('publishedAt'), release_url=final_state.get('url'))
+        return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--platform', required=True, choices=release.PLATFORMS)
+    for name in ('version', 'source-revision', 'build-run-id', 'manifest-artifact'):
+        parser.add_argument('--' + name, required=True)
+    parser.add_argument('--manifest-run-id')
+    parser.add_argument('--native-run-id')
+    parser.add_argument('--apply', action='store_true')
+    parser.add_argument('--make-public', action='store_true')
+    parser.add_argument('--advance-feed', action='store_true')
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args(argv)
+    try:
+        require(release.VERSION.fullmatch(args.version) and release.REVISION.fullmatch(args.source_revision),
+                'Exact version and source SHA are required')
+        result = promote(args)
+        release.write_json(args.output, result)
+        print(json.dumps(result, indent=2))
+        return 0
+    except Exception as error:
+        # Retain a failure receipt; never echo GitHub subprocess diagnostics.
+        message = 'GitHub command failed; inspect the selected run and artifact availability' if isinstance(error, subprocess.CalledProcessError) else str(error)
+        release.write_json(args.output, {'applied': args.apply, 'ok': False, 'error': message,
+                                         'platform': args.platform, 'version': args.version})
+        print('release-promotion: ' + message, file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/release/release-manifest.schema.json
+++ b/scripts/release/release-manifest.schema.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/reville/lighttable-digital-darkroom/blob/main/scripts/release/release-manifest.schema.json",
+  "title": "LightTable release manifest v1",
+  "description": "Structural schema. release_process.py also enforces cross-field version, source, URL ownership, unique asset names and publication policy. No credentials or secret values belong in this document.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "version",
+    "source_revision",
+    "platforms"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-beta\\.[1-9][0-9]*)?$"
+    },
+    "source_revision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "repository": {
+      "const": "reville/lighttable-digital-darkroom"
+    },
+    "tag": {
+      "type": "string",
+      "minLength": 1
+    },
+    "published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "platforms": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "linux-x86_64": {
+          "$ref": "#/$defs/platform"
+        },
+        "windows-x64": {
+          "$ref": "#/$defs/platform"
+        },
+        "macos-arm64": {
+          "$ref": "#/$defs/platform"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "platform": {
+      "type": "object",
+      "required": [
+        "version",
+        "channel",
+        "minimum_os",
+        "update_owner",
+        "state",
+        "signing",
+        "validation",
+        "artifacts"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-beta\\.[1-9][0-9]*)?$"
+        },
+        "channel": {
+          "enum": [
+            "stable",
+            "beta"
+          ]
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minimum_os": {
+          "type": "string",
+          "minLength": 1
+        },
+        "update_owner": {
+          "enum": [
+            "app",
+            "package-manager",
+            "manual"
+          ]
+        },
+        "state": {
+          "enum": [
+            "candidate",
+            "blocked",
+            "ready",
+            "published"
+          ]
+        },
+        "signing": {
+          "enum": [
+            "ed25519",
+            "authenticode",
+            "developer-id-notarized",
+            "ad-hoc",
+            "unsigned"
+          ]
+        },
+        "gates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "validation": {
+          "type": "object",
+          "required": [
+            "status"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "pending",
+                "passed",
+                "failed"
+              ]
+            },
+            "receipts": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "url",
+              "bytes",
+              "sha256"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "bytes": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$"
+              },
+              "update_owner": {
+                "enum": [
+                  "app",
+                  "package-manager",
+                  "manual"
+                ]
+              }
+            }
+          }
+        },
+        "build_run_id": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "build_source_revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "source_tree": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "native_run_id": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "build_workflow_revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "source_revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    }
+  }
+}

--- a/scripts/release/release_process.py
+++ b/scripts/release/release_process.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Small, fail-closed release metadata and additive publication tools (stdlib only)."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+from urllib.parse import quote
+import zipfile
+
+
+REPOSITORY = "reville/lighttable-digital-darkroom"
+PLATFORMS = ("linux-x86_64", "windows-x64", "macos-arm64")
+STATES = ("candidate", "blocked", "ready", "published")
+SIGNING = ("ed25519", "authenticode", "developer-id-notarized", "ad-hoc", "unsigned")
+VERSION = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-beta\.[1-9][0-9]*)?\Z")
+SHA = re.compile(r"[0-9a-f]{64}\Z")
+REVISION = re.compile(r"[0-9a-f]{40}\Z")
+NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+FEEDS = {"linux-x86_64": "linux-x86_64.json", "windows-x64": "appcast-windows-x64.xml", "macos-arm64": "appcast.xml"}
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def read_json(path):
+    with Path(path).open(encoding="utf-8-sig") as source:
+        return json.load(source)
+
+
+def write_json(path, value):
+    Path(path).write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def file_identity(path):
+    path = Path(path)
+    require(not path.is_symlink() and path.is_file(), f"not a regular artifact: {path.name}")
+    before = path.stat()
+    require(before.st_size > 0, f"empty artifact: {path.name}")
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    after = path.stat()
+    keys = ("st_dev", "st_ino", "st_size", "st_mtime_ns")
+    require(all(getattr(before, key) == getattr(after, key) for key in keys), f"artifact changed while hashing: {path.name}")
+    return {"name": path.name, "bytes": after.st_size, "sha256": digest.hexdigest()}
+
+
+def asset_url(manifest, name, platform=None):
+    entry = manifest["platforms"][platform] if platform else {}
+    tag = entry.get("tag", manifest.get("tag", "v" + manifest["version"]))
+    return f"https://github.com/{manifest.get('repository', REPOSITORY)}/releases/download/{tag}/{quote(name, safe='')}"
+
+
+def platform_names(version, platform):
+    stem = f"LightTable-{version}-{platform}"
+    return {"manifest": stem + "-release.json", "installers": stem + "-installers.tar.gz", "checksums": stem + "-SHA256SUMS"}
+
+
+def validate_manifest(manifest):
+    require(isinstance(manifest, dict) and type(manifest.get("schema_version")) is int and manifest["schema_version"] == 1, "unsupported release schema_version")
+    version = manifest.get("version", "")
+    require(isinstance(version, str) and VERSION.fullmatch(version), "invalid release version")
+    require(isinstance(manifest.get("source_revision"), str) and REVISION.fullmatch(manifest["source_revision"]), "source_revision must be a full lowercase Git commit")
+    repository = manifest.get("repository", REPOSITORY)
+    require(repository == REPOSITORY, "release repository must be the canonical public repository")
+    tag = manifest.get("tag", "v" + version)
+    require(tag in ("v" + version, "macos-v" + version), "release tag does not own this version")
+    platforms = manifest.get("platforms")
+    require(isinstance(platforms, dict) and platforms and set(platforms) <= set(PLATFORMS), "invalid release platforms")
+    if tag.startswith("macos-"):
+        require(set(platforms) == {"macos-arm64"}, "macOS release tag cannot own other platforms")
+    seen = set()
+    for platform, entry in platforms.items():
+        require(isinstance(entry, dict), "platform entry must be an object")
+        platform_version = entry.get("version", "")
+        own_source = entry.get("source_revision")
+        if own_source is not None:
+            require(isinstance(own_source, str) and REVISION.fullmatch(own_source), f"{platform}: invalid source_revision")
+        require(isinstance(platform_version, str) and VERSION.fullmatch(platform_version) and
+                (platform_version == version or ("-beta." not in version and platform_version.split("-beta.")[0] == version) or (own_source is not None and "tag" in entry)),
+                f"{platform}: version differs from release")
+        require(entry.get("channel") == ("beta" if "-beta." in platform_version else "stable"), f"{platform}: channel does not match version")
+        platform_tag = entry.get("tag", tag)
+        require(platform_tag == "v" + platform_version or (platform == "macos-arm64" and platform_tag == "macos-v" + platform_version), f"{platform}: tag does not own platform version")
+        if "build_source_revision" in entry:
+            require(isinstance(entry["build_source_revision"], str) and REVISION.fullmatch(entry["build_source_revision"]), "invalid build_source_revision")
+            require(isinstance(entry.get("source_tree"), str) and REVISION.fullmatch(entry["source_tree"]), "build_source_revision requires source_tree evidence")
+        require(entry.get("state") in STATES, f"{platform}: invalid state")
+        require(isinstance(entry.get("minimum_os"), str) and entry["minimum_os"].strip(), f"{platform}: minimum_os is required")
+        require(entry.get("update_owner") in ("app", "package-manager", "manual"), f"{platform}: invalid update_owner")
+        require(entry.get("signing") in SIGNING, f"{platform}: invalid signing declaration")
+        gates = entry.get("gates", [])
+        require(isinstance(gates, list) and all(isinstance(gate, str) and gate.strip() for gate in gates), f"{platform}: invalid gates")
+        validation = entry.get("validation", {})
+        require(isinstance(validation, dict) and validation.get("status") in ("pending", "passed", "failed"), f"{platform}: invalid validation status")
+        receipts = validation.get("receipts", [])
+        require(isinstance(receipts, list) and all(isinstance(item, str) and item.strip() for item in receipts), f"{platform}: invalid validation receipts")
+        artifacts = entry.get("artifacts")
+        require(isinstance(artifacts, list), f"{platform}: artifacts must be an array")
+        if entry["state"] in ("ready", "published"):
+            require(artifacts, f"{platform}: ready release needs artifacts")
+        for artifact in artifacts:
+            require(isinstance(artifact, dict), "artifact must be an object")
+            name = artifact.get("name", "")
+            require(isinstance(name, str) and NAME.fullmatch(name), "artifact name must be a safe basename")
+            require(name not in seen, f"artifact name collision: {name}")
+            seen.add(name)
+            names = platform_names(platform_version, platform)
+            require(name != names["manifest"], "manifest cannot contain its own checksum")
+            # Generic SHA256SUMS/installers archives collide when another platform joins.
+            canonical = name.startswith(f"LightTable-{platform_version}-{platform}.") or name.startswith(f"LightTable-{platform_version}-{platform}-")
+            if platform == "linux-x86_64":
+                canonical = canonical or bool(re.fullmatch(r"lighttable-bin-" + re.escape(platform_version) + r"-[1-9][0-9]*-x86_64\.pkg\.tar\.zst(?:\.sha256)?", name))
+            require(canonical or name == FEEDS[platform], f"{platform}: artifact name does not own version/platform: {name}")
+            require(artifact.get("url") == asset_url(manifest, name, platform), f"artifact URL/tag ownership mismatch: {name}")
+            require(type(artifact.get("bytes")) is int and artifact["bytes"] > 0, f"invalid artifact size: {name}")
+            require(isinstance(artifact.get("sha256"), str) and SHA.fullmatch(artifact["sha256"]), f"invalid artifact SHA-256: {name}")
+    return manifest
+
+
+def promotion_gates(platform, entry):
+    gates = list(entry.get("gates", []))
+    if entry["state"] not in ("ready", "published"):
+        gates.append("platform is not ready for publication")
+    if entry["validation"]["status"] != "passed" or not entry["validation"].get("receipts"):
+        gates.append("exact-artifact acceptance receipts have not passed")
+    required = {"linux-x86_64": "ed25519", "windows-x64": "authenticode", "macos-arm64": "developer-id-notarized"}[platform]
+    beta_manual = platform == "macos-arm64" and entry["channel"] == "beta" and entry["update_owner"] != "app" and entry["signing"] == "ad-hoc"
+    if entry["signing"] != required and not beta_manual:
+        gates.append(f"required signing is {required}")
+    return gates
+
+
+def preflight(manifest, capabilities, selected, phase="build"):
+    validate_manifest(manifest)
+    require(isinstance(capabilities, dict), "capabilities must be an object containing presence booleans only")
+    common = []
+    if capabilities.get("source_revision") != manifest["source_revision"]:
+        common.append("source revision mismatch")
+    if capabilities.get("source_clean") is not True:
+        common.append("source checkout is not verified clean")
+    if capabilities.get("tag_revision") != manifest["source_revision"]:
+        common.append("tag revision is missing or mismatched")
+    matrix = {}
+    for platform in sorted(manifest["platforms"]):
+        entry = manifest["platforms"][platform]
+        present = capabilities.get("platforms", {}).get(platform, {})
+        credentials = present.get("credentials", {})
+        require(isinstance(credentials, dict) and all(type(value) is bool for value in credentials.values()), "credential metadata must contain booleans, never secret values")
+        build_gates = list(common)
+        for key in ("release_environment_allowed", "build_runner_ready"):
+            if present.get(key) is not True:
+                build_gates.append(key.replace("_", " "))
+        needed = {"linux-x86_64": ["linux_update_signing"], "windows-x64": ["windows_authenticode", "sparkle_signing"], "macos-arm64": ["macos_developer_id", "macos_notarization", "sparkle_signing"]}[platform]
+        if platform == "macos-arm64" and entry["channel"] == "beta" and entry["signing"] == "ad-hoc" and entry["update_owner"] != "app":
+            needed = []
+        for key in needed:
+            if credentials.get(key) is not True:
+                build_gates.append(f"missing credential capability: {key}")
+        publish_gates = list(build_gates) + promotion_gates(platform, entry)
+        if present.get("native_acceptance_ready") is not True:
+            publish_gates.append("native acceptance environment unavailable")
+        matrix[platform] = {"selected": platform in selected, "build_ready": not build_gates, "promotion_ready": not publish_gates, "build_gates": build_gates, "promotion_gates": publish_gates}
+    require(selected and set(selected) <= set(matrix), "explicit platform selection must exist in the manifest")
+    return {"phase": phase, "ready": all(matrix[key]["build_ready" if phase == "build" else "promotion_ready"] for key in selected), "platforms": matrix}
+
+
+def check_build_manifest(value, manifest, platform):
+    entry = manifest["platforms"][platform]
+    require(value.get("version") == entry["version"], "embedded build manifest version mismatch")
+    require(value.get("source_revision") == entry.get("build_source_revision", entry.get("source_revision", manifest["source_revision"])), "embedded build manifest source mismatch")
+    require(value.get("source_dirty") is False, "embedded build manifest is not clean")
+    os_name, architecture = platform.rsplit("-", 1)
+    require(value.get("platform") in (os_name, "darwin" if os_name == "macos" else os_name), "embedded build manifest platform mismatch")
+    require(value.get("architecture") in (architecture, "AMD64" if architecture == "x64" else architecture), "embedded build manifest architecture mismatch")
+    if platform == "windows-x64" and entry["signing"] == "authenticode":
+        require(value.get("authenticode_signed") is True, "embedded Windows build does not declare Authenticode signing")
+
+
+def verify_embedded(path, manifest, platform):
+    """Read only the required metadata member; never extract untrusted archives."""
+    canonical = f"LightTable-{manifest['platforms'][platform]['version']}-{platform}"
+    value = None
+    if path.name == canonical + ".tar.gz" and platform == "linux-x86_64":
+        with tarfile.open(path, "r:gz") as archive:
+            matches = [member for member in archive if member.name == "LightTable/build-manifest.json"]
+            require(len(matches) == 1 and matches[0].isfile() and matches[0].size <= 65536, "missing or ambiguous embedded build manifest")
+            value = json.loads(archive.extractfile(matches[0]).read().decode("utf-8-sig"))
+    elif path.name == canonical + ".zip" and platform == "windows-x64":
+        with zipfile.ZipFile(path) as archive:
+            matches = [member for member in archive.infolist() if member.filename == "LightTable/build-manifest.json"]
+            require(len(matches) == 1 and matches[0].file_size <= 65536, "missing or ambiguous embedded build manifest")
+            value = json.loads(archive.read(matches[0]).decode("utf-8-sig"))
+    if value is not None:
+        check_build_manifest(value, manifest, platform)
+
+
+def verify_artifacts(manifest, directory, selected=None):
+    validate_manifest(manifest)
+    selected = selected or list(manifest["platforms"])
+    require(set(selected) <= set(manifest["platforms"]), "unknown selected platform")
+    results = []
+    for platform in sorted(selected):
+        require(manifest["platforms"][platform]["artifacts"], f"{platform}: no artifacts to verify")
+        for artifact in manifest["platforms"][platform]["artifacts"]:
+            path = Path(directory) / artifact["name"]
+            identity = file_identity(path)
+            require(identity["bytes"] == artifact["bytes"] and identity["sha256"] == artifact["sha256"], f"artifact bytes/checksum mismatch: {path.name}")
+            verify_embedded(path, manifest, platform)
+            results.append(identity)
+    return results
+
+
+def publication_plan(manifest, existing, selected):
+    validate_manifest(manifest)
+    require(selected and set(selected) <= set(manifest["platforms"]), "explicit platform selection must exist in manifest")
+    before = {}
+    for asset in existing:
+        require(asset["name"] not in before, f"duplicate remote asset: {asset['name']}")
+        before[asset["name"]] = asset
+    result = []
+    for platform in sorted(selected):
+        gates = promotion_gates(platform, manifest["platforms"][platform])
+        require(not gates, f"{platform} blocked: {'; '.join(gates)}")
+        for asset in sorted(manifest["platforms"][platform]["artifacts"], key=lambda value: value["name"]):
+            previous = before.get(asset["name"])
+            if previous is not None:
+                require(previous.get("sha256") == asset["sha256"] and previous.get("bytes") == asset["bytes"], f"immutable asset collision: {asset['name']}")
+            result.append({**asset, "action": "skip" if previous is not None else "add"})
+    return result
+
+
+def gh(*args):
+    return subprocess.run(["gh", *args], text=True, capture_output=True, check=True).stdout
+
+
+def remote_assets(manifest):
+    repository = manifest.get("repository", REPOSITORY)
+    tag = manifest.get("tag", "v" + manifest["version"])
+    revision = gh("api", f"repos/{repository}/commits/{tag}", "--jq", ".sha").strip()
+    require(revision == manifest["source_revision"], "remote release tag source mismatch")
+    release = json.loads(gh("release", "view", tag, "--repo", repository, "--json", "assets,tagName"))
+    require(release["tagName"] == tag, "remote release tag mismatch")
+    result = []
+    desired = {asset["name"] for entry in manifest["platforms"].values() for asset in entry["artifacts"]}
+    desired.update(platform_names(manifest["version"], key)["manifest"] for key in manifest["platforms"])
+    for asset in release["assets"]:
+        name = asset["name"]
+        if name not in desired:
+            continue
+        require(NAME.fullmatch(name), "unsafe remote asset name")
+        digest = asset.get("digest") or ""
+        if digest.startswith("sha256:") and SHA.fullmatch(digest[7:]):
+            result.append({"name": name, "bytes": asset["size"], "sha256": digest[7:]})
+        else:
+            # Older assets have no GitHub digest. Hash actual downloaded bytes.
+            with tempfile.TemporaryDirectory(prefix="lighttable-release-verify-") as temporary:
+                gh("release", "download", tag, "--repo", repository, "--pattern", name, "--dir", temporary)
+                identity = file_identity(Path(temporary) / name)
+                require(identity["bytes"] == asset["size"], f"remote download size mismatch: {name}")
+                result.append(identity)
+    return result
+
+
+def publish(manifest_path, directory, selected, apply=False):
+    manifest = validate_manifest(read_json(manifest_path))
+    require(len(selected) == 1 and set(manifest["platforms"]) == set(selected), "publish consumes one immutable platform manifest per invocation")
+    platform = selected[0]
+    entry = manifest["platforms"][platform]
+    require(entry["version"] == manifest["version"] and entry.get("tag", manifest.get("tag", "v" + manifest["version"])) == manifest.get("tag", "v" + manifest["version"]), "publish needs a standalone platform manifest, not aggregate version/tag overrides")
+    require(entry.get("source_revision", manifest["source_revision"]) == manifest["source_revision"], "publish platform source must match release source")
+    require(entry.get("build_source_revision", manifest["source_revision"]) == manifest["source_revision"], "publication requires exact source revision; historical same-tree records are metadata only")
+    name = platform_names(manifest["version"], platform)["manifest"]
+    require(Path(manifest_path).name == name, f"manifest must use immutable platform filename: {name}")
+    verify_artifacts(manifest, directory, selected)
+    existing = remote_assets(manifest)
+    plan = publication_plan(manifest, existing, selected)
+    identity = file_identity(manifest_path)
+    previous = next((asset for asset in existing if asset["name"] == name), None)
+    require(previous is None or (previous["sha256"] == identity["sha256"] and previous["bytes"] == identity["bytes"]), f"immutable manifest collision: {name}")
+    plan.append({**identity, "url": asset_url(manifest, name), "action": "skip" if previous else "add"})
+    if apply:
+        for asset in plan:
+            if asset["action"] == "add":
+                path = Path(manifest_path) if asset["name"] == name else Path(directory) / asset["name"]
+                # Recheck immediately before upload; never pass --clobber. A concurrent
+                # publisher causes a safe failure and the next invocation resumes.
+                current = file_identity(path)
+                require(current["sha256"] == asset["sha256"] and current["bytes"] == asset["bytes"], "artifact changed after planning")
+                gh("release", "upload", manifest.get("tag", "v" + manifest["version"]), str(path.resolve()), "--repo", manifest.get("repository", REPOSITORY))
+        after = {asset["name"]: asset for asset in remote_assets(manifest)}
+        require(all(after.get(asset["name"], {}).get("sha256") == asset["sha256"] and after[asset["name"]]["bytes"] == asset["bytes"] for asset in plan), "post-upload asset verification failed")
+    return {"applied": apply, "source_revision": manifest["source_revision"], "assets": plan}
+
+
+def create_manifest(args):
+    entry = {"version": args.version, "channel": args.channel, "minimum_os": args.minimum_os, "update_owner": args.update_owner, "state": args.state, "signing": args.signing, "gates": args.gate, "validation": {"status": args.validation_status, "receipts": args.receipt}, "artifacts": []}
+    if args.build_run_id:
+        entry["build_run_id"] = args.build_run_id
+    manifest = {"schema_version": 1, "repository": REPOSITORY, "tag": args.tag or "v" + args.version, "version": args.version, "source_revision": args.source_revision, "platforms": {args.platform: entry}}
+    for name in sorted(args.artifact):
+        require(NAME.fullmatch(name), "artifact must be a safe basename")
+        entry["artifacts"].append({**file_identity(Path(args.artifacts_dir) / name), "url": asset_url(manifest, name)})
+    validate_manifest(manifest)
+    if entry["artifacts"]:
+        verify_artifacts(manifest, args.artifacts_dir)
+    write_json(args.output, manifest)
+    return manifest
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    create = commands.add_parser("create-manifest")
+    for key in ("version", "source-revision", "artifacts-dir", "output", "minimum-os"):
+        create.add_argument("--" + key, required=True)
+    create.add_argument("--platform", choices=PLATFORMS, required=True)
+    create.add_argument("--channel", choices=("stable", "beta"), required=True)
+    create.add_argument("--update-owner", choices=("app", "package-manager", "manual"), required=True)
+    create.add_argument("--state", choices=STATES, default="candidate")
+    create.add_argument("--signing", choices=SIGNING, required=True)
+    create.add_argument("--validation-status", choices=("pending", "passed", "failed"), default="pending")
+    create.add_argument("--artifact", action="append", default=[])
+    create.add_argument("--gate", action="append", default=[])
+    create.add_argument("--receipt", action="append", default=[])
+    create.add_argument("--build-run-id")
+    create.add_argument("--tag")
+    for command in ("verify", "preflight", "plan", "publish"):
+        sub = commands.add_parser(command)
+        sub.add_argument("--manifest", required=True)
+        if command in ("preflight", "plan", "publish"):
+            sub.add_argument("--platform", choices=PLATFORMS, action="append", required=True)
+        if command in ("verify", "publish"):
+            sub.add_argument("--artifacts-dir", required=True)
+        if command == "preflight":
+            sub.add_argument("--capabilities", required=True)
+            sub.add_argument("--phase", choices=("build", "publish"), default="build")
+        if command == "plan":
+            sub.add_argument("--existing", required=True, help="JSON array of existing {name, bytes, sha256}")
+        if command == "publish":
+            sub.add_argument("--apply", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "create-manifest":
+            result = create_manifest(args)
+        else:
+            manifest = validate_manifest(read_json(args.manifest))
+            if args.command == "verify":
+                result = {"verified": verify_artifacts(manifest, args.artifacts_dir)}
+            elif args.command == "preflight":
+                result = preflight(manifest, read_json(args.capabilities), args.platform, args.phase)
+            elif args.command == "plan":
+                result = {"assets": publication_plan(manifest, read_json(args.existing), args.platform)}
+            else:
+                result = publish(args.manifest, args.artifacts_dir, args.platform, args.apply)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 2 if args.command == "preflight" and not result["ready"] else 0
+    except (ValueError, OSError, KeyError, TypeError, tarfile.TarError, zipfile.BadZipFile, subprocess.CalledProcessError) as error:
+        # Never echo subprocess output; GitHub errors can include credential diagnostics.
+        message = "GitHub command failed; no existing assets were replaced" if isinstance(error, subprocess.CalledProcessError) else str(error)
+        print(f"release-process: {message}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/update_index.py
+++ b/scripts/release/update_index.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Produce a reviewable website/index update from a verified promotion result."""
+import argparse
+import copy
+import json
+from pathlib import Path
+import release_process as release
+
+
+def merge(index, result):
+    release.validate_manifest(index)
+    release.require(result.get('applied') is True and result.get('public_bytes_verified') is True
+                    and result.get('published_release') is True and result.get('receipts_verified') is True,
+                    'Only completed, independently verified public promotion may update the index')
+    incoming = release.validate_manifest(result['manifest'])
+    platform = result['platform']
+    release.require(set(incoming['platforms']) == {platform}, 'Expected one promoted platform')
+    release.require(result['version'] == incoming['version'] and result['source_revision'] == incoming['source_revision'], 'Promotion receipt identity differs')
+    output = copy.deepcopy(index)
+    for entry in output['platforms'].values():
+        entry.setdefault('source_revision', output['source_revision'])
+        entry.setdefault('tag', output.get('tag', 'v'+entry['version']))
+    entry = copy.deepcopy(incoming['platforms'][platform])
+    entry['source_revision'] = incoming['source_revision']
+    entry['tag'] = incoming.get('tag', 'v'+incoming['version'])
+    entry['state'] = 'published'
+    release.require(result.get('published_at'), 'Public release timestamp required')
+    entry['published_at'] = result['published_at']
+    if platform in output['platforms']:
+        old = output['platforms'][platform]
+        def key(v):
+            base, _, beta = v.partition('-beta.')
+            return (*map(int,base.split('.')), 0 if beta else 1, int(beta or 0))
+        release.require(key(entry['version']) >= key(old['version']), 'Do not roll back an indexed platform')
+        # Retain already-published additional formats (e.g. Arch) on same-source/version resumes.
+        if entry['version'] == old['version'] and entry['source_revision'] == old['source_revision']:
+            names = {a['name']: a for a in entry['artifacts']}
+            for asset in old['artifacts']:
+                if asset['name'] in names:
+                    release.require(names[asset['name']] == asset, 'Indexed public asset identity differs')
+                else:
+                    entry['artifacts'].append(copy.deepcopy(asset))
+    output['platforms'][platform] = entry
+    if tuple(map(int,incoming['version'].split('-')[0].split('.'))) >= tuple(map(int,output['version'].split('-')[0].split('.'))):
+        output['version'] = incoming['version'].split('-')[0]
+        output['source_revision'] = incoming['source_revision']
+    output.pop('tag', None)
+    release.validate_manifest(output)
+    return output
+
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--index',required=True,type=Path);p.add_argument('--promotion-result',required=True,type=Path);p.add_argument('--output',required=True,type=Path)
+    a=p.parse_args();result=merge(release.read_json(a.index),release.read_json(a.promotion_result));release.write_json(a.output,result)
+    print('Verified platform index prepared; review/merge it, then synchronize and verify the website deployment.')
+
+if __name__=='__main__':main()

--- a/scripts/windows/build-release.ps1
+++ b/scripts/windows/build-release.ps1
@@ -98,7 +98,12 @@ if (-not $RuntimeSmokeOnly) {
     New-Item -ItemType Directory -Force -Path $Output | Out-Null
 }
 
+. (Join-Path $PSScriptRoot "build-timing.ps1")
+$Timing = New-BuildTiming -Path (Join-Path $Project ".build/windows-build-timings.json") -Version $Version
+$BuildSucceeded = $false
+
 try {
+    Start-BuildStage $Timing "dependency-acquisition-and-staging"
     $PythonArchive = Join-Path $BuildRoot "python.zip"
     Invoke-WebRequest `
         -Uri "https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip" `
@@ -198,33 +203,41 @@ try {
     # Pull requests exercise the exact embedded Python and updater payload before paying
     # for native engine/shell compilation, signing, or installer creation.
     if ($RuntimeSmokeOnly) {
+        Start-BuildStage $Timing "runtime-smoke"
         & $PythonExe -B (Join-Path $PSScriptRoot "runtime-smoke.py") $Resources
         if ($LASTEXITCODE -ne 0) { throw "The staged Windows runtime smoke test failed" }
+        $BuildSucceeded = $true
         Write-Host "Staged Windows runtime smoke passed"
         return
     }
 
+    Start-BuildStage $Timing "rust-toolchain"
     & rustup target add $Target
     if ($LASTEXITCODE -ne 0) { throw "The Windows Rust target could not be installed" }
 
+    Start-BuildStage $Timing "rust-engine-tests"
     & cargo test --locked --target $Target --manifest-path (Join-Path $Project "rust-engine\Cargo.toml")
     if ($LASTEXITCODE -ne 0) { throw "The resident render-engine tests failed" }
+    Start-BuildStage $Timing "shell-tests"
     $env:LIGHTTABLE_TEST_WINSPARKLE_DLL = Join-Path $Payload "WinSparkle.dll"
     & cargo test --locked --target $Target --manifest-path (Join-Path $Project "windows-shell\Cargo.toml")
     if ($LASTEXITCODE -ne 0) { throw "The Windows desktop-shell tests failed" }
 
+    Start-BuildStage $Timing "rust-engine-build"
     & cargo build --locked --release --target $Target --manifest-path (Join-Path $Project "rust-engine\Cargo.toml")
     if ($LASTEXITCODE -ne 0) { throw "The resident render engine failed to build" }
     Copy-Item `
         (Join-Path $Project "rust-engine\target\$Target\release\lighttable-engine.exe") `
         (Join-Path $Engine "lighttable-engine.exe")
 
+    Start-BuildStage $Timing "export-engine-build"
     & cargo build --locked --release --target $Target --manifest-path (Join-Path $RustSource "Cargo.toml") -p spektrafilm-cli --bin spektrafilm
     if ($LASTEXITCODE -ne 0) { throw "The export render engine failed to build" }
     Copy-Item `
         (Join-Path $RustSource "target\$Target\release\spektrafilm.exe") `
         (Join-Path $Engine "spektrafilm-rs.exe")
 
+    Start-BuildStage $Timing "shell-build"
     $Icon = Join-Path $BuildRoot "LightTable.ico"
     & $PythonExe (Join-Path $Project "scripts\windows\make-icon.py") (Join-Path $Project "build\icon-1024.png") $Icon
     if ($LASTEXITCODE -ne 0) { throw "The Windows icon could not be built" }
@@ -236,6 +249,7 @@ try {
         (Join-Path $Project "windows-shell\target\$Target\release\lighttable-desktop-shell.exe") `
         (Join-Path $Payload "LightTable.exe")
 
+    Start-BuildStage $Timing "payload-signing"
     if ($StoreCandidate) {
         & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $Payload -SignMissing
     }
@@ -248,19 +262,30 @@ try {
         )
     }
 
+    Start-BuildStage $Timing "runtime-smoke"
     & $PythonExe -B `
         (Join-Path $Project "scripts\windows\runtime-smoke.py") `
         $Resources `
         (Join-Path $Payload "LightTable.exe")
     if ($LASTEXITCODE -ne 0) { throw "The packaged Windows runtime smoke test failed" }
 
+    Start-BuildStage $Timing "updater-smoke"
     & (Join-Path $PSScriptRoot "updater-smoke.ps1") -Application (Join-Path $Payload "LightTable.exe")
 
+    Start-BuildStage $Timing "package-manifest"
     $SourceRevision = & git -C $Project rev-parse HEAD
     if ($LASTEXITCODE -ne 0) { throw "Could not resolve the package source revision" }
+    $SourceStatus = @(& git -C $Project status --porcelain --untracked-files=normal)
+    if ($LASTEXITCODE -ne 0) { throw "Could not verify the package source worktree" }
+    $SourceDirty = $SourceStatus.Count -gt 0
+    if ($RequireSigning -and $SourceDirty) {
+        throw "Signed release artifacts require a clean source worktree."
+    }
     @{
         version = $Version
         source_revision = $SourceRevision.Trim()
+        source_dirty = [bool]$SourceDirty
+        platform = "windows"
         architecture = "x64"
         winsparkle_version = $WinSparkleVersion
         python_version = $PythonVersion
@@ -271,6 +296,7 @@ try {
     } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $Payload "build-manifest.json") -Encoding utf8
 
     if (-not $PortableOnly) {
+        Start-BuildStage $Timing "installer-build-and-embedded-uninstaller-signing"
         $Installer = Join-Path $Output "LightTable-$Version-windows-x64-setup.exe"
         $UninstallManifest = Join-Path $BuildRoot "uninstall-files.nsh"
         & $PythonExe -B (Join-Path $Project "scripts\windows\make-uninstall-manifest.py") $Payload $UninstallManifest
@@ -293,11 +319,14 @@ try {
             "/DUNINSTALL_MANIFEST=$UninstallManifest" `
             (Join-Path $Project "scripts\windows\installer.nsi")
         if ($LASTEXITCODE -ne 0) { throw "The Windows installer failed to build" }
+        Start-BuildStage $Timing "installer-signing"
         if ($SigningEnabled) {
             & (Join-Path $PSScriptRoot "sign-release.ps1") -RequireSigning -Files $Installer
         }
+        Start-BuildStage $Timing "installer-client-smoke"
         & (Join-Path $Project "scripts\windows\installer-smoke.ps1") -Installer $Installer -Version $Version `
             -VerifyStoreSignatures:$StoreCandidate -ExpectedPublisher $(if ($StoreCandidate) { "Chonkers LLC" } else { "Nicholas Reville" }) -SignatureReport (Join-Path $Output "windows-store-pe-signatures.json")
+        Start-BuildStage $Timing "update-signing"
         if ($RequireSigning) {
             # WinSparkle accepts both the current Sparkle 32-byte seed and its
             # older 96-byte private-key format. No key material is logged or
@@ -330,12 +359,15 @@ try {
     }
 
     # Archive only after every required signature and installer check passes.
+    Start-BuildStage $Timing "portable-compression"
     $Zip = Join-Path $Output "LightTable-$Version-windows-x64.zip"
     if (Test-Path $Zip) { Remove-Item -Force $Zip }
     Compress-Archive -Path $Payload -DestinationPath $Zip -CompressionLevel Optimal
 
+    $BuildSucceeded = $true
     Write-Host "Built Windows artifacts in $Output"
 } finally {
+    Complete-BuildTiming $Timing $BuildSucceeded
     [Environment]::SetEnvironmentVariable("LIGHTTABLE_TEST_WINSPARKLE_DLL", $PreviousTestUpdater, "Process")
     [Environment]::SetEnvironmentVariable("LIGHTTABLE_ICON_ICO", $PreviousIcon, "Process")
     if (Test-Path $BuildRoot) {

--- a/scripts/windows/build-timing.ps1
+++ b/scripts/windows/build-timing.ps1
@@ -1,0 +1,60 @@
+# Stage names and durations only: never record commands, environment, or errors.
+function New-BuildTiming {
+    param([string]$Path, [string]$Version)
+    return @{
+        Path = $Path; Version = $Version; StartedAt = [DateTime]::UtcNow.ToString('o')
+        Clock = [Diagnostics.Stopwatch]::StartNew()
+        Stages = [Collections.Generic.List[object]]::new(); Active = $null
+    }
+}
+
+function Stop-BuildStage {
+    param([hashtable]$Timing, [bool]$Succeeded = $true)
+    if ($null -eq $Timing.Active) { return }
+    $Timing.Active.Clock.Stop()
+    $Timing.Stages.Add([ordered]@{
+        name = $Timing.Active.Name; started_at = $Timing.Active.StartedAt
+        elapsed_seconds = [Math]::Round($Timing.Active.Clock.Elapsed.TotalSeconds, 3)
+        status = $(if ($Succeeded) { 'success' } else { 'failed' })
+    })
+    Write-Host ("Release stage {0}: {1:N1}s ({2})" -f $Timing.Active.Name,
+        $Timing.Active.Clock.Elapsed.TotalSeconds, $Timing.Stages[-1].status)
+    $Timing.Active = $null
+}
+
+function Start-BuildStage {
+    param([hashtable]$Timing, [ValidatePattern('^[a-z][a-z0-9-]*$')][string]$Name)
+    Stop-BuildStage $Timing
+    $Timing.Active = @{
+        Name = $Name; StartedAt = [DateTime]::UtcNow.ToString('o')
+        Clock = [Diagnostics.Stopwatch]::StartNew()
+    }
+    Write-Host "Release stage: $Name"
+}
+
+function Complete-BuildTiming {
+    param([hashtable]$Timing, [bool]$Succeeded)
+    Stop-BuildStage $Timing $Succeeded
+    $Timing.Clock.Stop()
+    try {
+        $Directory = Split-Path -Parent $Timing.Path
+        if ($Directory) { New-Item -ItemType Directory -Force -Path $Directory | Out-Null }
+        [ordered]@{
+            schema_version = 1; version = $Timing.Version; started_at = $Timing.StartedAt
+            elapsed_seconds = [Math]::Round($Timing.Clock.Elapsed.TotalSeconds, 3)
+            status = $(if ($Succeeded) { 'success' } else { 'failed' })
+            stages = @($Timing.Stages.ToArray())
+        } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $Timing.Path -Encoding utf8
+        if ($env:GITHUB_STEP_SUMMARY) {
+            $Lines = @('### Windows build timings', '', '| Stage | Seconds | Result |', '| --- | ---: | --- |')
+            foreach ($Stage in $Timing.Stages) {
+                $Lines += "| $($Stage.name) | $($Stage.elapsed_seconds) | $($Stage.status) |"
+            }
+            $Lines += "`nTotal: $([Math]::Round($Timing.Clock.Elapsed.TotalSeconds, 1)) seconds."
+            $Lines | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+        }
+    } catch {
+        # Timing diagnostics must not mask the build's original failure or result.
+        Write-Warning 'Could not persist Windows build timing diagnostics.'
+    }
+}

--- a/scripts/windows/client-vm/bootstrap.ps1
+++ b/scripts/windows/client-vm/bootstrap.ps1
@@ -1,0 +1,81 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Root = 'C:\OEM'
+$Evidence = Join-Path $Root 'evidence'
+New-Item -ItemType Directory -Force $Evidence | Out-Null
+$Adapters = @()
+$HostReport = @{ok = $false; bootstrap_error = $null; evaluation_vm = $true}
+$EvidenceUrl = 'http://10.0.2.1:18080'
+try {
+    & icacls.exe $Root /grant ($env:USERNAME + ':(OI)(CI)M') /T /Q | Out-Null
+    $OS = Get-CimInstance Win32_OperatingSystem
+    $Config = Get-Content (Join-Path $Root 'candidate.json') -Raw | ConvertFrom-Json
+    $EvidenceUrl = $Config.evidence_url
+    # Fail early if the guest cannot return evidence, before offline installation.
+    $HostReport.stage = 'bootstrap-started'
+    $HostReport | ConvertTo-Json | Set-Content (Join-Path $Evidence 'bootstrap-started.json') -Encoding utf8
+    Invoke-WebRequest -UseBasicParsing -Method Put -Uri ($EvidenceUrl + '/bootstrap-started.json') -InFile (Join-Path $Evidence 'bootstrap-started.json') -TimeoutSec 20 | Out-Null
+    $HostReport.evidence_transport_verified = $true
+    $HostReport.caption = $OS.Caption
+    $HostReport.build = $OS.BuildNumber
+    $HostReport.product_type = $OS.ProductType
+    $HostReport.architecture = $env:PROCESSOR_ARCHITECTURE
+    $HostReport.expected_windows = $Config.windows
+    $HostReport.graphics = @(Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion)
+    $HostReport.uac_enabled = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System').EnableLUA
+    if ($OS.ProductType -ne 1 -or $env:PROCESSOR_ARCHITECTURE -ne 'AMD64') { throw 'Expected an x64 Windows client' }
+    if (($Config.windows -eq '11') -ne ([int]$OS.BuildNumber -ge 22000)) { throw 'Windows client version mismatch' }
+    . (Join-Path $Root 'scripts/ensure-webview2.ps1')
+    $HostReport.webview2_initially_present = Test-WebView2Runtime
+    # Use the vendor uninstaller only. Never fake absence by deleting registry keys.
+    if ($HostReport.webview2_initially_present) {
+        $Setups = @(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft\EdgeWebView\Application\*\Installer\setup.exe" -ErrorAction SilentlyContinue)
+        foreach ($Setup in $Setups) {
+            $Process = Start-Process $Setup.FullName -ArgumentList '--uninstall --msedgewebview --system-level --force-uninstall' -PassThru
+            if (-not $Process.WaitForExit(120000)) { $Process.Kill(); throw 'WebView2 removal timed out' }
+        }
+    }
+    $HostReport.webview2_absent_before_offline_install = -not (Test-WebView2Runtime)
+    # Verify the original file before disconnecting; record this trust-cache warmup.
+    $Installer = Join-Path $Root $Config.installer
+    if ((Get-FileHash $Installer -Algorithm SHA256).Hash.ToLowerInvariant() -cne $Config.installer_sha256) { throw 'Installer hash mismatch' }
+    $Signature = Get-AuthenticodeSignature $Installer
+    $HostReport.installer_signature_before_disconnect = $Signature.Status.ToString()
+    $HostReport.certificate_chain_checked_online_before_test = $true
+    if ($Signature.Status -ne 'Valid') { throw 'Installer signature is not trusted on the fresh client' }
+    $Adapters = @(Get-NetAdapter | Where-Object Status -eq 'Up')
+    $Adapters | Disable-NetAdapter -Confirm:$false
+    $HostReport.network_adapters_disabled = $true
+    # FirstLogonCommands is elevated. Schedule the test in the logged-on user's
+    # limited token so per-user installation is tested without administrator rights.
+    $Action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoLogo -NoProfile -ExecutionPolicy Bypass -File C:\OEM\guest-test.ps1'
+    $Principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited
+    $Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 20)
+    Register-ScheduledTask -TaskName 'LightTableClientAcceptance' -Action $Action -Principal $Principal -Settings $Settings -Force | Out-Null
+    Start-ScheduledTask -TaskName 'LightTableClientAcceptance'
+    $Deadline = (Get-Date).AddMinutes(20)
+    while ((Get-Date) -lt $Deadline -and -not (Test-Path (Join-Path $Root 'test.done'))) { Start-Sleep -Seconds 5 }
+    if (-not (Test-Path (Join-Path $Root 'test.done'))) { throw 'Client acceptance exceeded twenty minutes' }
+    $HostReport.ok = $true
+} catch {
+    $HostReport.bootstrap_error = $_.Exception.Message
+} finally {
+    foreach ($Adapter in $Adapters) { $Adapter | Enable-NetAdapter -Confirm:$false -ErrorAction Continue }
+    Stop-ScheduledTask -TaskName 'LightTableClientAcceptance' -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName 'LightTableClientAcceptance' -Confirm:$false -ErrorAction SilentlyContinue
+    $HostReport | ConvertTo-Json -Depth 8 | Set-Content (Join-Path $Evidence 'host.json') -Encoding utf8
+    # The receiver is private to the VM container, with no published port.
+    # Upload bounded test evidence only, never the Windows image or account file.
+    for ($Attempt = 0; $Attempt -lt 12; $Attempt++) {
+        try {
+            foreach ($File in Get-ChildItem $Evidence -Recurse -File) {
+                if ($File.Extension -notin @('.json', '.png', '.log', '.tif') -or $File.Length -gt 16MB) { continue }
+                $Relative = $File.FullName.Substring($Evidence.Length + 1).Replace('\', '/')
+                Invoke-WebRequest -UseBasicParsing -Method Put -Uri ($EvidenceUrl + '/' + $Relative) -InFile $File.FullName -TimeoutSec 20 | Out-Null
+            }
+            Invoke-WebRequest -UseBasicParsing -Method Put -Uri ($EvidenceUrl + '/complete') -Body 'done' -TimeoutSec 10 | Out-Null
+            break
+        } catch { Start-Sleep -Seconds 5 }
+    }
+    shutdown.exe /s /t 10
+}

--- a/scripts/windows/client-vm/guest-test.ps1
+++ b/scripts/windows/client-vm/guest-test.ps1
@@ -1,0 +1,26 @@
+param([string]$Root = 'C:\OEM')
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Evidence = Join-Path $Root 'evidence'
+New-Item -ItemType Directory -Force $Evidence | Out-Null
+$Report = @{ok = $false; offline = $true; account_is_elevated = $false}
+try {
+    $Principal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    $Report.account_is_elevated = $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if ($Report.account_is_elevated) { throw 'Installer acceptance must run unelevated' }
+    if (@(Get-NetAdapter | Where-Object Status -eq 'Up').Count) { throw 'A network adapter is still enabled' }
+    $Config = Get-Content (Join-Path $Root 'candidate.json') -Raw | ConvertFrom-Json
+    $Installer = Join-Path $Root $Config.installer
+    if ((Get-FileHash $Installer -Algorithm SHA256).Hash.ToLowerInvariant() -cne $Config.installer_sha256) {
+        throw 'Installer hash mismatch'
+    }
+    $Report.installer_sha256 = $Config.installer_sha256
+    & (Join-Path $Root 'scripts/installer-smoke.ps1') -Installer $Installer -Version $Config.version -ExpectedPublisher 'Chonkers LLC' -VerifyStoreSignatures -SignatureReport (Join-Path $Evidence 'installed-signatures.json') -NativeAcceptanceReport (Join-Path $Evidence 'native')
+    if ($LASTEXITCODE -ne 0) { throw 'Installer or installed desktop acceptance failed' }
+    $Report.ok = $true
+} catch {
+    $Report.error = $_.Exception.Message
+} finally {
+    $Report | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $Evidence 'result.json') -Encoding utf8
+    Set-Content (Join-Path $Root 'test.done') 'done'
+}

--- a/scripts/windows/client-vm/prepare.py
+++ b/scripts/windows/client-vm/prepare.py
@@ -1,0 +1,117 @@
+"""Stage only the verified candidate and test scripts for an ephemeral Windows VM."""
+from pathlib import Path
+import argparse
+import re
+import hashlib
+import json
+import secrets
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+
+parser = argparse.ArgumentParser()
+parser.add_argument('windows', choices=('10', '11'))
+parser.add_argument('--version', required=True)
+parser.add_argument('--source-sha', required=True)
+parser.add_argument('--installer-sha256', required=True)
+args = parser.parse_args()
+version = args.windows
+if not re.fullmatch(r'(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)', args.version):
+    parser.error('Use a stable candidate version')
+if not re.fullmatch(r'[0-9a-f]{40}', args.source_sha) or not re.fullmatch(r'[0-9a-f]{64}', args.installer_sha256):
+    parser.error('Exact source SHA and installer SHA-256 are required')
+root = Path('.build/client-vm')
+oem = root / 'oem'
+oem.mkdir(parents=True, exist_ok=True)
+download = Path('.build/windows-client-download')
+installer = download / f'LightTable-{args.version}-windows-x64-setup.exe'
+expected = args.installer_sha256
+with installer.open('rb') as source:
+    actual = hashlib.file_digest(source, 'sha256').hexdigest()
+if actual != expected:
+    raise SystemExit('Signed candidate installer does not match the verified SHA-256')
+shutil.copy2(installer, oem / installer.name)
+shutil.copytree('scripts/windows', oem / 'scripts', ignore=shutil.ignore_patterns('client-vm', '__pycache__'))
+for name in ('guest-test.ps1', 'bootstrap.ps1'):
+    shutil.copy2(Path('scripts/windows/client-vm') / name, oem / name)
+(oem / 'candidate.json').write_text(json.dumps({
+    'version': args.version, 'windows': version, 'installer': installer.name,
+    'installer_sha256': expected,
+    'source_sha': args.source_sha,
+    'evidence_url': 'http://10.0.2.1:18080',
+}), encoding='utf-8')
+
+# Minimal unattended Windows setup: preserve Defender, firewall, UAC and OS
+# requirements. No Dockur customization script or security bypass is staged.
+ns = 'urn:schemas-microsoft-com:unattend'
+wcm = 'http://schemas.microsoft.com/WMIConfig/2002/State'
+ET.register_namespace('', ns)
+ET.register_namespace('wcm', wcm)
+def add(parent, tag, value=None, **attributes):
+    item = ET.SubElement(parent, '{'+ns+'}'+tag, attributes)
+    if value is not None:
+        item.text = str(value)
+    return item
+def component(parent, name):
+    return add(parent, 'component', name=name, processorArchitecture='amd64',
+               publicKeyToken='31bf3856ad364e35', language='neutral', versionScope='nonSxS')
+def locale(parent, winpe=False):
+    c = component(parent, 'Microsoft-Windows-International-Core' + ('-WinPE' if winpe else ''))
+    if winpe:
+        add(add(c, 'SetupUILanguage'), 'UILanguage', 'en-US')
+    for field, value in [('InputLocale','0409:00000409'),('SystemLocale','en-US'),('UILanguage','en-US'),('UserLocale','en-US')]:
+        add(c, field, value)
+tree = ET.Element('{'+ns+'}unattend')
+pe = add(tree, 'settings', **{'pass': 'windowsPE'})
+locale(pe, True)
+setup = component(pe, 'Microsoft-Windows-Setup')
+disk = add(add(setup, 'DiskConfiguration'), 'Disk', **{'{'+wcm+'}action':'add'})
+add(disk, 'DiskID', 1)
+add(disk, 'WillWipeDisk', 'true')
+create = add(disk, 'CreatePartitions')
+modify = add(disk, 'ModifyPartitions')
+for order, kind, size, label, fmt in [(1,'EFI',128,'System','FAT32'),(2,'MSR',16,None,None),(3,'Primary',None,'Windows','NTFS')]:
+    part = add(create, 'CreatePartition', **{'{'+wcm+'}action':'add'})
+    add(part, 'Order', order); add(part, 'Type', kind)
+    add(part, 'Size' if size else 'Extend', size if size else 'true')
+    part = add(modify, 'ModifyPartition', **{'{'+wcm+'}action':'add'})
+    add(part, 'Order', order); add(part, 'PartitionID', order)
+    if label:
+        add(part, 'Label', label); add(part, 'Format', fmt)
+    if order == 3:
+        add(part, 'Letter', 'C')
+image = add(add(setup, 'ImageInstall'), 'OSImage')
+install = add(image, 'InstallTo')
+add(install, 'DiskID', 1); add(install, 'PartitionID', 3)
+metadata = add(add(image, 'InstallFrom'), 'MetaData', **{'{'+wcm+'}action':'add'})
+add(metadata, 'Key', '/IMAGE/INDEX'); add(metadata, 'Value', '1')
+user = add(setup, 'UserData')
+add(user, 'AcceptEula', 'true')
+add(user, 'FullName', 'LightTable Test')
+add(user, 'Organization', 'Chonkers LLC')
+add(add(setup, 'DynamicUpdate'), 'Enable', 'false')
+oobe = add(tree, 'settings', **{'pass':'oobeSystem'})
+locale(oobe)
+shell = component(oobe, 'Microsoft-Windows-Shell-Setup')
+password = secrets.token_urlsafe(32)
+accounts = add(add(shell, 'UserAccounts'), 'LocalAccounts')
+account = add(accounts, 'LocalAccount', **{'{'+wcm+'}action':'add'})
+add(account, 'Name', 'LightTableTest'); add(account, 'Group', 'Administrators')
+def set_password(parent):
+    node = add(parent, 'Password')
+    add(node, 'Value', password); add(node, 'PlainText', 'true')
+set_password(account)
+autologon = add(shell, 'AutoLogon')
+add(autologon, 'Username', 'LightTableTest'); add(autologon, 'Enabled', 'true'); add(autologon, 'LogonCount', 1)
+set_password(autologon)
+settings = add(shell, 'OOBE')
+for key in ('HideEULAPage', 'HideOEMRegistrationScreen', 'HideOnlineAccountScreens', 'HideWirelessSetupInOOBE'):
+    add(settings, key, 'true')
+add(settings, 'ProtectYourPC', 1)
+command = add(add(shell, 'FirstLogonCommands'), 'SynchronousCommand', **{'{'+wcm+'}action':'add'})
+add(command, 'Order', 1)
+add(command, 'CommandLine', 'powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File C:\\OEM\\bootstrap.ps1')
+add(command, 'Description', 'Run isolated LightTable client acceptance')
+ET.ElementTree(tree).write(root / 'custom.xml', encoding='utf-8', xml_declaration=True)
+(root / 'custom.xml').chmod(0o600)
+print('Staged verified installer and disposable Windows', version, 'configuration')

--- a/scripts/windows/client-vm/receive.py
+++ b/scripts/windows/client-vm/receive.py
@@ -1,0 +1,31 @@
+"""Bounded evidence receiver, listening inside a disposable VM container only."""
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import time
+
+ROOT = Path('/evidence')
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_PUT(self):
+        relative = self.path.lstrip('/')
+        path = (ROOT / relative).resolve()
+        size = int(self.headers.get('Content-Length', '0'))
+        if not path.is_relative_to(ROOT) or size > 16 * 1024 * 1024:
+            self.send_error(400)
+            return
+        if relative != 'complete' and path.suffix not in ('.json', '.png', '.log', '.tif'):
+            self.send_error(400)
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.rfile.read(size))
+        self.send_response(200)
+        self.end_headers()
+
+
+server = HTTPServer(('0.0.0.0', 18080), Handler)
+server.timeout = 5
+deadline = time.monotonic() + 3300
+while time.monotonic() < deadline and not (ROOT / 'complete').exists():
+    server.handle_request()
+server.server_close()

--- a/scripts/windows/desktop-smoke.py
+++ b/scripts/windows/desktop-smoke.py
@@ -60,12 +60,13 @@ def validate_paths(report: dict, root: Path, bundle: Path) -> None:
         raise RuntimeError("The native shell is not using the packaged resources")
 
 
-def validate_bundle(bundle: Path) -> None:
+def validate_bundle(bundle: Path, *, allow_disposable_direct_install: bool = False) -> None:
     for relative in ("LightTable.exe", "Python/python.exe", "Resources/LightTable/server.py"):
         if not (bundle / relative).is_file():
             raise RuntimeError(f"The Windows bundle is incomplete: {relative}")
     marker = bundle / "install-channel.txt"
-    if marker.exists() and marker.read_text(encoding="utf-8-sig").strip() != "portable":
+    channel = marker.read_text(encoding="utf-8-sig").strip() if marker.exists() else "portable"
+    if channel != "portable" and not (allow_disposable_direct_install and channel == "direct"):
         # A signed direct install configures WinSparkle's global registry state.
         # Validate the extracted ZIP so this smoke cannot alter that preference.
         raise RuntimeError("Use the extracted portable ZIP, not an installed/package-managed copy")
@@ -569,6 +570,8 @@ def main():
     parser.add_argument("--report-dir", type=Path, help="New directory for JSON evidence, logs and the exported TIFF")
     parser.add_argument("--stack-dumper", type=Path,
                         help="Optional py-spy.exe for failure diagnostics only; adds at most four 5-second dumps without locals")
+    parser.add_argument("--allow-disposable-direct-install", action="store_true",
+                        help="Allow a direct install ONLY in a disposable test account; WinSparkle may change its registry preferences")
     args = parser.parse_args()
     if sys.platform != "win32":
         parser.error("Run with packaged Python in a logged-on Windows desktop")
@@ -576,7 +579,7 @@ def main():
         parser.error("--timeout must be between 60 and 270 seconds, plus at most 25 seconds of cleanup")
     require_interactive_desktop()
     bundle = args.bundle.resolve()
-    validate_bundle(bundle)
+    validate_bundle(bundle, allow_disposable_direct_install=args.allow_disposable_direct_install)
     if Path(sys.executable).resolve() != (bundle / "Python/python.exe").resolve():
         parser.error("Run this script with the tested bundle's Python/python.exe")
     if args.report_dir:

--- a/scripts/windows/installer-smoke.ps1
+++ b/scripts/windows/installer-smoke.ps1
@@ -5,7 +5,8 @@ param(
     [string]$Version,
     [switch]$VerifyStoreSignatures,
     [string]$SignatureReport = "",
-    [string]$ExpectedPublisher = "Nicholas Reville"
+    [string]$ExpectedPublisher = "Nicholas Reville",
+    [string]$NativeAcceptanceReport = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -62,6 +63,10 @@ try {
     }
     if ($VerifyStoreSignatures) {
         & (Join-Path $PSScriptRoot "store-pe-signatures.ps1") -Payload $InstallPath -Report $SignatureReport
+    }
+    if ($NativeAcceptanceReport) {
+        & (Join-Path $InstallPath "Python/python.exe") -B (Join-Path $PSScriptRoot "desktop-smoke.py") $InstallPath --allow-disposable-direct-install --timeout 270 --report-dir $NativeAcceptanceReport
+        if ($LASTEXITCODE -ne 0) { throw "Installed desktop acceptance failed" }
     }
     $Installed = Get-ItemProperty $RegistryPath
     if ($Installed.DisplayVersion -ne $Version -or $Installed.Publisher -ne $ExpectedPublisher) {

--- a/scripts/windows/verify-native-candidate.ps1
+++ b/scripts/windows/verify-native-candidate.ps1
@@ -1,0 +1,44 @@
+param(
+    [Parameter(Mandatory)][string]$Directory,
+    [Parameter(Mandatory)][ValidatePattern('^[0-9a-f]{40}$')][string]$SourceRevision,
+    [Parameter(Mandatory)][ValidatePattern('^[0-9a-f]{64}$')][string]$InstallerSha256
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$Receipt = Get-Content -LiteralPath (Join-Path $Directory 'store-candidate-receipt.json') -Raw | ConvertFrom-Json
+if ($Receipt.source_revision -cne $SourceRevision -or $Receipt.version -cnotmatch '^[0-9]+\.[0-9]+\.[0-9]+$') {
+    throw 'Candidate receipt source or version does not match the selected build.'
+}
+$Archives = @(Get-ChildItem -LiteralPath $Directory -File -Filter 'LightTable-*-windows-x64.zip')
+$Installers = @(Get-ChildItem -LiteralPath $Directory -File -Filter 'LightTable-*-windows-x64-setup.exe')
+if ($Archives.Count -ne 1 -or $Installers.Count -ne 1) { throw 'Expected one archive and one installer.' }
+$Archive = $Archives[0]
+$Installer = $Installers[0]
+if ($Installer.Name -cne "LightTable-$($Receipt.version)-windows-x64-setup.exe" -or
+    $Archive.Name -cne "LightTable-$($Receipt.version)-windows-x64.zip") {
+    throw 'Candidate filenames do not match its version.'
+}
+foreach ($File in @($Archive, $Installer)) {
+    $Entries = @($Receipt.artifacts | Where-Object { $_.file -ceq $File.Name })
+    $Hash = (Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($Entries.Count -ne 1 -or $Entries[0].sha256 -cne $Hash -or $Entries[0].bytes -ne $File.Length) {
+        throw 'Candidate artifact hash or size differs from its receipt.'
+    }
+    if ($File.Name -ceq $Installer.Name -and $Hash -cne $InstallerSha256) {
+        throw 'Installer differs from the independently verified candidate.'
+    }
+}
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$Zip = [IO.Compression.ZipFile]::OpenRead($Archive.FullName)
+try {
+    $Entries = @($Zip.Entries | Where-Object { $_.FullName -ceq 'LightTable/build-manifest.json' })
+    if ($Entries.Count -ne 1) { throw 'Expected one bundle identity manifest.' }
+    $Reader = [IO.StreamReader]::new($Entries[0].Open())
+    try { $Manifest = $Reader.ReadToEnd() | ConvertFrom-Json } finally { $Reader.Dispose() }
+    if ($Manifest.source_revision -cne $SourceRevision -or $Manifest.version -cne $Receipt.version -or
+        $Manifest.architecture -cne 'x64' -or $Manifest.store_candidate -ne $true -or
+        $Manifest.authenticode_signed -ne $true) {
+        throw 'Bundle identity differs from the selected signed Store candidate.'
+    }
+} finally { $Zip.Dispose() }
+$Receipt.version

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -48,9 +48,11 @@ class MacReleaseWorkflowContractTests(unittest.TestCase):
         )
         self.assertIn("--layer package", workflow)
         notarize = workflow.index("scripts/notarize-app.sh dist/LightTable.app")
-        publish = workflow.index("gh release create")
+        self.assertNotIn("gh release create", workflow)
+        self.assertNotIn("    tags:", workflow)
+        self.assertNotIn("schedule:", workflow)
         self.assertLess(smoke, notarize)
-        self.assertLess(smoke, publish)
+        self.assertIn("macos-release-proof.json", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_download.py
+++ b/tests/test_release_download.py
@@ -1,0 +1,34 @@
+import importlib.util
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('download_upgrade', ROOT/'scripts/release/download_upgrade.py')
+m = importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
+
+class PublicDownloadTests(unittest.TestCase):
+    def setUp(self):
+        tmp=tempfile.TemporaryDirectory();self.addCleanup(tmp.cleanup);self.directory=Path(tmp.name)/'candidate'
+        self.name='LightTable-0.6.0-linux-x86_64.tar.gz';self.data=b'published archive bytes'
+        self.asset=dict(name=self.name,browser_download_url=f'https://github.com/{m.REPO}/releases/download/v0.6.0/{self.name}',size=len(self.data),digest='sha256:'+hashlib.sha256(self.data).hexdigest())
+        self.release=dict(draft=False,prerelease=False,assets=[self.asset])
+    def run_download(self, data=None):
+        def curl(*args,**kwargs):(self.directory/self.name).write_bytes(self.data if data is None else data)
+        with patch.object(m.subprocess,'check_output',return_value=json.dumps(self.release).encode()), patch.object(m.subprocess,'run',side_effect=curl):
+            return m.download('0.6.0',self.directory)
+    def test_verified_public_download(self):self.assertEqual(self.run_download()['sha256'],self.asset['digest'][7:])
+    def test_changed_download_and_incomplete_digest_rejected(self):
+        with self.assertRaises(ValueError):self.run_download(b'altered')
+        self.asset['digest']=''
+        with self.assertRaises(ValueError):self.run_download()
+    def test_unpublished_or_external_asset_rejected(self):
+        self.release['draft']=True
+        with self.assertRaises(ValueError):self.run_download()
+        self.release['draft']=False;self.asset['browser_download_url']='https://example.com/file'
+        with self.assertRaises(ValueError):self.run_download()
+
+if __name__=='__main__':unittest.main()

--- a/tests/test_release_evidence.py
+++ b/tests/test_release_evidence.py
@@ -1,0 +1,45 @@
+import importlib.util
+import json
+from pathlib import Path
+import plistlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+def load(name):
+    spec=importlib.util.spec_from_file_location(name, ROOT/'scripts/release'/f'{name}.py')
+    m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m);return m
+mac=load('macos_receipt')
+
+class MacReceiptTests(unittest.TestCase):
+    def setUp(self):
+        t=tempfile.TemporaryDirectory();self.addCleanup(t.cleanup)
+        self.root=Path(t.name);self.app=self.root/'LightTable.app';(self.app/'Contents').mkdir(parents=True)
+        self.info={'LightTableSourceDirty':False,'LightTableSourceRevision':'a'*40,'CFBundleShortVersionString':'0.7.0-beta.1','LSMinimumSystemVersion':'14.0','SUEnableAutomaticChecks':False}
+        self.native={'ok':True,'layer':'package','fixtureCount':2,'machine':{'machine':'arm64'}}
+        self.dmg=self.root/'LightTable-0.7.0-beta.1-macos-arm64.dmg';self.dmg.write_bytes(b'final signed image')
+    def write(self): (self.app/'Contents/Info.plist').write_bytes(plistlib.dumps(self.info))
+    @patch.object(mac,'checked')
+    def test_manual_beta_records_actual_bytes_without_notarization_claim(self, check):
+        self.write();r=mac.create(self.app,self.native,[self.dmg],'beta')
+        self.assertTrue(r['code_signature_verified']);self.assertFalse(r['notarization_verified'])
+        self.assertEqual(r['artifacts'][0]['bytes'],len(b'final signed image'))
+        self.assertEqual(check.call_count,1)
+    @patch.object(mac,'checked')
+    def test_dirty_source_failed_native_and_enabled_beta_updates_are_rejected(self, check):
+        for field,value in [('LightTableSourceDirty',True),('SUEnableAutomaticChecks',True)]:
+            original=self.info[field];self.info[field]=value;self.write()
+            with self.assertRaises(AssertionError):mac.create(self.app,self.native,[self.dmg],'beta')
+            self.info[field]=original
+        self.write()
+        with self.assertRaises(AssertionError):mac.create(self.app,{**self.native,'ok':False},[self.dmg],'beta')
+    @patch.object(mac,'checked')
+    def test_stable_requires_application_and_dmg_trust_checks(self, check):
+        self.info['CFBundleShortVersionString']='0.7.0'
+        self.write();r=mac.create(self.app,self.native,[self.dmg],'stable')
+        self.assertTrue(r['notarization_verified'])
+        self.assertTrue(any(c.args[:2]==('spctl','--assess') for c in check.call_args_list))
+        self.assertEqual(sum(c.args[:3]==('xcrun','stapler','validate') for c in check.call_args_list),2)
+
+if __name__=='__main__':unittest.main()

--- a/tests/test_release_index.py
+++ b/tests/test_release_index.py
@@ -1,0 +1,48 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts/release'))
+from update_index import merge
+
+
+class ReleaseIndexTests(unittest.TestCase):
+    def setUp(self):
+        self.index = json.loads((ROOT / 'release/manifest.json').read_text())
+        incoming = copy.deepcopy(self.index)
+        incoming['platforms'] = {'linux-x86_64': incoming['platforms']['linux-x86_64']}
+        incoming['platforms']['linux-x86_64']['artifacts'] = incoming['platforms']['linux-x86_64']['artifacts'][:2]
+        self.result = dict(applied=True, public_bytes_verified=True, published_release=True,
+                           receipts_verified=True, manifest=incoming, platform='linux-x86_64',
+                           version=incoming['version'], source_revision=incoming['source_revision'],
+                           published_at='2026-09-10T03:51:06Z')
+
+    def test_resume_preserves_arch_and_other_platforms(self):
+        out = merge(self.index, self.result)
+        self.assertEqual(len(out['platforms']['linux-x86_64']['artifacts']), 4)
+        self.assertEqual(out['platforms']['macos-arm64']['artifacts'], self.index['platforms']['macos-arm64']['artifacts'])
+        self.assertEqual(out['platforms']['windows-x64']['state'], 'blocked')
+        self.assertNotIn('source_revision', self.index['platforms']['macos-arm64'])
+
+    def test_new_linux_version_preserves_older_mac_source(self):
+        m = self.result['manifest'];m['version'] = '0.7.0';m['source_revision'] = 'a'*40
+        e = m['platforms']['linux-x86_64'];e['version'] = '0.7.0';e['tag'] = 'v0.7.0'
+        for a in e['artifacts']:
+            a['name'] = a['name'].replace('0.6.0','0.7.0');a['url'] = a['url'].replace('0.6.0','0.7.0')
+        self.result.update(version='0.7.0', source_revision='a'*40)
+        out = merge(self.index, self.result)
+        self.assertEqual(out['version'], '0.7.0')
+        self.assertEqual(out['platforms']['macos-arm64']['source_revision'], self.index['source_revision'])
+        self.assertEqual(out['platforms']['macos-arm64']['version'], '0.6.0-beta.1')
+
+    def test_unpublished_unverified_or_changed_assets_are_rejected(self):
+        for flag in ('applied', 'public_bytes_verified', 'published_release', 'receipts_verified'):
+            with self.subTest(flag=flag), self.assertRaises(ValueError):
+                merge(self.index, {**self.result, flag: False})
+        self.result['manifest']['platforms']['linux-x86_64']['artifacts'][0]['sha256'] = 'a'*64
+        with self.assertRaises(ValueError):merge(self.index, self.result)
+
+if __name__ == '__main__':unittest.main()

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -1,0 +1,423 @@
+"""Offline proof of immutable, independently resumable platform publication."""
+import copy
+import importlib.util
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/release/release_process.py"
+SPEC = importlib.util.spec_from_file_location("release_process", SCRIPT)
+RELEASE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RELEASE)
+PREP_SPEC = importlib.util.spec_from_file_location("prepare_candidate", SCRIPT.with_name("prepare_candidate.py"))
+PREPARE = importlib.util.module_from_spec(PREP_SPEC)
+with patch.dict(sys.modules, {"release_process": RELEASE}):
+    PREP_SPEC.loader.exec_module(PREPARE)
+REVISION = "a" * 40
+
+
+class ReleaseProcessTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.manifest = {"schema_version": 1, "version": "1.2.3", "source_revision": REVISION,
+                         "platforms": {"linux-x86_64": self.entry("linux-x86_64")}}
+        self.platform = "linux-x86_64"
+
+    def entry(self, platform):
+        return {"version": "1.2.3", "channel": "stable", "minimum_os": "Ubuntu 24.04+",
+                "update_owner": "app", "state": "ready", "signing": "ed25519" if platform == "linux-x86_64" else "authenticode",
+                "gates": [], "validation": {"status": "passed", "receipts": ["https://github.com/reville/lighttable-digital-darkroom/actions/runs/1"]}, "artifacts": []}
+
+    def artifact(self, name=None, content=b"signed installer definitions", platform=None):
+        platform = platform or self.platform
+        name = name or f"LightTable-1.2.3-{platform}-installers.tar.gz"
+        path = self.root / name
+        path.write_bytes(content)
+        identity = RELEASE.file_identity(path)
+        self.manifest["platforms"][platform]["artifacts"].append({**identity, "url": RELEASE.asset_url(self.manifest, name, platform)})
+        return path
+
+    def archive(self, **overrides):
+        payload = {"version": "1.2.3", "source_revision": REVISION, "source_dirty": False, "platform": "linux", "architecture": "x86_64", **overrides}
+        content = json.dumps(payload).encode()
+        path = self.root / "LightTable-1.2.3-linux-x86_64.tar.gz"
+        with tarfile.open(path, "w:gz") as archive:
+            info = tarfile.TarInfo("LightTable/build-manifest.json")
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+        self.manifest["platforms"][self.platform]["artifacts"].append({**RELEASE.file_identity(path), "url": RELEASE.asset_url(self.manifest, path.name, self.platform)})
+        return path
+
+    def manifest_path(self):
+        path = self.root / RELEASE.platform_names("1.2.3", self.platform)["manifest"]
+        RELEASE.write_json(path, self.manifest)
+        return path
+
+    def capabilities(self):
+        return {"source_revision": REVISION, "source_clean": True, "tag_revision": REVISION,
+                "platforms": {self.platform: {"release_environment_allowed": True, "build_runner_ready": True,
+                                              "native_acceptance_ready": True, "credentials": {"linux_update_signing": True}}}}
+
+    def test_release_schema_and_binary_round_trip(self):
+        self.archive()
+        result = RELEASE.verify_artifacts(self.manifest, self.root)
+        self.assertEqual(len(result), 1)
+
+    def test_tampering_and_size_mismatch_rejected(self):
+        path = self.artifact()
+        path.write_bytes(b"different bytes")
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            RELEASE.verify_artifacts(self.manifest, self.root)
+        self.manifest["platforms"][self.platform]["artifacts"][0].update(RELEASE.file_identity(path))
+        self.manifest["platforms"][self.platform]["artifacts"][0]["bytes"] += 1
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            RELEASE.verify_artifacts(self.manifest, self.root)
+
+    def test_embedded_version_source_clean_and_platform_are_independent_gates(self):
+        for overrides, message in [({"version": "1.2.2"}, "version mismatch"),
+                                   ({"source_revision": "b" * 40}, "source mismatch"),
+                                   ({"source_dirty": True}, "not clean"),
+                                   ({"platform": "windows"}, "platform mismatch"),
+                                   ({"architecture": "aarch64"}, "architecture mismatch")]:
+            with self.subTest(overrides=overrides):
+                self.manifest["platforms"][self.platform]["artifacts"] = []
+                self.archive(**overrides)
+                with self.assertRaisesRegex(ValueError, message):
+                    RELEASE.verify_artifacts(self.manifest, self.root)
+
+    def test_windows_legacy_or_unsigned_bundle_is_not_promotable(self):
+        self.platform = "windows-x64"
+        self.manifest["platforms"] = {self.platform: self.entry(self.platform)}
+        payload = {"version": "1.2.3", "source_revision": REVISION, "architecture": "x64"}
+        for clean_fields, expected in [({}, "not clean"), ({"source_dirty": False, "platform": "windows"}, "Authenti")]:
+            self.manifest["platforms"][self.platform]["artifacts"] = []
+            path = self.root / "LightTable-1.2.3-windows-x64.zip"
+            with zipfile.ZipFile(path, "w") as archive:
+                archive.writestr("LightTable/build-manifest.json", json.dumps({**payload, **clean_fields}))
+            self.manifest["platforms"][self.platform]["artifacts"].append({**RELEASE.file_identity(path), "url": RELEASE.asset_url(self.manifest, path.name, self.platform)})
+            with self.assertRaisesRegex(ValueError, expected):
+                RELEASE.verify_artifacts(self.manifest, self.root)
+
+    def test_archive_duplicate_metadata_rejected(self):
+        path = self.root / "LightTable-1.2.3-linux-x86_64.tar.gz"
+        with tarfile.open(path, "w:gz") as archive:
+            for _ in range(2):
+                info = tarfile.TarInfo("LightTable/build-manifest.json")
+                info.size = 2
+                archive.addfile(info, io.BytesIO(b"{}"))
+        self.manifest["platforms"][self.platform]["artifacts"].append({**RELEASE.file_identity(path), "url": RELEASE.asset_url(self.manifest, path.name, self.platform)})
+        with self.assertRaisesRegex(ValueError, "ambiguous"):
+            RELEASE.verify_artifacts(self.manifest, self.root)
+
+    def test_symlink_artifacts_rejected(self):
+        path = self.artifact()
+        path.rename(self.root / "actual")
+        path.symlink_to(self.root / "actual")
+        with self.assertRaisesRegex(ValueError, "regular"):
+            RELEASE.verify_artifacts(self.manifest, self.root)
+
+    def test_wrong_url_owner_tag_query_and_version_rejected(self):
+        self.artifact()
+        valid = copy.deepcopy(self.manifest)
+        asset = valid["platforms"][self.platform]["artifacts"][0]
+        for url in [asset["url"].replace("reville/", "someone/"), asset["url"].replace("v1.2.3", "v1.2.2"), asset["url"] + "?token=secret", asset["url"].replace("https:", "http:")]:
+            self.manifest = copy.deepcopy(valid)
+            self.manifest["platforms"][self.platform]["artifacts"][0]["url"] = url
+            with self.assertRaisesRegex(ValueError, "ownership"):
+                RELEASE.validate_manifest(self.manifest)
+        self.manifest = copy.deepcopy(valid)
+        self.manifest["platforms"][self.platform]["version"] = "2.0.0"
+        with self.assertRaisesRegex(ValueError, "version differs"):
+            RELEASE.validate_manifest(self.manifest)
+
+    def test_name_collision_and_unscoped_checksums_rejected(self):
+        self.artifact()
+        entry = self.manifest["platforms"][self.platform]
+        entry["artifacts"].append(copy.deepcopy(entry["artifacts"][0]))
+        with self.assertRaisesRegex(ValueError, "name collision"):
+            RELEASE.validate_manifest(self.manifest)
+        entry["artifacts"] = []
+        self.artifact("SHA256SUMS")
+        with self.assertRaisesRegex(ValueError, "does not own"):
+            RELEASE.validate_manifest(self.manifest)
+
+    def test_arch_package_filename_preserves_public_convention(self):
+        self.artifact("lighttable-bin-1.2.3-1-x86_64.pkg.tar.zst")
+        self.artifact("lighttable-bin-1.2.3-1-x86_64.pkg.tar.zst.sha256")
+        RELEASE.validate_manifest(self.manifest)
+        self.manifest["platforms"][self.platform]["artifacts"][0]["name"] = "lighttable-bin-1.2.3-0-x86_64.pkg.tar.zst"
+        with self.assertRaisesRegex(ValueError, "does not own"):
+            RELEASE.validate_manifest(self.manifest)
+
+    def test_beta_mac_aggregate_keeps_explicit_tag_and_same_tree_provenance(self):
+        self.artifact()
+        entry = self.entry("macos-arm64")
+        entry.update(version="1.2.3-beta.1", channel="beta", update_owner="manual", signing="ad-hoc", tag="macos-v1.2.3-beta.1", build_source_revision="b" * 40, source_tree="c" * 40)
+        self.manifest["platforms"]["macos-arm64"] = entry
+        self.artifact("LightTable-1.2.3-beta.1-macos-arm64.dmg", platform="macos-arm64")
+        RELEASE.validate_manifest(self.manifest)
+        self.assertEqual(RELEASE.promotion_gates("macos-arm64", entry), [])
+        entry["update_owner"] = "app"
+        self.assertTrue(RELEASE.promotion_gates("macos-arm64", entry))
+
+    def test_aggregate_preserves_older_published_platform_with_own_source_and_tag(self):
+        self.artifact()
+        old = copy.deepcopy(self.manifest["platforms"][self.platform])
+        old.update(tag="v1.2.3", source_revision=REVISION)
+        self.manifest.update(version="1.3.0", source_revision="b" * 40)
+        self.manifest["platforms"][self.platform] = old
+        RELEASE.validate_manifest(self.manifest)
+        del old["source_revision"]
+        with self.assertRaisesRegex(ValueError, "version differs"):
+            RELEASE.validate_manifest(self.manifest)
+
+    def test_partial_release_resume_skips_identical_and_adds_missing(self):
+        first = self.artifact()
+        self.artifact("LightTable-1.2.3-linux-x86_64-SHA256SUMS")
+        plan = RELEASE.publication_plan(self.manifest, [RELEASE.file_identity(first)], [self.platform])
+        actions = {item["name"]: item["action"] for item in plan}
+        self.assertEqual(actions[first.name], "skip")
+        self.assertEqual(list(actions.values()).count("add"), 1)
+        again = RELEASE.publication_plan(self.manifest, plan, [self.platform])
+        self.assertEqual({item["action"] for item in again}, {"skip"})
+
+    def test_published_binary_mismatch_fails_even_when_size_matches(self):
+        path = self.artifact()
+        previous = {**RELEASE.file_identity(path), "sha256": "0" * 64}
+        with self.assertRaisesRegex(ValueError, "immutable asset collision"):
+            RELEASE.publication_plan(self.manifest, [previous], [self.platform])
+
+    def test_selected_ready_platform_does_not_inherit_other_platform_gate(self):
+        self.artifact()
+        entry = self.entry("windows-x64")
+        entry.update(state="blocked", gates=["Windows 10/11 native client acceptance"])
+        self.manifest["platforms"]["windows-x64"] = entry
+        self.assertTrue(RELEASE.publication_plan(self.manifest, [], [self.platform]))
+        with self.assertRaisesRegex(ValueError, "Windows 10/11"):
+            RELEASE.publication_plan(self.manifest, [], ["windows-x64"])
+
+    def test_receipts_and_signing_cannot_be_silently_weakened(self):
+        self.artifact()
+        entry = self.manifest["platforms"][self.platform]
+        entry["validation"]["receipts"] = []
+        with self.assertRaisesRegex(ValueError, "receipts"):
+            RELEASE.publication_plan(self.manifest, [], [self.platform])
+        entry["validation"]["receipts"] = ["receipt.json"]
+        entry["signing"] = "unsigned"
+        with self.assertRaisesRegex(ValueError, "ed25519"):
+            RELEASE.publication_plan(self.manifest, [], [self.platform])
+
+    def test_prebuild_preflight_needs_no_artifacts_or_acceptance_receipt(self):
+        entry = self.manifest["platforms"][self.platform]
+        entry.update(state="candidate", validation={"status": "pending", "receipts": []})
+        caps = self.capabilities()
+        caps["platforms"][self.platform]["native_acceptance_ready"] = False
+        self.assertTrue(RELEASE.preflight(self.manifest, caps, [self.platform], "build")["ready"])
+        self.assertFalse(RELEASE.preflight(self.manifest, caps, [self.platform], "publish")["ready"])
+        with self.assertRaisesRegex(ValueError, "no artifacts"):
+            RELEASE.verify_artifacts(self.manifest, self.root)
+
+    def test_preflight_reports_missing_credential_without_values(self):
+        self.artifact()
+        caps = self.capabilities()
+        caps["platforms"][self.platform]["credentials"]["linux_update_signing"] = False
+        result = RELEASE.preflight(self.manifest, caps, [self.platform])
+        self.assertFalse(result["ready"])
+        self.assertIn("missing credential capability", json.dumps(result))
+        caps["platforms"][self.platform]["credentials"]["linux_update_signing"] = "PRIVATE KEY"
+        with self.assertRaisesRegex(ValueError, "booleans"):
+            RELEASE.preflight(self.manifest, caps, [self.platform])
+
+    def test_source_tag_and_environment_fail_preflight_before_build(self):
+        self.artifact()
+        caps = self.capabilities()
+        caps.update(source_clean=False, tag_revision="b" * 40)
+        caps["platforms"][self.platform]["release_environment_allowed"] = False
+        result = RELEASE.preflight(self.manifest, caps, [self.platform])
+        self.assertFalse(result["ready"])
+        self.assertEqual(len(result["platforms"][self.platform]["build_gates"]), 3)
+
+    def test_publish_plan_does_not_mutate_and_apply_only_adds(self):
+        path = self.artifact()
+        manifest_path = self.manifest_path()
+        remote = [RELEASE.file_identity(path)]
+        with patch.object(RELEASE, "remote_assets", return_value=remote), patch.object(RELEASE, "gh") as gh:
+            result = RELEASE.publish(manifest_path, self.root, [self.platform])
+            self.assertFalse(result["applied"])
+            gh.assert_not_called()
+        after = remote + [RELEASE.file_identity(manifest_path)]
+        with patch.object(RELEASE, "remote_assets", side_effect=[remote, after]), patch.object(RELEASE, "gh") as gh:
+            RELEASE.publish(manifest_path, self.root, [self.platform], apply=True)
+            self.assertEqual(gh.call_count, 1)
+            args = gh.call_args.args
+            self.assertEqual(args[:3], ("release", "upload", "v1.2.3"))
+            self.assertNotIn("--clobber", args)
+            self.assertIn(str(manifest_path.resolve()), args)
+
+    def test_changed_immutable_manifest_rejected_before_any_upload(self):
+        self.artifact()
+        path = self.manifest_path()
+        old = {**RELEASE.file_identity(path), "sha256": "0" * 64}
+        with patch.object(RELEASE, "remote_assets", return_value=[old]), patch.object(RELEASE, "gh") as gh:
+            with self.assertRaisesRegex(ValueError, "immutable manifest collision"):
+                RELEASE.publish(path, self.root, [self.platform], apply=True)
+            gh.assert_not_called()
+
+    def test_remote_tag_mismatch_prevents_publication(self):
+        self.artifact()
+        with patch.object(RELEASE, "gh", return_value="b" * 40):
+            with self.assertRaisesRegex(ValueError, "tag source mismatch"):
+                RELEASE.remote_assets(self.manifest)
+
+    def test_remote_digest_and_legacy_download_fallback(self):
+        path = self.artifact()
+        identity = RELEASE.file_identity(path)
+        for digest in ["sha256:" + identity["sha256"], None]:
+            calls = []
+            def fake_gh(*args):
+                calls.append(args)
+                if args[0] == "api":
+                    return REVISION
+                if args[:2] == ("release", "view"):
+                    return json.dumps({"tagName": "v1.2.3", "assets": [{"name": path.name, "size": identity["bytes"], "digest": digest}]})
+                destination = Path(args[args.index("--dir") + 1])
+                (destination / path.name).write_bytes(path.read_bytes())
+                return ""
+            with patch.object(RELEASE, "gh", side_effect=fake_gh):
+                self.assertEqual(RELEASE.remote_assets(self.manifest), [identity])
+            self.assertEqual(any(call[:2] == ("release", "download") for call in calls), digest is None)
+
+    def test_cli_create_verify_and_offline_plan(self):
+        artifact = self.archive()
+        output = self.root / "created.json"
+        command = [sys.executable, str(SCRIPT), "create-manifest", "--version", "1.2.3", "--source-revision", REVISION,
+                   "--platform", self.platform, "--channel", "stable", "--minimum-os", "Ubuntu 24.04+", "--update-owner", "app",
+                   "--state", "ready", "--signing", "ed25519", "--validation-status", "passed", "--receipt", "native.json",
+                   "--artifact", artifact.name, "--artifacts-dir", str(self.root), "--output", str(output)]
+        created = subprocess.run(command, capture_output=True, text=True)
+        self.assertEqual(created.returncode, 0, created.stderr)
+        verified = subprocess.run([sys.executable, str(SCRIPT), "verify", "--manifest", str(output), "--artifacts-dir", str(self.root)], capture_output=True, text=True)
+        self.assertEqual(verified.returncode, 0, verified.stderr)
+        existing = self.root / "existing.json"
+        existing.write_text("[]")
+        planned = subprocess.run([sys.executable, str(SCRIPT), "plan", "--manifest", str(output), "--existing", str(existing), "--platform", self.platform], capture_output=True, text=True)
+        self.assertEqual(planned.returncode, 0, planned.stderr)
+        self.assertEqual(json.loads(planned.stdout)["assets"][0]["action"], "add")
+
+
+class ReleasePreparationTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+
+    def test_installer_archive_is_deterministic(self):
+        one, two = self.root / "one.tar.gz", self.root / "two.tar.gz"
+        PREPARE.deterministic_archive({"z/installer": "last", "a/installer": "first"}, one)
+        PREPARE.deterministic_archive({"a/installer": "first", "z/installer": "last"}, two)
+        self.assertEqual(one.read_bytes(), two.read_bytes())
+        with tarfile.open(one) as archive:
+            self.assertEqual(archive.getnames(), ["a/installer", "z/installer"])
+            self.assertTrue(all(member.mtime == 0 and member.uid == 0 for member in archive))
+
+    def test_existing_public_feed_is_reused_only_when_digest_and_size_match(self):
+        content = b'{"signed":"immutable feed"}'
+        source = self.root / "source.json"
+        source.write_bytes(content)
+        identity = RELEASE.file_identity(source)
+        metadata = {"draft": False, "assets": [{"name": "linux-x86_64.json", "size": identity["bytes"], "digest": "sha256:" + identity["sha256"]}]}
+        def gh(*args):
+            if args[0] == "api":
+                return json.dumps(metadata)
+            destination = Path(args[args.index("--dir") + 1])
+            (destination / "linux-x86_64.json").write_bytes(content)
+        output = self.root / "linux-x86_64.json"
+        with patch.object(RELEASE, "gh", side_effect=gh):
+            self.assertTrue(PREPARE.reuse_public_feed("v1.2.3", output.name, output))
+        self.assertEqual(output.read_bytes(), content)
+        metadata["assets"][0]["digest"] = "sha256:" + "0" * 64
+        with patch.object(RELEASE, "gh", side_effect=gh):
+            with self.assertRaisesRegex(ValueError, "identity mismatch"):
+                PREPARE.reuse_public_feed("v1.2.3", output.name, output)
+
+    def test_missing_release_allows_new_feed_but_auth_failure_does_not(self):
+        for stderr, expected in [("HTTP 404: Not Found", False), ("HTTP 403: Forbidden", None)]:
+            error = subprocess.CalledProcessError(1, ["gh"], stderr=stderr)
+            with patch.object(RELEASE, "gh", side_effect=error):
+                if expected is False:
+                    self.assertFalse(PREPARE.reuse_public_feed("v1.2.3", "linux-x86_64.json", self.root / "feed"))
+                else:
+                    with self.assertRaises(subprocess.CalledProcessError):
+                        PREPARE.reuse_public_feed("v1.2.3", "linux-x86_64.json", self.root / "feed")
+
+    def test_failed_fork_and_unrelated_build_runs_rejected(self):
+        base = {"status": "completed", "event": "workflow_dispatch", "conclusion": "success", "head_repository": {"full_name": RELEASE.REPOSITORY}, "path": ".github/workflows/windows-build.yml", "head_sha": REVISION}
+        for change in [{"status": "in_progress"}, {"event": "pull_request"}, {"head_repository": {"full_name": "someone/fork"}}, {"path": ".github/workflows/unrelated.yml"}]:
+            with patch.object(RELEASE, "gh", return_value=json.dumps({**base, **change})):
+                with self.assertRaises(ValueError):
+                    PREPARE.build_run("123", "windows-x64")
+
+    def test_other_platform_failure_does_not_block_successful_selected_package(self):
+        run = {"status": "completed", "event": "workflow_dispatch", "conclusion": "failure", "head_repository": {"full_name": RELEASE.REPOSITORY}, "path": ".github/workflows/release.yml", "head_sha": REVISION}
+        jobs = [{"jobs": [{"id": 1, "name": "macos", "conclusion": "failure"}, {"id": 2, "name": "windows / package", "conclusion": "success", "steps": [{"name": "Require native edit, export and restart", "conclusion": "success"}]}]}]
+        with patch.object(RELEASE, "gh", side_effect=[json.dumps(run), json.dumps(jobs)]):
+            result = PREPARE.build_run("123", "windows-x64")
+        self.assertEqual(result["selected_job_id"], 2)
+        jobs[0]["jobs"][1]["steps"][0]["conclusion"] = "skipped"
+        with patch.object(RELEASE, "gh", side_effect=[json.dumps(run), json.dumps(jobs)]):
+            with self.assertRaisesRegex(ValueError, "proof step"):
+                PREPARE.build_run("123", "windows-x64")
+
+    def test_prepare_preserves_candidate_bytes_and_does_not_claim_acceptance(self):
+        platform, version = "windows-x64", "1.2.3"
+        stem = f"LightTable-{version}-{platform}"
+        original = self.root / "original"
+        original.mkdir()
+        with zipfile.ZipFile(original / (stem + ".zip"), "w") as archive:
+            archive.writestr("LightTable/LightTable.exe", b"signed executable")
+            archive.writestr("LightTable/lighttable.cmd", "@echo off")
+            archive.writestr("LightTable/build-manifest.json", json.dumps({"version": version, "source_revision": REVISION, "source_dirty": False, "platform": "windows", "architecture": "x64", "authenticode_signed": True}))
+        (original / (stem + "-setup.exe")).write_bytes(b"immutable signed installer")
+        (original / "appcast-windows-x64.xml").write_text("<signed-feed />")
+        (original / "windows-signatures.json").write_text('{"fixture":"signature evidence verified at promotion"}')
+        before = {path.name: RELEASE.file_identity(path) for path in original.iterdir()}
+        run = {"head_sha": "b" * 40}
+        def download(*args):
+            if args[0] == "api":
+                return REVISION
+            self.assertEqual(args[:2], ("run", "download"))
+            destination = Path(args[args.index("--dir") + 1])
+            for path in original.iterdir():
+                (destination / path.name).write_bytes(path.read_bytes())
+        args = SimpleNamespace(platform=platform, version=version, build_run_id="123", native_run_id="456", source_revision=REVISION, output_dir=self.root / "prepared")
+        with patch.object(PREPARE, "build_run", return_value=run), patch.object(RELEASE, "gh", side_effect=download):
+            result = PREPARE.prepare(args)
+        manifest = RELEASE.read_json(result["manifest"])
+        entry = manifest["platforms"][platform]
+        self.assertEqual(entry["state"], "candidate")
+        self.assertEqual(entry["validation"]["status"], "pending")
+        self.assertEqual(entry["native_run_id"], "456")
+        self.assertEqual(entry["build_workflow_revision"], "b" * 40)
+        self.assertEqual(manifest["source_revision"], REVISION)
+        for path in original.iterdir():
+            output_name = stem + "-" + path.name if path.name == "windows-signatures.json" else path.name
+            after = RELEASE.file_identity(args.output_dir / output_name)
+            self.assertEqual(after["sha256"], before[path.name]["sha256"])
+        RELEASE.verify_artifacts(manifest, args.output_dir)
+        with self.assertRaisesRegex(ValueError, "blocked"):
+            RELEASE.publication_plan(manifest, [], [platform])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_promotion.py
+++ b/tests/test_release_promotion.py
@@ -1,0 +1,234 @@
+"""Promotion consumes immutable binaries and actual client receipts; no external writes."""
+from __future__ import annotations
+
+import argparse
+import base64
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'scripts/release'))
+import promote_candidate as promote
+import release_process as release
+
+
+class PromotionProofTests(unittest.TestCase):
+    def manifest(self, platform='windows-x64'):
+        return {'schema_version': 1, 'repository': release.REPOSITORY, 'tag': 'v0.7.0',
+                'version': '0.7.0', 'source_revision': 'a' * 40, 'platforms': {platform: {
+                    'version': '0.7.0', 'channel': 'stable', 'minimum_os': 'Windows 10 x64',
+                    'update_owner': 'manual', 'signing': 'authenticode', 'state': 'candidate',
+                    'validation': {'status': 'pending', 'receipts': []}, 'gates': [],
+                    'artifacts': [], 'build_run_id': '123'}}}
+
+    def native(self):
+        return {'ok': True, 'build': {'source_revision': 'a' * 40, 'version': '0.7.0',
+                'source_dirty': False, 'platform': 'windows', 'architecture': 'x64', 'authenticode_signed': True},
+                'export': {'bits': 16}, 'edit_persistence': {'server_restarted': True}}
+
+    def test_windows_requires_actual_offline_native_client_receipts(self):
+        fixture = {'host.json': {'ok': True, 'product_type': 1, 'architecture': 'AMD64', 'build': '26200',
+                   'webview2_absent_before_offline_install': True, 'network_adapters_disabled': True,
+                   'installer_signature_before_disconnect': 'Valid'},
+                   'result.json': {'ok': True, 'offline': True, 'account_is_elevated': False,
+                                   'installer_sha256': 'b' * 64},
+                   'installed-signatures.json': {'pe_count': 1, 'invalid_count': 0,
+                                                'signatures': [{'path': 'Uninstall.exe', 'status': 'Valid'}]},
+                   'native/report.json': self.native()}
+        mutations = [None,
+            ('host.json', 'product_type', 3), ('host.json', 'architecture', 'ARM64'),
+            ('host.json', 'webview2_absent_before_offline_install', False),
+            ('host.json', 'network_adapters_disabled', False), ('host.json', 'build', '19045'),
+            ('result.json', 'account_is_elevated', True), ('result.json', 'offline', False),
+            ('result.json', 'installer_sha256', 'c' * 64), ('native/report.json', 'ok', False),
+            ('installed-signatures.json', 'invalid_count', 1)]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary)
+                data = copy.deepcopy(fixture)
+                if mutation:
+                    filename, key, value = mutation
+                    data[filename][key] = value
+                for filename, record in data.items():
+                    path = directory / filename
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text(json.dumps(record))
+                if mutation:
+                    with self.assertRaises(ValueError):
+                        promote.verify_windows_client(directory, '11', self.manifest(), 'b' * 64)
+                else:
+                    promote.verify_windows_client(directory, '11', self.manifest(), 'b' * 64)
+
+    def test_native_source_and_restart_are_required(self):
+        for key, value in [('source_revision', 'b' * 40), ('source_dirty', True), ('architecture', 'arm64')]:
+            report = self.native()
+            report['build'][key] = value
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                promote.verify_native_report(report, self.manifest(), 'windows-x64')
+        report = self.native()
+        report['edit_persistence']['server_restarted'] = False
+        with self.assertRaises(ValueError):
+            promote.verify_native_report(report, self.manifest(), 'windows-x64')
+
+    def test_feed_refuses_downgrade_and_same_version_replacement(self):
+        def feed(version, signature='fixture'):
+            return json.dumps({'signed': {'version': version}, 'signature': signature}).encode()
+        promote.check_feed_forward(feed('0.6.0'), feed('0.7.0'), 'linux-x86_64')
+        promote.check_feed_forward(feed('0.7.0'), feed('0.7.0'), 'linux-x86_64')
+        for old, new in [(feed('0.7.0'), feed('0.6.0')), (feed('0.7.0'), feed('0.7.0', 'different'))]:
+            with self.assertRaises(ValueError):
+                promote.check_feed_forward(old, new, 'linux-x86_64')
+
+    def test_windows_feed_signature_must_match_installer_and_embedded_key(self):
+        try:
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+            from cryptography.exceptions import InvalidSignature
+        except ImportError:
+            self.skipTest('cryptography is required')
+        key = Ed25519PrivateKey.generate()
+        public = base64.b64encode(key.public_key().public_bytes_raw()).decode()
+        with tempfile.TemporaryDirectory() as temporary, patch.object(promote, 'SPARKLE_KEY', public):
+            directory = Path(temporary)
+            manifest = self.manifest()
+            entry = manifest['platforms']['windows-x64']
+            entry['update_owner'] = 'app'
+            entry['artifacts'] = [{'name': 'appcast-windows-x64.xml'}]
+            archive_name, installer_name = promote.primary_names(manifest, 'windows-x64')
+            archive = directory / archive_name
+            with zipfile.ZipFile(archive, 'w') as bundle:
+                bundle.writestr('LightTable/LightTable.exe', b'PE fixture ' + public.encode())
+            installer = directory / installer_name
+            installer.write_bytes(b'signed installer fixture')
+            signature = base64.b64encode(key.sign(installer.read_bytes())).decode()
+            feed = directory / 'appcast-windows-x64.xml'
+            feed.write_text('<rss xmlns:sparkle="' + promote.SPARKLE + '"><channel><item><enclosure '
+                'url="' + release.asset_url(manifest, installer_name) + '" length="' + str(installer.stat().st_size) + '" '
+                'sparkle:version="0.7.0" sparkle:edSignature="' + signature + '"/></item></channel></rss>')
+            self.assertEqual(promote.verify_signed_feed(manifest, 'windows-x64', directory), feed)
+            installer.write_bytes(b'tampered installer bytes')
+            with self.assertRaises((ValueError, InvalidSignature)):
+                promote.verify_signed_feed(manifest, 'windows-x64', directory)
+            installer.write_bytes(b'signed installer fixture')
+            with zipfile.ZipFile(archive, 'w') as bundle:
+                bundle.writestr('LightTable/LightTable.exe', b'PE fixture with another update key')
+            with self.assertRaisesRegex(ValueError, 'public key'):
+                promote.verify_signed_feed(manifest, 'windows-x64', directory)
+
+    def test_binary_identity_must_match_original_build_not_only_candidate(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = self.manifest()
+            for name in promote.primary_names(manifest, 'windows-x64'):
+                (root / name).write_bytes(b'original')
+                manifest['platforms']['windows-x64']['artifacts'].append(release.file_identity(root / name))
+            promote.verify_original_binaries(manifest, 'windows-x64', root)
+            (root / promote.primary_names(manifest, 'windows-x64')[0]).write_bytes(b'tampered')
+            with self.assertRaises(ValueError):
+                promote.verify_original_binaries(manifest, 'windows-x64', root)
+
+    def test_dry_run_checks_evidence_without_publication_or_feed_mutation(self):
+        args = argparse.Namespace(platform='windows-x64', version='0.7.0', source_revision='a' * 40,
+            build_run_id='123', manifest_run_id='456', manifest_artifact='LightTable-windows-x64-promotion',
+            native_run_id='789', apply=False, make_public=True, advance_feed=False)
+        manifest = self.manifest()
+        def download(run_id, name, directory):
+            directory.mkdir()
+            if name.endswith('-promotion'):
+                release.write_json(directory / release.platform_names('0.7.0', args.platform)['manifest'], manifest)
+            return directory
+        def gh(*command):
+            if command[0] == 'api':
+                return 'a' * 40
+            self.assertEqual(command[:2], ('release', 'view'))
+            return json.dumps({'isDraft': True, 'isPrerelease': False})
+        with patch.object(promote, 'build_run', return_value={'head_sha': 'd' * 40}), patch.object(promote, 'workflow_run') as runs, patch.object(promote, 'download_artifact', side_effect=download), \
+             patch.object(release, 'verify_artifacts'), patch.object(promote, 'verify_original_binaries'), \
+             patch.object(promote, 'verify_evidence') as evidence, patch.object(promote, 'verify_signed_feed', return_value=None), \
+             patch.object(release, 'gh', side_effect=gh), patch.object(promote, 'release_state', return_value={'isDraft': True, 'isPrerelease': False}), \
+             patch.object(release, 'publish', return_value={'assets': [], 'applied': False}) as publish, \
+             patch.object(promote, 'public_download') as public, patch.object(promote, 'advance_feed') as feed:
+            result = promote.promote(args)
+            self.assertFalse(result['applied'])
+            self.assertTrue(result['receipts_verified'])
+            self.assertEqual(result['source_revision'], args.source_revision)
+            evidence.assert_called_once()
+            self.assertFalse(publish.call_args.kwargs['apply'])
+            public.assert_not_called()
+            feed.assert_not_called()
+
+    def test_missing_release_is_planned_without_writes_and_created_only_on_apply(self):
+        for apply in (False, True):
+            with self.subTest(apply=apply), tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary)
+                manifest = self.manifest()
+                entry = manifest['platforms']['windows-x64']
+                entry['state'] = 'ready'
+                entry['validation'] = {'status': 'passed', 'receipts': ['https://example.test/receipt']}
+                name = 'LightTable-0.7.0-windows-x64-setup.exe'
+                entry['artifacts'] = [{'name': name, 'bytes': 7, 'sha256': 'b' * 64,
+                                       'url': release.asset_url(manifest, name)}]
+                manifest_path = directory / release.platform_names('0.7.0', 'windows-x64')['manifest']
+                release.write_json(manifest_path, manifest)
+                states = [None, {'isDraft': True, 'isPrerelease': False}] if apply else [None]
+                with patch.object(promote, 'release_state', side_effect=states), patch.object(release, 'gh') as gh, \
+                     patch.object(release, 'publish', return_value={'applied': apply, 'assets': []}) as publish:
+                    result, state = promote.plan_or_publish(manifest_path, directory, 'windows-x64', apply)
+                    self.assertTrue(result['create_draft'])
+                    self.assertEqual(result['draft_created'], apply)
+                    self.assertTrue(state['isDraft'])
+                    if apply:
+                        self.assertEqual(gh.call_args.args[:3], ('release', 'create', 'v0.7.0'))
+                        self.assertIn('--verify-tag', gh.call_args.args)
+                        self.assertIn('--draft', gh.call_args.args)
+                        self.assertNotIn('--clobber', gh.call_args.args)
+                        self.assertTrue(publish.call_args.kwargs['apply'])
+                    else:
+                        gh.assert_not_called()
+                        publish.assert_not_called()
+                        self.assertEqual(len(result['assets']), 2)
+                        self.assertTrue(all(item['action'] == 'add' for item in result['assets']))
+
+    def test_release_listing_errors_do_not_trigger_draft_creation(self):
+        with patch.object(release, 'gh', return_value='[[]]'):
+            self.assertIsNone(promote.release_state('v0.7.0'))
+        with tempfile.TemporaryDirectory() as temporary:
+            manifest_path = Path(temporary) / 'manifest.json'
+            release.write_json(manifest_path, self.manifest())
+            for failure in (subprocess.CalledProcessError(1, ['gh', 'api']), json.JSONDecodeError('bad response', '', 0)):
+                with self.subTest(failure=type(failure).__name__), \
+                     patch.object(release, 'gh', side_effect=failure) as gh, patch.object(release, 'publish') as publish:
+                    with self.assertRaises(type(failure)):
+                        promote.plan_or_publish(manifest_path, Path(temporary), 'windows-x64', True)
+                    self.assertEqual(gh.call_args.args[0], 'api')
+                    self.assertEqual(gh.call_count, 1)
+                    publish.assert_not_called()
+
+    def test_failed_evidence_never_calls_publish(self):
+        args = argparse.Namespace(platform='windows-x64', version='0.7.0', source_revision='a' * 40,
+            build_run_id='123', manifest_run_id='456', manifest_artifact='LightTable-windows-x64-promotion',
+            native_run_id='789', apply=True, make_public=True, advance_feed=False)
+        manifest = self.manifest()
+        def download(run_id, name, directory):
+            directory.mkdir()
+            if name.endswith('-promotion'):
+                release.write_json(directory / release.platform_names('0.7.0', args.platform)['manifest'], manifest)
+            return directory
+        with patch.object(promote, 'build_run', return_value={'head_sha': 'd' * 40}), patch.object(promote, 'workflow_run'), patch.object(promote, 'download_artifact', side_effect=download), \
+             patch.object(release, 'verify_artifacts'), patch.object(promote, 'verify_original_binaries'), \
+             patch.object(promote, 'verify_evidence', side_effect=ValueError('client proof missing')), \
+             patch.object(release, 'gh', return_value='a' * 40), patch.object(release, 'publish') as publish:
+            with self.assertRaisesRegex(ValueError, 'client proof missing'):
+                promote.promote(args)
+            publish.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_release_selection.py
+++ b/tests/test_release_selection.py
@@ -31,14 +31,15 @@ class ReleaseSelectionTests(unittest.TestCase):
         output.unlink(missing_ok=True)
         result = subprocess.run(["bash", "-euo", "pipefail", "-c", self.script], cwd=self.repo,
                                 env=os.environ | {"REQUESTED_VERSION": version, "GITHUB_REF_NAME": "v0.5.0",
-                                                  "PLATFORMS": platforms, "GITHUB_OUTPUT": str(output)},
+                                                  "PLATFORMS": platforms, "GITHUB_OUTPUT": str(output), "MACOS_CHANNEL": "stable",
+                                                  "GITHUB_STEP_SUMMARY": str(self.repo/"summary")},
                                 text=True, capture_output=True)
         fields = dict(line.split("=", 1) for line in output.read_text().splitlines()) if output.exists() else {}
         return result, fields
 
     def test_all_and_independent_platforms_select_only_requested_builds(self):
         for selection, expected in (("all", {"linux", "macos", "windows"}),
-                                    ("both", {"macos", "windows"}), ("linux", {"linux"}),
+                                    ("linux", {"linux"}),
                                     ("macos", {"macos"}), ("windows", {"windows"})):
             with self.subTest(selection=selection):
                 result, fields = self.run_selection(selection)

--- a/tests/test_windows_client_vm.py
+++ b/tests/test_windows_client_vm.py
@@ -1,0 +1,56 @@
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'scripts/windows/client-vm/prepare.py'
+
+class ClientPreparationTests(unittest.TestCase):
+    def prepare(self, digest=None, source='a'*40, version='0.6.0'):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        download = root / '.build/windows-client-download'
+        download.mkdir(parents=True)
+        (download / 'LightTable-0.6.0-windows-x64-setup.exe').write_bytes(b'verified candidate')
+        scripts = root / 'scripts/windows/client-vm'
+        scripts.mkdir(parents=True)
+        for name in ('guest-test.ps1', 'bootstrap.ps1'):
+            (scripts/name).write_text('# fixture')
+        digest = digest or hashlib.sha256(b'verified candidate').hexdigest()
+        result = subprocess.run([sys.executable, str(SCRIPT), '11', '--version', version,
+            '--source-sha', source, '--installer-sha256', digest], cwd=root,
+            capture_output=True, text=True)
+        return root, result
+
+    def test_exact_candidate_and_matching_receiver_are_staged(self):
+        root, result = self.prepare()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        config = json.loads((root/'.build/client-vm/oem/candidate.json').read_text())
+        self.assertEqual(config['version'], '0.6.0')
+        self.assertEqual(config['source_sha'], 'a'*40)
+        self.assertEqual(config['evidence_url'], 'http://10.0.2.1:18080')
+        tree = ET.parse(root/'.build/client-vm/custom.xml')
+        ns = {'u':'urn:schemas-microsoft-com:unattend'}
+        command = tree.find('.//u:CommandLine', ns).text
+        self.assertIn('C:\\OEM\\bootstrap.ps1', command)
+        password = tree.find('.//u:Password/u:Value', ns).text
+        self.assertNotIn(password, result.stdout+result.stderr)
+
+    def test_wrong_hash_is_rejected_before_staging(self):
+        root, result = self.prepare(digest='0'*64)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((root/'.build/client-vm/custom.xml').exists())
+
+    def test_invalid_source_or_version_is_rejected(self):
+        for kwargs in ({'source':'main'}, {'version':'../0.6.0'}):
+            with self.subTest(kwargs=kwargs):
+                root, result = self.prepare(**kwargs)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((root/'.build/client-vm/custom.xml').exists())
+
+if __name__ == '__main__': unittest.main()

--- a/tests/test_windows_desktop_smoke.py
+++ b/tests/test_windows_desktop_smoke.py
@@ -73,6 +73,20 @@ class DesktopSmokeSafetyTests(unittest.TestCase):
             (bundle / "install-channel.txt").write_text("\ufeffportable\n", encoding="utf-8")
             smoke.validate_bundle(bundle)
 
+    def test_disposable_override_only_allows_direct_installs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            bundle = Path(temporary)
+            for relative in ("LightTable.exe", "Python/python.exe", "Resources/LightTable/server.py"):
+                path = bundle / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+            (bundle / 'install-channel.txt').write_text('direct')
+            smoke.validate_bundle(bundle, allow_disposable_direct_install=True)
+            for channel in ('scoop', 'winget', 'chocolatey'):
+                (bundle / 'install-channel.txt').write_text(channel)
+                with self.assertRaises(RuntimeError):
+                    smoke.validate_bundle(bundle, allow_disposable_direct_install=True)
+
     def test_timeout_does_not_resubmit_a_delivered_native_command(self):
         api = Mock()
         api.request.side_effect = HTTPError("http://127.0.0.1", 504, "UI timed out", {}, None)

--- a/tests/test_windows_release_process.py
+++ b/tests/test_windows_release_process.py
@@ -1,0 +1,101 @@
+"""Executable checks for release timings and exact candidate identity, without Windows UI."""
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[1]
+POWERSHELL = shutil.which('pwsh') or shutil.which('powershell')
+
+
+def quote(path):
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+@unittest.skipUnless(POWERSHELL, 'PowerShell is required')
+class WindowsReleaseProcessTests(unittest.TestCase):
+    def run_ps(self, script):
+        return subprocess.run([POWERSHELL, '-NoProfile', '-Command', script],
+                              capture_output=True, text=True, timeout=30)
+
+    def test_timing_records_success_and_failure_without_logging_environment(self):
+        for succeeds in (True, False):
+            with self.subTest(succeeds=succeeds), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                report, summary = root / 'timing.json', root / 'summary.md'
+                result = self.run_ps(
+                    f". {quote(ROOT / 'scripts/windows/build-timing.ps1')}; "
+                    f"$env:GITHUB_STEP_SUMMARY = {quote(summary)}; "
+                    "$env:SPARKLE_PRIVATE_KEY = 'never-record-this-fixture'; "
+                    f"$timing = New-BuildTiming -Path {quote(report)} -Version '0.6.0'; "
+                    "$ok = $false; try { Start-BuildStage $timing 'dependency-acquisition'; "
+                    "Start-Sleep -Milliseconds 20; Start-BuildStage $timing 'payload-signing'; "
+                    + ("$ok = $true; " if succeeds else "throw 'original build failure'; ")
+                    + "} finally { Complete-BuildTiming $timing $ok }")
+                self.assertEqual(result.returncode == 0, succeeds, result.stderr)
+                data = json.loads(report.read_text(encoding='utf-8-sig'))
+                self.assertEqual(data['status'], 'success' if succeeds else 'failed')
+                self.assertEqual(len(data['stages']), 2)
+                self.assertEqual(data['stages'][0]['status'], 'success')
+                self.assertGreaterEqual(data['stages'][0]['elapsed_seconds'], .02)
+                self.assertEqual(data['stages'][1]['status'], data['status'])
+                self.assertGreaterEqual(data['elapsed_seconds'], data['stages'][0]['elapsed_seconds'])
+                self.assertNotIn('never-record-this-fixture', report.read_text() + summary.read_text() + result.stdout)
+                if not succeeds:
+                    self.assertIn('original build failure', result.stderr)
+
+    def test_timing_write_failure_does_not_mask_original_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            blocker = Path(directory) / 'file'
+            blocker.write_text('not a directory')
+            result = self.run_ps(
+                "$ErrorActionPreference = 'Stop'; "
+                f". {quote(ROOT / 'scripts/windows/build-timing.ps1')}; "
+                f"$timing = New-BuildTiming -Path {quote(blocker / 'timing.json')} -Version '0.6.0'; "
+                "try { Start-BuildStage $timing 'compile'; throw 'original build failure' } "
+                "finally { Complete-BuildTiming $timing $false }")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('original build failure', result.stderr)
+            self.assertIn('Could not persist', result.stdout)
+
+    def test_selected_candidate_requires_matching_source_manifest_and_artifact_hashes(self):
+        cases = ('valid', 'receipt-source', 'manifest-source', 'wrong-installer', 'corrupt-archive',
+                 'wrong-size', 'unsigned', 'duplicate-artifact', 'wrong-architecture', 'version-mismatch')
+        for case in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                installer = root / 'LightTable-0.6.0-windows-x64-setup.exe'
+                installer.write_bytes(b'installer fixture')
+                archive = root / 'LightTable-0.6.0-windows-x64.zip'
+                manifest = dict(source_revision='b' * 40 if case == 'manifest-source' else 'a' * 40,
+                                version='0.5.0' if case == 'version-mismatch' else '0.6.0',
+                                architecture='arm64' if case == 'wrong-architecture' else 'x64',
+                                authenticode_signed=case != 'unsigned', store_candidate=True)
+                with zipfile.ZipFile(archive, 'w') as bundle:
+                    bundle.writestr('LightTable/build-manifest.json', json.dumps(manifest))
+                artifacts = [dict(file=p.name, sha256=hashlib.sha256(p.read_bytes()).hexdigest(),
+                                  bytes=p.stat().st_size) for p in (installer, archive)]
+                if case == 'wrong-size':
+                    artifacts[0]['bytes'] += 1
+                if case == 'duplicate-artifact':
+                    artifacts.append(artifacts[0])
+                receipt = dict(source_revision='b' * 40 if case == 'receipt-source' else 'a' * 40,
+                               version='0.6.0', artifacts=artifacts)
+                (root / 'store-candidate-receipt.json').write_text(json.dumps(receipt))
+                if case == 'corrupt-archive':
+                    archive.write_bytes(b'tampered')
+                digest = '0' * 64 if case == 'wrong-installer' else artifacts[0]['sha256']
+                result = self.run_ps(
+                    f"& {quote(ROOT / 'scripts/windows/verify-native-candidate.ps1')} "
+                    f"-Directory {quote(root)} -SourceRevision {'a' * 40} -InstallerSha256 {digest}")
+                self.assertEqual(result.returncode == 0, case == 'valid', result.stderr)
+                if case == 'valid':
+                    self.assertEqual(result.stdout.strip(), '0.6.0')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Release builds now retain immutable platform candidates for independent, resumable publication. Manual preparation and promotion verify exact source tags, binaries, production signatures, native receipts and public hashes before advancing a platform feed; existing assets cannot be replaced. A canonical release manifest and generated index handoff keep website metadata tied to published artifacts.

Windows client VM testing now uses an explicit guest transport, exact candidate/source verification and installed native acceptance. Build stages retain timing receipts. Linux public upgrade acceptance accepts explicit baseline/target versions. Mac builds retain final native/signing receipts, with explicit stable or manual-beta channels.

Validation: 50 focused release tests, four CI workflow contracts, executable Windows timing/candidate and VM tests, updater contracts and actionlint. Public Linux 0.5-to-0.6 native upgrade passed in run 34480473446. Windows 10/11 client proof remains a publication gate and is running separately; this change does not waive it. Full PR CI is required before merge. No recurring scheduler is introduced.
