### PR TITLE
Validate Windows 10 missing-runtime and Windows 11 preinstalled-runtime cases

### DIFF
--- a/.github/workflows/windows-client-vm.yml
+++ b/.github/workflows/windows-client-vm.yml
@@ -169,8 +169,10 @@ jobs:
             exit 1
           fi
           python3 - <<'PY'
-          import json
+          import json, sys
           from pathlib import Path
+          sys.path.insert(0, 'scripts/release')
+          from promote_candidate import verify_windows_runtime_case
           root = Path('.build/client-vm/evidence')
           host = json.loads((root / 'host.json').read_text(encoding='utf-8-sig'))
           print(json.dumps(host, indent=2))
@@ -180,8 +182,7 @@ jobs:
           print(json.dumps(result, indent=2))
           if not result.get('ok'):
               raise SystemExit('Windows client acceptance failed; see result.json')
-          if not host.get('webview2_absent_before_offline_install'):
-              raise SystemExit('Offline runtime-present checks passed, but WebView2-absent acceptance remains unproven')
+          verify_windows_runtime_case(host, '${{ matrix.windows }}')
           PY
 
       - name: Stop the disposable VM

--- a/docs/windows-client-acceptance.md
+++ b/docs/windows-client-acceptance.md
@@ -36,9 +36,9 @@ The Windows 11 host and installer receipts report success; the overall job corre
 
 ## Remaining release gates and test choices
 
-Windows remains blocked in the [canonical release manifest](../release/manifest.json). Two issues remain:
+The historical 0.6.0 candidate remains blocked in the [canonical release manifest](../release/manifest.json). Its original gates were:
 
-1. The currently declared gate requires Windows 11 offline installation with WebView2 genuinely absent. Keep that case open unless a deliberate release-policy decision accepts Windows 10 absence coverage plus normal Windows 11 runtime-present coverage. Do not relabel the failed run as passing.
+1. The historical gate required Windows 11 offline installation with WebView2 genuinely absent. The 0.6.1 publication coverage below supersedes that requirement with an explicit OS-specific matrix. The old failed run is not relabeled as passing.
 2. The older 0.6.0 ZIP lacks the clean-source and platform fields required by the newer preparation verifier. It cannot pass automated promotion as-is. A future versioned candidate should include the required embedded metadata and repeat acceptance; never change existing versioned binary bytes or invent a clean-source receipt.
 
 For further testing:
@@ -48,3 +48,19 @@ For further testing:
 - **Azure client VMs:** an alternative repeatable environment if appropriately licensed client images and an Azure subscription are available. [Microsoft's dev/test requirements](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/client-images) apply. A Windows Server VM cannot substitute for Windows 10/11 client evidence, and a different provider does not by itself remove the preinstalled runtime.
 
 The current manual workflow is `.github/workflows/windows-client-vm.yml`, with explicit candidate version/source/build/hash inputs, bounded jobs, real guest receipts and automatic VM cleanup. Do not restart the superseded pinned 0.5.1 workflow or its expired monitor. See [release/process.md](../release/process.md) for preparation and immutable publication.
+
+## Windows 0.6.1 publication coverage
+
+The September 10 publication request adopts the OS-specific matrix: Windows 10
+must establish genuine WebView2 absence before offline installation; Windows 11
+must preserve and observe its normal preinstalled runtime. Both cases retain
+network-disabled, unelevated installation, exact installer hashes, installed
+signature audits, native editing/export and reopen requirements. The guest records
+`webview2_test_case` plus actual runtime observations; the workflow and promotion
+verifier enforce the same case. Missing fields and the wrong runtime state fail.
+
+The historical failed 0.6.0 Windows 11 receipt is unchanged and cannot satisfy the
+new explicit case contract. Run fresh acceptance on the new signed 0.6.1 candidate,
+whose embedded metadata includes clean-source and platform identity. ARM x64
+emulation is rechecked separately and still does not imply native ARM64 or
+physical GPU/display validation.

--- a/release/process.md
+++ b/release/process.md
@@ -185,7 +185,10 @@ been published, conflicting metadata must not be overwritten to force a retry.
 Keep original build, preparation, signature verification, native acceptance,
 public download and live website verification distinct. Windows Server and
 Windows 11 ARM emulation do not establish native Windows 10/11 x64 offline
-acceptance. Store enrollment/review and direct download readiness are separate.
+acceptance. The client matrix requires Windows 10 with WebView2 genuinely absent
+before offline install and Windows 11 with its preinstalled runtime preserved;
+both require actual offline, unelevated native acceptance. See
+[the client test contract](../docs/windows-client-acceptance.md). Store enrollment/review and direct download readiness are separate.
 
 Windows build timing records separate compilation, runtime/native tests,
 installer construction/signing and compression. Optimize the measured expensive

--- a/scripts/release/promote_candidate.py
+++ b/scripts/release/promote_candidate.py
@@ -87,6 +87,20 @@ def verify_native_report(report, manifest, platform):
                 'Native Linux quit/reopen persistence is unproven')
 
 
+def verify_windows_runtime_case(host, windows):
+    """Require explicit, observed prerequisite coverage for each client OS."""
+    require(windows in ('10', '11'), 'Unsupported Windows client runtime case')
+    if windows == '10':
+        require(host.get('webview2_test_case') == 'absent'
+                and host.get('webview2_absent_before_offline_install') is True,
+                'Windows 10 offline WebView2-absent coverage is unproven')
+    else:
+        require(host.get('webview2_test_case') == 'preinstalled'
+                and host.get('webview2_initially_present') is True
+                and host.get('webview2_absent_before_offline_install') is False,
+                'Windows 11 preinstalled WebView2 coverage is unproven')
+
+
 def verify_windows_client(directory, windows, manifest, installer_hash):
     host = release.read_json(directory / 'host.json')
     result = release.read_json(directory / 'result.json')
@@ -95,8 +109,8 @@ def verify_windows_client(directory, windows, manifest, installer_hash):
             and host.get('architecture') == 'AMD64'
             and ((windows == '11' and build >= 22000) or (windows == '10' and 19041 <= build < 22000)),
             f'Windows {windows} native x64 client identity is unproven')
-    require(host.get('webview2_absent_before_offline_install') is True
-            and host.get('network_adapters_disabled') is True
+    verify_windows_runtime_case(host, windows)
+    require(host.get('network_adapters_disabled') is True
             and host.get('installer_signature_before_disconnect') == 'Valid'
             and result.get('ok') is True and result.get('offline') is True
             and result.get('account_is_elevated') is False

--- a/scripts/windows/client-vm/bootstrap.ps1
+++ b/scripts/windows/client-vm/bootstrap.ps1
@@ -27,8 +27,11 @@ try {
     if (($Config.windows -eq '11') -ne ([int]$OS.BuildNumber -ge 22000)) { throw 'Windows client version mismatch' }
     . (Join-Path $Root 'scripts/ensure-webview2.ps1')
     $HostReport.webview2_initially_present = Test-WebView2Runtime
+    # Windows 10 covers bootstrap with the runtime absent; Windows 11 keeps its
+    # normal preinstalled runtime. Record the case and the actual observations.
+    $HostReport.webview2_test_case = if ($Config.windows -eq '10') { 'absent' } else { 'preinstalled' }
     # Use the vendor uninstaller only. Never fake absence by deleting registry keys.
-    if ($HostReport.webview2_initially_present) {
+    if ($Config.windows -eq '10' -and $HostReport.webview2_initially_present) {
         $Setups = @(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft\EdgeWebView\Application\*\Installer\setup.exe" -ErrorAction SilentlyContinue)
         foreach ($Setup in $Setups) {
             $Process = Start-Process $Setup.FullName -ArgumentList '--uninstall --msedgewebview --system-level --force-uninstall' -PassThru

--- a/tests/test_release_promotion.py
+++ b/tests/test_release_promotion.py
@@ -36,7 +36,8 @@ class PromotionProofTests(unittest.TestCase):
 
     def test_windows_requires_actual_offline_native_client_receipts(self):
         fixture = {'host.json': {'ok': True, 'product_type': 1, 'architecture': 'AMD64', 'build': '26200',
-                   'webview2_absent_before_offline_install': True, 'network_adapters_disabled': True,
+                   'webview2_absent_before_offline_install': False, 'network_adapters_disabled': True,
+                   'webview2_initially_present': True, 'webview2_test_case': 'preinstalled',
                    'installer_signature_before_disconnect': 'Valid'},
                    'result.json': {'ok': True, 'offline': True, 'account_is_elevated': False,
                                    'installer_sha256': 'b' * 64},
@@ -45,7 +46,9 @@ class PromotionProofTests(unittest.TestCase):
                    'native/report.json': self.native()}
         mutations = [None,
             ('host.json', 'product_type', 3), ('host.json', 'architecture', 'ARM64'),
-            ('host.json', 'webview2_absent_before_offline_install', False),
+            ('host.json', 'webview2_absent_before_offline_install', True),
+            ('host.json', 'webview2_initially_present', False),
+            ('host.json', 'webview2_test_case', 'absent'),
             ('host.json', 'network_adapters_disabled', False), ('host.json', 'build', '19045'),
             ('result.json', 'account_is_elevated', True), ('result.json', 'offline', False),
             ('result.json', 'installer_sha256', 'c' * 64), ('native/report.json', 'ok', False),
@@ -66,6 +69,24 @@ class PromotionProofTests(unittest.TestCase):
                         promote.verify_windows_client(directory, '11', self.manifest(), 'b' * 64)
                 else:
                     promote.verify_windows_client(directory, '11', self.manifest(), 'b' * 64)
+
+    def test_runtime_cases_require_actual_observations_and_explicit_case(self):
+        cases = {
+            '10': {'webview2_test_case': 'absent', 'webview2_absent_before_offline_install': True},
+            '11': {'webview2_test_case': 'preinstalled', 'webview2_initially_present': True,
+                   'webview2_absent_before_offline_install': False},
+        }
+        for windows, host in cases.items():
+            promote.verify_windows_runtime_case(host, windows)
+            for key in host:
+                missing = {k: v for k, v in host.items() if k != key}
+                with self.subTest(windows=windows, missing=key), self.assertRaises(ValueError):
+                    promote.verify_windows_runtime_case(missing, windows)
+            wrong = dict(host, webview2_absent_before_offline_install=windows != '10')
+            with self.assertRaises(ValueError):
+                promote.verify_windows_runtime_case(wrong, windows)
+        with self.assertRaises(ValueError):
+            promote.verify_windows_runtime_case(cases['11'], '12')
 
     def test_native_source_and_restart_are_required(self):
         for key, value in [('source_revision', 'b' * 40), ('source_dirty', True), ('architecture', 'arm64')]:


### PR DESCRIPTION
Windows 11 includes WebView2, so requiring its removal blocked publication even after offline installation and native editing passed. Define explicit OS-specific acceptance: Windows 10 must prove the runtime is absent before offline install; Windows 11 must prove its preinstalled runtime is present. The guest records the chosen case and actual observations; both the VM workflow and promotion verifier enforce those fields.

Both platforms continue to require the exact signed installer, network-disabled unelevated installation, installed signature audit and native edit/export/reopen. The prior failed receipt is unchanged and lacks the new case marker, so it cannot silently pass. The signed 0.6.1 application source is separately pinned at v0.6.1; this changes test/promotion tooling only.

Validation: 39 release and promotion tests passed, including missing or contradictory runtime observations and tampered native evidence. Three Windows-only timing tests are left to Windows CI; native client runs will test the fresh signed candidate before publication.
