### PR TITLE
Record the verified public Windows 0.6.1 release

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -5,8 +5,8 @@
 Public releases are published at
 [reville/lighttable-digital-darkroom](https://github.com/reville/lighttable-digital-darkroom/releases).
 The Windows x64 artifacts are `LightTable-VERSION-windows-x64-setup.exe` and
-`LightTable-VERSION-windows-x64.zip`. Availability depends on a successful
-release build; installer manifests do not create downloadable binaries.
+`LightTable-VERSION-windows-x64.zip`. See the [Windows installation guide](https://lighttable.app/windows.html)
+and [exact-binary acceptance record](docs/windows-client-acceptance.md) for the current release.
 
 The installer runs without administrator rights and defaults to
 `%LOCALAPPDATA%\Programs\LightTable`. It adds a dedicated `bin` directory to
@@ -16,14 +16,17 @@ checkout, Python installation, or Node.js. The dedicated directory prevents
 Windows from resolving the desktop `LightTable.exe` before the CLI.
 
 Before copying or replacing LightTable, setup checks for the Microsoft Edge
-WebView2 Runtime in both the per-machine and per-user registry locations. If
-it is missing, setup downloads Microsoft's Evergreen bootstrapper, requires a
-valid Microsoft Authenticode signature, and installs the Runtime without
-elevation. Downloads and installation have time limits; failure stops setup
-before changing an existing LightTable installation. Internet access is only
-needed for this prerequisite when the Runtime is missing. For offline setup,
-install Microsoft's [Evergreen Standalone Installer](https://developer.microsoft.com/microsoft-edge/webview2)
-first. LightTable uninstall leaves this shared Microsoft runtime installed.
+WebView2 Runtime in both the per-machine and per-user registry locations. The
+signed 0.6.1 installer bundles Microsoft's verified standalone runtime and can
+install it without network access when missing. Windows 10 acceptance covers
+that missing-runtime case; Windows 11 acceptance preserves its preinstalled
+runtime. Setup runs without elevation and leaves this shared Microsoft runtime
+installed when LightTable is removed.
+
+Developer installers built without the offline prerequisite use Microsoft's
+Evergreen bootstrapper when the runtime is missing. That fallback requires
+internet access and a valid Microsoft Authenticode signature; a bounded download
+or installation failure stops setup before changing the existing app.
 
 For unattended installation:
 
@@ -33,7 +36,7 @@ Start-Process -Wait .\LightTable-VERSION-windows-x64-setup.exe -ArgumentList '/S
 
 An optional `/D=C:\path with spaces\LightTable` must be the last installer
 argument and its value must not be quoted separately. The per-user uninstall
-registry key is `LightTable`, publisher is `Nicholas Reville`, and the
+registry key is `LightTable`, publisher metadata is `Chonkers LLC`, and the
 `QuietUninstallString` supports `/S` for WinGet and other package managers.
 Uninstall removes shipped files, shortcuts, and the CLI's PATH entry. Catalogs,
 preferences, caches, photos, and unrelated files in the install directory remain.
@@ -210,7 +213,8 @@ Configuring this workflow does not itself obtain a certificate or prove a
 successful signed release.
 
 To produce a signed candidate without publishing a release, dispatch
-`windows-build.yml` on `main` with `version=0.5.0` and `require_signing=true`.
+`windows-build.yml` on a pinned version tag with the matching new numeric
+`version` and `require_signing=true`.
 Inspect the signature report and native acceptance evidence before publishing.
 
 Windows support is an additional host around the shared render core, not a
@@ -319,8 +323,8 @@ require another application rewrite or a forked Windows pipeline.
    exported files, not only the remote desktop stream.
 
 The [Windows client acceptance record](docs/windows-client-acceptance.md) records
-the completed 0.6.0 Windows 10/11 and Windows 11 ARM emulation checks, exact
-candidate identity, and remaining publication gates.
+the current Windows 10/11 and Windows 11 ARM emulation checks, exact
+release identity, and physical hardware coverage limits.
 
 ## First Windows GPU session
 
@@ -385,19 +389,18 @@ Candidate builds:
   with the Chonkers LLC Partner Center account before submission.
 
 Partner Center installation arguments: `/S` (case-sensitive). Silent uninstall
-uses `/S`. The installer is per-user and currently leaves its own update service
-in control, as with other EXE installations; it is not an MSIX package.
+uses `/S`. The installer is per-user and currently uses the direct WinSparkle updater;
+it is not an MSIX package.
 
 ### Evidence still required before initial submission
 
-The existing successful Windows release run predates this candidate mode. Run
-it on Windows and retain the installed-payload signature report, installer
-hash, build manifest, native startup/edit/export/restart evidence, and install,
-repair, uninstall results. Separately exercise installation on clean Windows
-10/11 x64 with WebView2 absent and network disabled, then launch and export.
-An ordinary CI image with WebView2 already present cannot prove this case.
-Check that `/S` shows no setup UI and no app is launched by setup. Confirm all
-supported OS/device claims and that uninstall preserves photos and catalogs.
+The [current acceptance record](docs/windows-client-acceptance.md) binds the
+selected installer to its source, hash, signatures and native edit/export/restart
+checks. Windows 10 covers offline installation with WebView2 absent; Windows 11
+covers offline installation with its preinstalled runtime. Keep those cases
+explicit when selecting future candidates. Recheck Store-specific requirements,
+listing screenshots, update ownership, and declarations against the final
+submitted installer; direct release validation is not Store certification.
 
 Host the final signed EXE at a permanent **versioned HTTPS URL** only after
 release approval. Record its SHA256 and never replace bytes at that URL.
@@ -409,7 +412,7 @@ signatures or the standard Windows workflow passed.
 Sources: [Store EXE package requirements](https://learn.microsoft.com/windows/apps/publish/publish-your-app/msi/app-package-requirements)
 and [Microsoft's offline WebView2 deployment](https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution#offline-deployment).
 
-### Dispatch the initial candidate after the preparation branch is merged
+### Build a future candidate
 
 The checked-in `packaging/webview2-store-input.json` pins the acquired Microsoft
 x64 standalone download (258,614,480 bytes; SHA256
@@ -421,11 +424,12 @@ never replace the checksum automatically.
 
 ```sh
 gh workflow run windows-build.yml --repo reville/lighttable-digital-darkroom \
-  --ref main -f version=0.5.0 -F store_candidate=true -F require_signing=true
+  --ref VERSION_TAG -f version=VERSION -F store_candidate=true -F require_signing=true
 ```
 
-This command is an instruction for a future authorized run, not evidence that a
-run occurred. Store mode implies required signing even when the separate signing
+Replace `VERSION_TAG` and `VERSION` with a new immutable source tag and its
+numeric version. Do not rebuild or overwrite an already published version.
+Store mode implies required signing even when the separate signing
 input is false, uses the existing `windows-release` environment, accepts only
 main/version-tag dispatches, and cannot be combined with native-recheck mode.
 The direct-download workflow defaults and artifact name remain unchanged.
@@ -438,8 +442,7 @@ edit/export/restart still gates the job and uploads separate
 `Windows-native-acceptance` evidence. The receipt explicitly leaves clean-machine
 offline acceptance unconfirmed until that independent Windows test is done.
 
-For the selected initial release `0.5.0`, the proposed public EXE URL is
-`https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.5.0/LightTable-0.5.0-windows-x64-setup.exe`.
-This is a proposed location, not a live download. Publish only the exact verified
-candidate bytes after all release and Store gates pass; do not replace bytes at
-that URL after submission.
+Select the current permanent installer URL and checksum from the
+[canonical release manifest](release/manifest.json), after verifying that the
+Windows entry is published. Store account approval, listing preparation and
+certification remain separate gates. Never replace bytes at a submitted URL.

--- a/docs/windows-client-acceptance.md
+++ b/docs/windows-client-acceptance.md
@@ -1,66 +1,46 @@
 # Windows client acceptance
 
-Verified September 10, 2026. The Windows 11 ARM **x64-emulation test work is complete** for the signed 0.6.0 candidate. The ARM workflow, installer checks, native editing checks and updated x64 VM harness are already integrated through [PR #122](https://github.com/reville/lighttable-digital-darkroom/pull/122). Draft [PR #114](https://github.com/reville/lighttable-digital-darkroom/pull/114) is superseded; its old failed 0.5.1 VM run is not the current acceptance result.
+Verified September 10, 2026. **Windows 0.6.1 passed native Windows 10/11 x64 acceptance and Windows 11 ARM x64-emulation acceptance.** The signed installer and portable ZIP are published on [v0.6.1](https://github.com/reville/lighttable-digital-darkroom/releases/tag/v0.6.1); the [installation guide](https://lighttable.app/windows.html) explains processor selection and signature/checksum verification.
 
-## Exact candidate
+## Exact release
 
-- Application source: `0ae5e9aaf90b3554ad1d027d5b6b10667cd61ae2`.
-- Signed Windows build: [34434174967](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34434174967).
-- Installer: `LightTable-0.6.0-windows-x64-setup.exe`.
-- Installer SHA-256: `e49f246e848069598849e4919cbf2be28015115524e33dbb156a03e7bbfc4aea`.
-- Portable ZIP SHA-256: `a4cbba3bfe8ffc367acb5bf9da334462b504b32fe1f47b2f427dcd59f14bbf5c`.
+- Application source and immutable `v0.6.1` tag: `2382de7ccb6a2e81c304a6c9116bf578b95aee69`.
+- Signed build: [34506394820](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34506394820).
+- Installer: `LightTable-0.6.1-windows-x64-setup.exe`, 439,153,216 bytes.
+- Installer SHA-256: `d5a4a0e3ba069b93cb9f0157814a50a5eece32478b3aa69ed1a935e7b07bb951`.
+- Portable ZIP: 292,263,647 bytes; SHA-256 `4916b83ed786752d84666c5c4c44cebdab23a43c75665e775eccb44eedef2356`.
+- Embedded source, version, Windows/x64 identity and `source_dirty: false` were independently verified. The original build's artifact sizes/hashes and all 420 packaged native-file hashes match the downloaded bytes. Windows reports 421 valid installed PE signatures, including the uninstaller. The certificate identifies Nicholas Reville; installer metadata is Chonkers LLC.
 
-No binary was rebuilt or published for this closeout. This is an x64 application; no native Windows ARM64 package exists.
+The package source is separate from the tested acceptance/promotion tooling revision `b4bd228708f663c8499534122ea025afc8baaf52` ([PR #131](https://github.com/reville/lighttable-digital-darkroom/pull/131)). Native tests select the original build and require its exact installer hash; no rebuild is substituted.
 
-## Windows 11 ARM: passed
+## Passed client matrix
 
-[Run 34436651354](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34436651354) passed on Windows 11 Enterprise ARM64 build 26200, hosted image `20260906.161.1`, using tester revision `fe9bebbd343d39d607c898d876c28cce17207961`.
+| Target | Runtime case | Offline, unelevated install | Native edit, RGB16 export and reopen |
+| --- | --- | --- | --- |
+| Windows 10 x64, build 19045 | WebView2 genuinely absent | Passed | Passed |
+| Windows 11 x64, build 26200 | Normal preinstalled WebView2 preserved | Passed | Passed |
+| Windows 11 ARM64, build 26200 | Hosted runtime; x64 application under emulation | Install/repair/removal passed; offline absence not claimed | Passed |
 
-The signed installer passed installation, same-version repair, CLI registration and data-preserving removal. All 421 installed PE signatures were valid. The extracted x64 application passed native rendering, saved exposure/rating, server restart and RGB16 TIFF export under Windows x64 emulation. Its downloaded TIFF independently matched SHA-256 `dfadcf6a657eadb64bd7060652b3d4af2f39e62bc0a43104ded75d1523b333cf`.
+[Windows 10/11 run 34510352623](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34510352623) passed both jobs in disposable native AMD64 client VMs. Both guest receipts confirm networking disabled, installation without elevation, the exact installer digest, valid installed signatures, and successful native rendering/edit/export/restart. Windows 10 reports the `absent` case and actual runtime absence; Windows 11 reports `preinstalled`, initial presence, and no fabricated absence. Microsoft [documents WebView2 as preinstalled on Windows 11](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution).
 
-The hosted image does not prove a native ARM64 build, offline installation with WebView2 absent, physical Snapdragon GPU/display behavior, or an old-to-new updater journey. The workflow explicitly records those boundaries. Use `.github/workflows/windows-native.yml` with `runner=windows-11-arm` for future candidates, keeping tester revision separate from package source and binding the installer digest to the original build.
+[ARM run 34510354937](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34510354937) passed on Windows 11 Enterprise ARM64, image `20260906.161.1`. The same signed installer passed installation, same-version repair, CLI registration and data-preserving removal. All 421 installed PE signatures were valid. The extracted x64 app passed rendering, saved exposure/rating, server restart and RGB16 TIFF export under Windows x64 emulation.
 
-## Windows 10/11 x64: newer results
+All downloaded native TIFF exports independently match SHA-256 `dfadcf6a657eadb64bd7060652b3d4af2f39e62bc0a43104ded75d1523b333cf`. The reports describe a 128 × 1024 RGB uint16 export with an embedded ICC profile.
 
-[Run 34481336232](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34481336232) tested that same installer in disposable native AMD64 client VMs with networking disabled and installation running without elevation.
+## Publication and updates
 
-| Check | Windows 10 build 19045 | Windows 11 build 26200 |
-| --- | --- | --- |
-| Offline install, repair, CLI and removal | Passed | Passed |
-| Installed executable signatures | 421 valid | 421 valid |
-| Native editing, TIFF export and reopen | Passed | Passed |
-| WebView2 absent before offline install | Passed | Not established; runtime preinstalled |
-| Overall job | Passed | Failed the runtime-absence gate |
+[Preparation 34510377102](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34510377102) retained the original binaries and generated versioned checksums and installer recipes. [Promotion 34513680232](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34513680232) independently verifies the public download bytes and the appcast Ed25519 signature against the key embedded in the actual executable before advancing the Windows feed. The [canonical release manifest](../release/manifest.json) records the published platform and receipts. macOS and Linux keep their own versions and artifacts.
 
-The Windows 11 host and installer receipts report success; the overall job correctly failed the additional prerequisite-absence condition. Microsoft [documents WebView2 as preinstalled on Windows 11](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution). The vendor uninstaller did not establish absence on this image. No detection keys were removed to imitate it. Certificate trust was checked online before disconnecting; this is not cold-cache certificate verification. The VMs use a virtual display adapter, so they do not establish physical GPU or color/display quality.
+Direct installer installations use the signed Windows feed on the `desktop-updates` release; portable ZIP installations update manually. This is the first public Windows binary release, so an old-to-new public Windows updater journey is not claimed. Prepared Scoop, WinGet and Chocolatey recipes are not published package-manager listings. Microsoft Store certification is separate.
 
-## Remaining release gates and test choices
+## Coverage limits and next hardware checks
 
-The historical 0.6.0 candidate remains blocked in the [canonical release manifest](../release/manifest.json). Its original gates were:
+Windows support remains experimental. These VMs use a virtual display adapter; they do not establish physical GPU, display scaling, color management, performance or large-RAW behavior. Certificate trust was checked online before disconnecting, so this is not cold-cache certificate verification. ARM testing does not establish a native ARM64 package or an ARM missing-runtime offline case.
 
-1. The historical gate required Windows 11 offline installation with WebView2 genuinely absent. The 0.6.1 publication coverage below supersedes that requirement with an explicit OS-specific matrix. The old failed run is not relabeled as passing.
-2. The older 0.6.0 ZIP lacks the clean-source and platform fields required by the newer preparation verifier. It cannot pass automated promotion as-is. A future versioned candidate should include the required embedded metadata and repeat acceptance; never change existing versioned binary bytes or invent a clean-source receipt.
+The next useful checks are physical Intel/AMD Windows PCs and a Snapdragon Windows 11 device, including real GPU drivers, color/display behavior, representative large RAWs and update/recovery. The existing disposable VM workflow remains available for repeatable installer regression tests. Alternative appropriately licensed client VMs can provide additional OS-image coverage; Windows Server results cannot replace Windows client evidence.
 
-For further testing:
+## Superseded candidates
 
-- **Existing disposable VMs:** retain the successful Windows 10 case, report Windows 11 runtime-present compatibility separately, and find a supported image/setup where prerequisite absence is real if that case remains mandatory. No new cloud account is needed for this route.
-- **Physical Windows PCs:** test an Intel/AMD Windows 10 and Windows 11 machine, including actual GPU drivers, display scaling, color management, large RAWs and update/recovery behavior. This fills hardware gaps that the VMs cannot cover. Windows 11 may still include WebView2, so hardware alone does not solve the absence case.
-- **Azure client VMs:** an alternative repeatable environment if appropriately licensed client images and an Azure subscription are available. [Microsoft's dev/test requirements](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/client-images) apply. A Windows Server VM cannot substitute for Windows 10/11 client evidence, and a different provider does not by itself remove the preinstalled runtime.
+The 0.6.0 staging draft remains historical. Its [Windows 11 ARM run 34436651354](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34436651354) passed, and [client run 34481336232](https://github.com/reville/lighttable-digital-darkroom/actions/runs/34481336232) passed Windows 10. The old Windows 11 job failed a runtime-absence gate despite successful runtime-present installation/native checks; it is not relabeled as passing. The old ZIP also lacks the newer required clean-source/platform metadata. Fresh 0.6.1 bytes and receipts supersede those publication blockers without modifying the old artifacts.
 
-The current manual workflow is `.github/workflows/windows-client-vm.yml`, with explicit candidate version/source/build/hash inputs, bounded jobs, real guest receipts and automatic VM cleanup. Do not restart the superseded pinned 0.5.1 workflow or its expired monitor. See [release/process.md](../release/process.md) for preparation and immutable publication.
-
-## Windows 0.6.1 publication coverage
-
-The September 10 publication request adopts the OS-specific matrix: Windows 10
-must establish genuine WebView2 absence before offline installation; Windows 11
-must preserve and observe its normal preinstalled runtime. Both cases retain
-network-disabled, unelevated installation, exact installer hashes, installed
-signature audits, native editing/export and reopen requirements. The guest records
-`webview2_test_case` plus actual runtime observations; the workflow and promotion
-verifier enforce the same case. Missing fields and the wrong runtime state fail.
-
-The historical failed 0.6.0 Windows 11 receipt is unchanged and cannot satisfy the
-new explicit case contract. Run fresh acceptance on the new signed 0.6.1 candidate,
-whose embedded metadata includes clean-source and platform identity. ARM x64
-emulation is rechecked separately and still does not imply native ARM64 or
-physical GPU/display validation.
+Draft [PR #114](https://github.com/reville/lighttable-digital-darkroom/pull/114) is closed as superseded; its ARM workflow and updated VM harness were already integrated through [PR #122](https://github.com/reville/lighttable-digital-darkroom/pull/122). Use the current manual workflows and [release process](../release/process.md) for future candidates, not the old pinned 0.5.1 harness or expired monitor.

--- a/release/README.md
+++ b/release/README.md
@@ -13,8 +13,10 @@ x86_64. Each platform needs its own native release validation.
 
 See [the machine-readable release manifest](manifest.json) for exact current
 platform versions, artifacts, signing and blockers. Linux portable 0.6 and
-macOS 0.6 beta are public; Windows 0.6 remains a signed candidate pending native
-Windows 10/11 x64 clean/offline acceptance. A Mac beta is manual-update only.
+macOS 0.6 beta are public. Signed Windows 0.6.1 is public after native Windows
+10/11 x64 offline acceptance and Windows 11 ARM x64-emulation checks passed.
+See [Windows acceptance and coverage limits](../docs/windows-client-acceptance.md).
+A Mac beta is manual-update only.
 Store enrollment and review remain separate from direct distribution.
 
 ## Repeatable release process

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -1,105 +1,160 @@
 {
-  "schema_version": 1,
-  "version": "0.6.0",
-  "source_revision": "0ae5e9aaf90b3554ad1d027d5b6b10667cd61ae2",
-  "repository": "reville/lighttable-digital-darkroom",
   "platforms": {
     "linux-x86_64": {
-      "version": "0.6.0",
+      "artifacts": [
+        {
+          "bytes": 363504544,
+          "name": "LightTable-0.6.0-linux-x86_64.tar.gz",
+          "sha256": "4b116ac098df209a3c755ef751e19ed226da5621d9238f9c2bb3dbe94fe020f5",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz"
+        },
+        {
+          "bytes": 103,
+          "name": "LightTable-0.6.0-linux-x86_64.tar.gz.sha256",
+          "sha256": "9ee243d24344a8448feaa916fc7c1a0761acd113e171d58b5ff247118c0b6f33",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz.sha256"
+        },
+        {
+          "bytes": 343675816,
+          "name": "lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst",
+          "sha256": "0a2f964ec1be558cd92537484e4d0f8c0789d4b79f5af967f7de58865e3c8565",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst"
+        },
+        {
+          "bytes": 108,
+          "name": "lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst.sha256",
+          "sha256": "2690a6412aba7ce048f074d3b166ea64f6bb8eb2035e202211de2663d0d3bd46",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst.sha256"
+        }
+      ],
       "channel": "stable",
+      "gates": [],
       "minimum_os": "Ubuntu 24.04+",
-      "update_owner": "app",
-      "state": "published",
+      "published_at": "2026-09-10T03:51:06Z",
       "signing": "ed25519",
+      "source_revision": "0ae5e9aaf90b3554ad1d027d5b6b10667cd61ae2",
+      "state": "published",
+      "tag": "v0.6.0",
+      "update_owner": "app",
       "validation": {
-        "status": "passed",
         "receipts": [
           "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34435011848"
-        ]
+        ],
+        "status": "passed"
       },
-      "gates": [],
-      "artifacts": [
-        {
-          "name": "LightTable-0.6.0-linux-x86_64.tar.gz",
-          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz",
-          "bytes": 363504544,
-          "sha256": "4b116ac098df209a3c755ef751e19ed226da5621d9238f9c2bb3dbe94fe020f5"
-        },
-        {
-          "name": "LightTable-0.6.0-linux-x86_64.tar.gz.sha256",
-          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/LightTable-0.6.0-linux-x86_64.tar.gz.sha256",
-          "bytes": 103,
-          "sha256": "9ee243d24344a8448feaa916fc7c1a0761acd113e171d58b5ff247118c0b6f33"
-        },
-        {
-          "name": "lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst",
-          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst",
-          "bytes": 343675816,
-          "sha256": "0a2f964ec1be558cd92537484e4d0f8c0789d4b79f5af967f7de58865e3c8565"
-        },
-        {
-          "name": "lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst.sha256",
-          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.0/lighttable-bin-0.6.0-1-x86_64.pkg.tar.zst.sha256",
-          "bytes": 108,
-          "sha256": "2690a6412aba7ce048f074d3b166ea64f6bb8eb2035e202211de2663d0d3bd46"
-        }
-      ],
-      "published_at": "2026-09-10T03:51:06Z",
-      "tag": "v0.6.0"
+      "version": "0.6.0"
     },
     "macos-arm64": {
-      "version": "0.6.0-beta.1",
-      "channel": "beta",
-      "minimum_os": "macOS 14+",
-      "update_owner": "manual",
-      "state": "published",
-      "signing": "ad-hoc",
-      "validation": {
-        "status": "passed",
-        "receipts": [
-          "https://github.com/reville/lighttable-digital-darkroom/releases/tag/macos-v0.6.0-beta.1"
-        ]
-      },
-      "gates": [],
       "artifacts": [
         {
-          "name": "LightTable-0.6.0-beta.1-macos-arm64.dmg",
-          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/macos-v0.6.0-beta.1/LightTable-0.6.0-beta.1-macos-arm64.dmg",
           "bytes": 349428501,
-          "sha256": "cd1beafccfe2f455e91a5377d6ba4ca61394094bf34acb2521dda9627eb31b20"
+          "name": "LightTable-0.6.0-beta.1-macos-arm64.dmg",
+          "sha256": "cd1beafccfe2f455e91a5377d6ba4ca61394094bf34acb2521dda9627eb31b20",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/macos-v0.6.0-beta.1/LightTable-0.6.0-beta.1-macos-arm64.dmg"
         },
         {
-          "name": "LightTable-0.6.0-beta.1-macos-arm64.dmg.sha256",
-          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/macos-v0.6.0-beta.1/LightTable-0.6.0-beta.1-macos-arm64.dmg.sha256",
           "bytes": 106,
-          "sha256": "e33333701e501afd902b3f08e235eb5a69e69e34f37b5e0487826a8aca525dbd"
+          "name": "LightTable-0.6.0-beta.1-macos-arm64.dmg.sha256",
+          "sha256": "e33333701e501afd902b3f08e235eb5a69e69e34f37b5e0487826a8aca525dbd",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/macos-v0.6.0-beta.1/LightTable-0.6.0-beta.1-macos-arm64.dmg.sha256"
         }
       ],
-      "published_at": "2026-09-10T03:46:23Z",
-      "tag": "macos-v0.6.0-beta.1",
       "build_source_revision": "438bb12693a1d117cc3c5cbce56ec05252b243ee",
-      "source_tree": "a8b776446890dd88ca3fc44aab0a1cad7544633e"
+      "channel": "beta",
+      "gates": [],
+      "minimum_os": "macOS 14+",
+      "published_at": "2026-09-10T03:46:23Z",
+      "signing": "ad-hoc",
+      "source_revision": "0ae5e9aaf90b3554ad1d027d5b6b10667cd61ae2",
+      "source_tree": "a8b776446890dd88ca3fc44aab0a1cad7544633e",
+      "state": "published",
+      "tag": "macos-v0.6.0-beta.1",
+      "update_owner": "manual",
+      "validation": {
+        "receipts": [
+          "https://github.com/reville/lighttable-digital-darkroom/releases/tag/macos-v0.6.0-beta.1"
+        ],
+        "status": "passed"
+      },
+      "version": "0.6.0-beta.1"
     },
     "windows-x64": {
-      "version": "0.6.0",
-      "channel": "stable",
-      "minimum_os": "Windows 10/11 x64",
-      "update_owner": "manual",
-      "state": "blocked",
-      "signing": "authenticode",
-      "validation": {
-        "status": "pending",
-        "receipts": [
-          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34434174967",
-          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34436651354",
-          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34481336232"
-        ]
-      },
-      "gates": [
-        "Windows 11 offline installation with WebView2 absent remains unproved",
-        "Candidate bundle lacks required clean-source and platform metadata"
+      "artifacts": [
+        {
+          "bytes": 778,
+          "name": "LightTable-0.6.1-windows-x64-SHA256SUMS",
+          "sha256": "5f1a1b3b5b73db1ad3b79769af19bd2227b132715e144a43ce6da0269c423bb5",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-SHA256SUMS"
+        },
+        {
+          "bytes": 2283,
+          "name": "LightTable-0.6.1-windows-x64-installers.tar.gz",
+          "sha256": "8232be59ba44fd2ae27ce12d576d16cb0fa869faf7a2225b6cfb9c9cb38e64c6",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-installers.tar.gz"
+        },
+        {
+          "bytes": 439153216,
+          "name": "LightTable-0.6.1-windows-x64-setup.exe",
+          "sha256": "d5a4a0e3ba069b93cb9f0157814a50a5eece32478b3aa69ed1a935e7b07bb951",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-setup.exe"
+        },
+        {
+          "bytes": 1805,
+          "name": "LightTable-0.6.1-windows-x64-store-candidate-receipt.json",
+          "sha256": "cfc98f6796bd8481eca2bc18fe1bff24b9d947e2726821267edfbebbbf763299",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-store-candidate-receipt.json"
+        },
+        {
+          "bytes": 2887,
+          "name": "LightTable-0.6.1-windows-x64-windows-signatures.json",
+          "sha256": "300e9375a9412b9e0ad47de45d87ae672e5cb4ef9b00c7ea99d74e8f645a8ee7",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-windows-signatures.json"
+        },
+        {
+          "bytes": 126268,
+          "name": "LightTable-0.6.1-windows-x64-windows-store-pe-signatures.json",
+          "sha256": "18a6213aa42ef7bea1614970d1d3af1bb67050363081f7cab5b0b2d620d98862",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64-windows-store-pe-signatures.json"
+        },
+        {
+          "bytes": 292263647,
+          "name": "LightTable-0.6.1-windows-x64.zip",
+          "sha256": "4916b83ed786752d84666c5c4c44cebdab23a43c75665e775eccb44eedef2356",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/LightTable-0.6.1-windows-x64.zip"
+        },
+        {
+          "bytes": 855,
+          "name": "appcast-windows-x64.xml",
+          "sha256": "b87eb2703ea63d014113c89e74138e1f05dae8b6d48bd5329c238f24b6d4c893",
+          "url": "https://github.com/reville/lighttable-digital-darkroom/releases/download/v0.6.1/appcast-windows-x64.xml"
+        }
       ],
-      "artifacts": []
+      "build_run_id": "34506394820",
+      "build_workflow_revision": "2382de7ccb6a2e81c304a6c9116bf578b95aee69",
+      "channel": "stable",
+      "gates": [],
+      "minimum_os": "Windows 10/11 x64",
+      "native_run_id": "34510352623",
+      "published_at": "2026-09-10T18:21:13Z",
+      "signing": "authenticode",
+      "source_revision": "2382de7ccb6a2e81c304a6c9116bf578b95aee69",
+      "state": "published",
+      "tag": "v0.6.1",
+      "update_owner": "app",
+      "validation": {
+        "receipts": [
+          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34506394820",
+          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34510352623",
+          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34510354937",
+          "https://github.com/reville/lighttable-digital-darkroom/actions/runs/34513680232"
+        ],
+        "status": "passed"
+      },
+      "version": "0.6.1"
     }
-  }
+  },
+  "repository": "reville/lighttable-digital-darkroom",
+  "schema_version": 1,
+  "source_revision": "2382de7ccb6a2e81c304a6c9116bf578b95aee69",
+  "version": "0.6.1"
 }

--- a/tests/test_release_index.py
+++ b/tests/test_release_index.py
@@ -14,6 +14,10 @@ class ReleaseIndexTests(unittest.TestCase):
         self.index = json.loads((ROOT / 'release/manifest.json').read_text())
         incoming = copy.deepcopy(self.index)
         incoming['platforms'] = {'linux-x86_64': incoming['platforms']['linux-x86_64']}
+        linux = incoming['platforms']['linux-x86_64']
+        incoming['version'] = linux['version']
+        incoming['source_revision'] = linux.get('source_revision', self.index['source_revision'])
+        incoming['tag'] = linux.get('tag', 'v' + linux['version'])
         incoming['platforms']['linux-x86_64']['artifacts'] = incoming['platforms']['linux-x86_64']['artifacts'][:2]
         self.result = dict(applied=True, public_bytes_verified=True, published_release=True,
                            receipts_verified=True, manifest=incoming, platform='linux-x86_64',
@@ -21,21 +25,23 @@ class ReleaseIndexTests(unittest.TestCase):
                            published_at='2026-09-10T03:51:06Z')
 
     def test_resume_preserves_arch_and_other_platforms(self):
+        original = copy.deepcopy(self.index)
         out = merge(self.index, self.result)
         self.assertEqual(len(out['platforms']['linux-x86_64']['artifacts']), 4)
         self.assertEqual(out['platforms']['macos-arm64']['artifacts'], self.index['platforms']['macos-arm64']['artifacts'])
-        self.assertEqual(out['platforms']['windows-x64']['state'], 'blocked')
-        self.assertNotIn('source_revision', self.index['platforms']['macos-arm64'])
+        self.assertEqual(out['platforms']['windows-x64'], self.index['platforms']['windows-x64'])
+        self.assertEqual(self.index, original)
 
     def test_new_linux_version_preserves_older_mac_source(self):
-        m = self.result['manifest'];m['version'] = '0.7.0';m['source_revision'] = 'a'*40
-        e = m['platforms']['linux-x86_64'];e['version'] = '0.7.0';e['tag'] = 'v0.7.0'
+        m = self.result['manifest'];m['version'] = '0.7.0';m['source_revision'] = 'a'*40;m['tag'] = 'v0.7.0'
+        e = m['platforms']['linux-x86_64'];e['version'] = '0.7.0';e['tag'] = 'v0.7.0';e['source_revision'] = 'a'*40
         for a in e['artifacts']:
             a['name'] = a['name'].replace('0.6.0','0.7.0');a['url'] = a['url'].replace('0.6.0','0.7.0')
         self.result.update(version='0.7.0', source_revision='a'*40)
         out = merge(self.index, self.result)
         self.assertEqual(out['version'], '0.7.0')
-        self.assertEqual(out['platforms']['macos-arm64']['source_revision'], self.index['source_revision'])
+        self.assertEqual(out['platforms']['macos-arm64']['source_revision'],
+                         self.index['platforms']['macos-arm64'].get('source_revision', self.index['source_revision']))
         self.assertEqual(out['platforms']['macos-arm64']['version'], '0.6.0-beta.1')
 
     def test_unpublished_unverified_or_changed_assets_are_rejected(self):


### PR DESCRIPTION
Windows 0.6.1 is now publicly downloadable as a signed installer and portable ZIP, with its signed updater feed live. Record the verified promotion in the canonical manifest while preserving existing macOS and Linux versions, assets and sources.

The acceptance record links the exact build and passed Windows 10/11 x64 and Windows 11 ARM emulation tests. Installation docs now describe the bundled offline WebView2 runtime and current signing/publisher metadata. Release-index tests now construct a platform-specific candidate when the aggregate version belongs to another platform.

Validation: all 51 focused release tests passed; exact-source full CI, signed package build, native client/ARM acceptance, public download hashing and feed signature verification passed. Public promotion: https://github.com/reville/lighttable-digital-darkroom/actions/runs/34513680232. Website synchronization is part of this release handoff.
