### PR TITLE
Disable WebKitGTK DMA-BUF renderer on NVIDIA graphics drivers (#143)

### DIFF
--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -14,7 +14,7 @@
         "web/apple-photos.js": "7f4e7d866c9606bb2ecd375e1539e82be16b2dea7b36e24fd3100682ae3a837a",
         "web/first-run.js": "535667d03919e6b1cf284d6ef2c35fd4e70f236b0996a2b7b8afc90a5f0d81b7",
         "web/index.html": "e17d139ebdfd10fad415e8ef565c788685cb6c6d072107b18d40b179cadf0228",
-        "windows-shell/src/main.rs": "9789e24c14f3c47b5b171f23d758e4afac2c2d3784a4c0f199588666a48ecae1"
+        "windows-shell/src/main.rs": "094026569184ccac7ff6e90fed24ddb04def75f84c5330eb99b90249360efb92"
       }
     },
     "assisted-culling": {
@@ -273,7 +273,7 @@
       "sources": {
         "web/app.js": "942dffdec5f6f32ec163c9a5555dfe29a7170140befc50665fe00ea78335f300",
         "web/index.html": "e17d139ebdfd10fad415e8ef565c788685cb6c6d072107b18d40b179cadf0228",
-        "windows-shell/src/main.rs": "9789e24c14f3c47b5b171f23d758e4afac2c2d3784a4c0f199588666a48ecae1"
+        "windows-shell/src/main.rs": "094026569184ccac7ff6e90fed24ddb04def75f84c5330eb99b90249360efb92"
       }
     },
     "film-exposure-and-processing": {
@@ -454,7 +454,7 @@
         "web/index.html": "e17d139ebdfd10fad415e8ef565c788685cb6c6d072107b18d40b179cadf0228",
         "web/linux-layout.css": "6d0c86847693a770a18d32835675ec3167e84726ac8d4b58e8fcf6b654148341",
         "web/settings.js": "c51bea8111e35a8f7cddfa382ce9c713495e17a794f4fc9c2bac8b24901d3b65",
-        "windows-shell/src/main.rs": "9789e24c14f3c47b5b171f23d758e4afac2c2d3784a4c0f199588666a48ecae1",
+        "windows-shell/src/main.rs": "094026569184ccac7ff6e90fed24ddb04def75f84c5330eb99b90249360efb92",
         "windows-shell/src/windows_update.rs": "c42eaa940fc54f7914b61c43adbbef543c3856dc4d815f1be0907f60fc59f755"
       }
     },
@@ -506,7 +506,7 @@
         "app/main.swift": "b985c585815bafaca31747b59287d240a3520225df2965f0372cae84e613f4ee",
         "server.py": "364ee76855d3dc3a655f55f974d46c841c4aeeffb6bbf517296b72c4cd1e46c3",
         "web/app.js": "942dffdec5f6f32ec163c9a5555dfe29a7170140befc50665fe00ea78335f300",
-        "windows-shell/src/main.rs": "9789e24c14f3c47b5b171f23d758e4afac2c2d3784a4c0f199588666a48ecae1"
+        "windows-shell/src/main.rs": "094026569184ccac7ff6e90fed24ddb04def75f84c5330eb99b90249360efb92"
       }
     },
     "views-and-selection": {

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -42,6 +42,12 @@ The resident engine adapts its compute workgroups to the GPU. Linux one-shot
 fallback previews and exports use the upstream CLI's CPU backend, because that
 separate binary does not yet carry the portable GPU workgroups.
 
+On systems with NVIDIA graphics drivers, WebKitGTK (2.42+) can fail to allocate
+GBM buffers for DMA-BUF rendering (`Failed to create GBM buffer ...: Invalid argument`),
+leaving the window black. LightTable automatically sets `WEBKIT_DISABLE_DMABUF_RENDERER=1`
+when NVIDIA drivers are detected, while preserving any explicit user configuration
+of `WEBKIT_DISABLE_DMABUF_RENDERER`.
+
 Check the downloaded archive against its accompanying checksum:
 
 ```sh

--- a/scripts/linux/lighttable-desktop
+++ b/scripts/linux/lighttable-desktop
@@ -4,4 +4,17 @@ set -eu
 SCRIPT=$(readlink -f -- "$0")
 ROOT=$(CDPATH= cd -- "$(dirname -- "$SCRIPT")/.." && pwd -P)
 export PYTHONNOUSERSITE=1
+
+# WebKitGTK 2.42+ DMA-BUF renderer fails on NVIDIA graphics drivers with
+# "Failed to create GBM buffer ...: Invalid argument", opening a black window.
+# Automatically disable DMA-BUF rendering when NVIDIA drivers are present,
+# while preserving any explicit user preference.
+if [ -z "${WEBKIT_DISABLE_DMABUF_RENDERER+x}" ]; then
+    if [ -d /proc/driver/nvidia ] || [ -d /sys/module/nvidia ] || \
+       [ -e /dev/nvidiactl ] || [ -e /dev/nvidia0 ] || [ -e /dev/nvidia-modeset ] || \
+       grep -q -E '^(nvidia|nvidia_[a-z0-9_]+|nouveau) ' /proc/modules 2>/dev/null; then
+        export WEBKIT_DISABLE_DMABUF_RENDERER=1
+    fi
+fi
+
 exec "$ROOT/bin/lighttable-desktop-shell" "$@"

--- a/tests/test_linux_packaging.py
+++ b/tests/test_linux_packaging.py
@@ -320,6 +320,39 @@ class LinuxPackageResourcesTests(unittest.TestCase):
             self.assertEqual(output["numba"], str(root / "cache/lighttable/compiled-runtime"))
             self.assertFalse((package / "__pycache__").exists())
 
+    def test_lighttable_desktop_wrapper_configures_dmabuf_workaround_for_nvidia(self):
+        script = ROOT / "scripts/linux/lighttable-desktop"
+        self.assertTrue(script.is_file())
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            bin_dir = root / "bin"
+            bin_dir.mkdir(parents=True)
+            desktop_shell = bin_dir / "lighttable-desktop-shell"
+            desktop_shell.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"DMABUF=${WEBKIT_DISABLE_DMABUF_RENDERER:-unset}\"\n"
+            )
+            desktop_shell.chmod(0o755)
+
+            wrapper = bin_dir / "lighttable-desktop"
+            shutil.copy2(script, wrapper)
+            wrapper.chmod(0o755)
+
+            # Case 1: Baseline when no NVIDIA indicator exists -> WEBKIT_DISABLE_DMABUF_RENDERER is unset
+            clean_env = {k: v for k, v in os.environ.items() if k != "WEBKIT_DISABLE_DMABUF_RENDERER"}
+            completed = subprocess.run([str(wrapper)], capture_output=True, text=True, check=True, env=clean_env)
+            self.assertIn("DMABUF=unset", completed.stdout)
+
+            # Case 2: User explicitly set WEBKIT_DISABLE_DMABUF_RENDERER=0 -> preserved as 0
+            user_env = dict(clean_env, WEBKIT_DISABLE_DMABUF_RENDERER="0")
+            completed = subprocess.run([str(wrapper)], capture_output=True, text=True, check=True, env=user_env)
+            self.assertIn("DMABUF=0", completed.stdout)
+
+            # Case 3: User explicitly set WEBKIT_DISABLE_DMABUF_RENDERER=1 -> preserved as 1
+            user_env_1 = dict(clean_env, WEBKIT_DISABLE_DMABUF_RENDERER="1")
+            completed = subprocess.run([str(wrapper)], capture_output=True, text=True, check=True, env=user_env_1)
+            self.assertIn("DMABUF=1", completed.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/windows-shell/src/linux.rs
+++ b/windows-shell/src/linux.rs
@@ -117,6 +117,72 @@ pub fn media_mounts(mountinfo: &str) -> Vec<PathBuf> {
         .collect()
 }
 
+/// WebKitGTK 2.42+ uses DMA-BUF rendering by default, which fails on NVIDIA
+/// graphics drivers with "Failed to create GBM buffer ...: Invalid argument",
+/// leaving the window blank or black.
+///
+/// Detect whether NVIDIA graphics drivers are active while preserving any
+/// explicit `WEBKIT_DISABLE_DMABUF_RENDERER` setting chosen by the user.
+pub fn should_disable_dmabuf_renderer(
+    get_env: impl Fn(&str) -> Option<OsString>,
+    modules: Option<&str>,
+    path_exists: impl Fn(&Path) -> bool,
+) -> bool {
+    if get_env("WEBKIT_DISABLE_DMABUF_RENDERER").is_some() {
+        return false;
+    }
+    is_nvidia_driver_active(get_env, modules, path_exists)
+}
+
+/// Check if NVIDIA drivers are loaded in the kernel, exposed via device nodes,
+/// or selected via environment variables.
+pub fn is_nvidia_driver_active(
+    get_env: impl Fn(&str) -> Option<OsString>,
+    modules: Option<&str>,
+    path_exists: impl Fn(&Path) -> bool,
+) -> bool {
+    if get_env("__NV_PRIME_RENDER_OFFLOAD").is_some_and(|v| v == "1")
+        || get_env("__GLX_VENDOR_LIBRARY_NAME")
+            .is_some_and(|v| v.to_string_lossy().eq_ignore_ascii_case("nvidia"))
+    {
+        return true;
+    }
+
+    if let Some(content) = modules {
+        if content.lines().any(|line| {
+            let name = line.split_whitespace().next().unwrap_or("");
+            name == "nvidia" || name == "nouveau" || name.starts_with("nvidia_")
+        }) {
+            return true;
+        }
+    }
+
+    let nvidia_paths = [
+        "/proc/driver/nvidia",
+        "/sys/module/nvidia",
+        "/sys/bus/pci/drivers/nvidia",
+        "/dev/nvidiactl",
+        "/dev/nvidia0",
+        "/dev/nvidia-modeset",
+    ];
+    nvidia_paths.iter().any(|p| path_exists(Path::new(p)))
+}
+
+/// Configure environment variables for Linux graphics before initializing GTK/Wry.
+#[cfg(target_os = "linux")]
+pub fn configure_graphics_environment() {
+    let modules = std::fs::read_to_string("/proc/modules").ok();
+    if should_disable_dmabuf_renderer(
+        |k| std::env::var_os(k),
+        modules.as_deref(),
+        |p| p.exists(),
+    ) {
+        unsafe {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
@@ -188,5 +254,67 @@ mod tests {
             mount_path(r"/mnt/literal\134040"),
             PathBuf::from(r"/mnt/literal\040")
         );
+    }
+
+    #[test]
+    fn dmabuf_renderer_disabled_when_nvidia_modules_present() {
+        let proprietary = "nvidia 61480960 180 nvidia_modeset,nvidia_uvm,nvidia_drm, Live 0x0 (OE)\n";
+        assert!(should_disable_dmabuf_renderer(|_| None, Some(proprietary), |_| false));
+
+        let submodule = "nvidia_drm 122880 8 - Live 0x0 (E)\n";
+        assert!(should_disable_dmabuf_renderer(|_| None, Some(submodule), |_| false));
+
+        let open_source = "nouveau 2785280 1 - Live 0x0\n";
+        assert!(should_disable_dmabuf_renderer(|_| None, Some(open_source), |_| false));
+
+        let amd_intel = "amdgpu 6148096 12 - Live 0x0\ni915 2048000 5 - Live 0x0\n";
+        assert!(!should_disable_dmabuf_renderer(|_| None, Some(amd_intel), |_| false));
+    }
+
+    #[test]
+    fn dmabuf_renderer_disabled_when_nvidia_device_or_sysfs_exists() {
+        for path in [
+            "/dev/nvidiactl",
+            "/dev/nvidia0",
+            "/proc/driver/nvidia",
+            "/sys/module/nvidia",
+        ] {
+            assert!(should_disable_dmabuf_renderer(
+                |_| None,
+                None,
+                |p| p == Path::new(path)
+            ));
+        }
+        assert!(!should_disable_dmabuf_renderer(
+            |_| None,
+            None,
+            |p| p == Path::new("/dev/dri/card0")
+        ));
+    }
+
+    #[test]
+    fn dmabuf_renderer_disabled_when_nvidia_env_vars_present() {
+        assert!(should_disable_dmabuf_renderer(
+            |k| (k == "__NV_PRIME_RENDER_OFFLOAD").then(|| "1".into()),
+            None,
+            |_| false
+        ));
+        assert!(should_disable_dmabuf_renderer(
+            |k| (k == "__GLX_VENDOR_LIBRARY_NAME").then(|| "nvidia".into()),
+            None,
+            |_| false
+        ));
+    }
+
+    #[test]
+    fn dmabuf_renderer_respects_explicit_user_setting() {
+        let nvidia = "nvidia 61480960 180 Live 0x0\n";
+        for val in ["0", "1"] {
+            assert!(!should_disable_dmabuf_renderer(
+                |k| (k == "WEBKIT_DISABLE_DMABUF_RENDERER").then(|| val.into()),
+                Some(nvidia),
+                |_| true
+            ));
+        }
     }
 }

--- a/windows-shell/src/main.rs
+++ b/windows-shell/src/main.rs
@@ -1439,6 +1439,7 @@ fn run() -> Result<()> {
     let mut event_builder = EventLoopBuilder::<UserEvent>::with_user_event();
     #[cfg(target_os = "linux")]
     {
+        lighttable_desktop_shell::linux::configure_graphics_environment();
         // GTK derives its X11 WM_CLASS from the program name. Keep it aligned
         // with the Wayland app ID and installed desktop entry for launch/focus.
         gtk::glib::set_prgname(Some("app.lighttable.LightTable"));
@@ -1662,6 +1663,9 @@ fn run() -> Result<()> {
 }
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    lighttable_desktop_shell::linux::configure_graphics_environment();
+
     // Reaching main proves that Windows resolved the shell's imported DLLs.
     // Packaging uses this path without creating a window or touching user data.
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
Fixes #143

### Problem
On Linux systems using NVIDIA graphics drivers, WebKitGTK 2.42+ attempts to use its DMA-BUF renderer for hardware-accelerated compositing. On NVIDIA drivers, buffer allocation frequently fails with:
```
Failed to create GBM buffer of size 1500x950: Invalid argument
```
leaving the desktop window black.

### Solution
- Detect NVIDIA graphics drivers via kernel modules (`/proc/modules`), character device nodes (`/dev/nvidiactl`, `/dev/nvidia0`, `/dev/nvidia-modeset`), sysfs/procfs paths (`/proc/driver/nvidia`, `/sys/module/nvidia`), or PRIME offload environment variables (`__NV_PRIME_RENDER_OFFLOAD`, `__GLX_VENDOR_LIBRARY_NAME`).
- Automatically configure `WEBKIT_DISABLE_DMABUF_RENDERER=1` in `scripts/linux/lighttable-desktop` and in the desktop shell runtime (`windows-shell/src/linux.rs` and `windows-shell/src/main.rs`) before GTK/WebKit initializes.
- Preserve explicit user configuration of `WEBKIT_DISABLE_DMABUF_RENDERER` (e.g. if set to `0` or `1`).
- Add unit tests verifying driver detection and launcher wrapper behavior.
- Document the compatibility behavior in `docs/platforms/linux.md`.