### PR TITLE
Update npm package version and release metadata to 0.6.2

### DIFF
--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,21 +1,35 @@
 {
   "name": "lighttable-digital-darkroom",
-  "version": "0.0.0-unreleased",
+  "version": "0.6.2",
   "description": "Install the LightTable digital darkroom and run its bundled command-line interface",
   "license": "GPL-3.0-only",
   "type": "module",
-  "bin": { "lighttable": "bin/lighttable.mjs" },
-  "engines": { "node": ">=20" },
+  "bin": {
+    "lighttable": "bin/lighttable.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/reville/lighttable-digital-darkroom.git",
     "directory": "packaging/npm"
   },
   "homepage": "https://github.com/reville/lighttable-digital-darkroom",
-  "files": ["bin/", "lib/", "scripts/postinstall.mjs", "scripts/check-release.mjs", "release.json", "README.md", "LICENSE"],
+  "files": [
+    "bin/",
+    "lib/",
+    "scripts/postinstall.mjs",
+    "scripts/check-release.mjs",
+    "release.json",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "node --test",
     "prepublishOnly": "node scripts/check-release.mjs"
   },
-  "publishConfig": { "access": "public" }
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packaging/npm/release.json
+++ b/packaging/npm/release.json
@@ -1,5 +1,9 @@
 {
   "schema": 1,
-  "version": null,
-  "platforms": {}
+  "version": "0.6.2",
+  "platforms": {
+    "win32-x64": {
+      "sha256": "32d8b8d32affba2c29c901a1a7b1c35ee072051ebb06a8fe70270a3be0590842"
+    }
+  }
 }


### PR DESCRIPTION
Updates `packaging/npm/package.json` to 0.6.2 and records verified Windows x64 release asset hash in `packaging/npm/release.json` matching published npm package.