### PR TITLE
Read the app version from one source and require it at release

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -207,10 +207,14 @@ jobs:
           .build/linux/test-runtime/bin/python3 -m unittest discover -s tests -p test_gpu_grade.py -v
           .build/linux/test-runtime/bin/python3 -m unittest discover -s tests -p test_merge_acceleration.py -v
 
-      - name: Build and smoke-test relocated package
+      - name: Select package version
         if: github.event_name != 'pull_request' || inputs.build_package
         env:
-          PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: echo "PACKAGE_VERSION=${REQUESTED_VERSION:-$(python3 app_version.py)-ci.$GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Build and smoke-test relocated package
+        if: github.event_name != 'pull_request' || inputs.build_package
         run: ./scripts/linux/build-release.sh --version "$PACKAGE_VERSION"
 
       - name: Retain completed portable bundle before native acceptance
@@ -226,8 +230,6 @@ jobs:
       - name: Open native GTK desktop and require a rendered photo
         if: github.event_name != 'pull_request' || inputs.build_package
         timeout-minutes: 3
-        env:
-          PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
         run: |
           mkdir -p ".build/linux/native desktop smoke"
           tar -xzf "dist/LightTable-$PACKAGE_VERSION-linux-x86_64.tar.gz" -C ".build/linux/native desktop smoke"
@@ -273,8 +275,6 @@ jobs:
 
       - name: Prepare local pacman package recipe
         if: github.event_name != 'pull_request' || inputs.build_package
-        env:
-          PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
         run: |
           python3 scripts/linux/make-arch-package.py \
             "dist/LightTable-$PACKAGE_VERSION-linux-x86_64.tar.gz" --output-dir .build/linux/arch-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
           version="${REQUESTED_VERSION:-${GITHUB_REF_NAME#v}}"
           [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || { echo 'Use a stable version such as 0.5.0'; exit 1; }
           source_ref="$(git rev-parse --verify "refs/tags/v$version^{commit}")"
+          # About, the local API and the CLI read app_version.py, so the tag must carry the bump.
+          if git cat-file -e "refs/tags/v$version:app_version.py" 2>/dev/null; then
+            tagged_version="$(git show "refs/tags/v$version:app_version.py" | sed -n 's/^VERSION = "\([^"]*\)"$/\1/p')"
+            [[ "$tagged_version" == "$version" ]] || { echo "app_version.py at v$version says ${tagged_version:-nothing}; run scripts/release/set-version.py $version and tag the merged bump"; exit 1; }
+          else
+            echo "::notice::v$version predates app_version.py; only the requested version is embedded"
+          fi
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -259,7 +259,7 @@ jobs:
         shell: pwsh
         env:
           STORE_CANDIDATE: ${{ inputs.store_candidate && 'true' || 'false' }}
-          PACKAGE_VERSION: ${{ inputs.version || format('0.1.0-ci.{0}', github.run_number) }}
+          PACKAGE_VERSION: ${{ inputs.version }}
           REQUIRE_SIGNING: ${{ (inputs.require_signing || inputs.store_candidate) && 'true' || 'false' }}
           WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
@@ -294,6 +294,7 @@ jobs:
               OfflineWebView2Sha256 = $InputRecord.sha256
             }
           }
+          if (-not $env:PACKAGE_VERSION) { $env:PACKAGE_VERSION = "$(python app_version.py)-ci.$env:GITHUB_RUN_NUMBER" }
           ./scripts/windows/build-release.ps1 @StoreOptions -Version $env:PACKAGE_VERSION -RequireSigning:($env:REQUIRE_SIGNING -eq 'true')
 
       - name: Verify signatures in the completed artifacts

--- a/LightTable.xcodeproj/project.pbxproj
+++ b/LightTable.xcodeproj/project.pbxproj
@@ -180,7 +180,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reville.lighttable;
 				PRODUCT_NAME = LightTable;
 				SWIFT_VERSION = 5.0;
@@ -200,7 +200,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reville.lighttable;
 				PRODUCT_NAME = LightTable;
 				SWIFT_VERSION = 5.0;

--- a/app_version.py
+++ b/app_version.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""The one LightTable release version.
+
+About, the local API, the command client and every build without an explicit
+version read this. Bump it before tagging a release with
+`python3 scripts/release/set-version.py X.Y.Z`; the release workflow refuses a
+tag that disagrees with it.
+"""
+
+VERSION = "0.7.0"
+
+
+if __name__ == "__main__":
+    print(VERSION)

--- a/build-app.sh
+++ b/build-app.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")"
 PROJECT="$(pwd)"
 APP="build/LightTable.app"
 BUNDLE_IDENTIFIER="${LIGHTTABLE_BUNDLE_IDENTIFIER:-com.reville.lighttable}"
+VERSION="$(sed -n 's/^VERSION = "\([^"]*\)"$/\1/p' app_version.py)"
 
 # Keep Metal, compiled shaders, and decoded inputs resident across requests.
 # The server discovers this release binary directly from rust-engine/target.
@@ -51,7 +52,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CFBundleTypeRole</key><string>Viewer</string>
   </dict></array>
   <key>CFBundleVersion</key><string>1.0</string>
-  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleShortVersionString</key><string>$VERSION</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleExecutable</key><string>LightTable</string>
   <key>CFBundleIconFile</key><string>LightTable</string>

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -93,7 +93,7 @@
       "content": "a94cf3edb0403756d16cc7e0b65d24374451e2322e6de012d1ed2232c5db591e",
       "sources": {
         "app/main.swift": "293ad54260ecb1a58087345aeaec7379739f8b96c915a29870c0c0af12c67735",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/app.js": "d1f6aab486fd514705618f2d232180612daeda14a1feaa901aa4159afc688906",
         "web/edit-transfer.js": "768afe5a493987fc44e20cc50a71a0c45da3464827f32792983e0ca1796034a0",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31",
@@ -182,7 +182,7 @@
       "sources": {
         "app/main.swift": "293ad54260ecb1a58087345aeaec7379739f8b96c915a29870c0c0af12c67735",
         "merge_workflow.py": "1645759c959111d306622837f1a048973f7b1c1bcb877fa5e3c9c9e4d70dabd9",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/app.js": "d1f6aab486fd514705618f2d232180612daeda14a1feaa901aa4159afc688906",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -195,7 +195,7 @@
         "preset_library.py": "751779c9f3eb00a3ed02be4f69f9bb546a043c06d385832e228744ee3571fb8c",
         "preset_submission.py": "6f56eeb58611560e99ad9d8644388a1a8fe804e636c6181b2b8e9f2cd8d72995",
         "presets/builtin.json": "d82181ddb5d522736dcb626d29bd41da3b5478e9a7182a69798224bed844f713",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/app.js": "d1f6aab486fd514705618f2d232180612daeda14a1feaa901aa4159afc688906",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31",
         "web/numeric-controls.js": "2a636746cdc7ed8a6307edba404d0ad9102fd4d66662e09b72a56e1502a43f76",
@@ -263,7 +263,7 @@
     "export-photos": {
       "content": "eee4673a39ad76c0d276d7ab4790509d55aaa0c7fbadd8f403f44d22372cc4da",
       "sources": {
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/app.js": "d1f6aab486fd514705618f2d232180612daeda14a1feaa901aa4159afc688906",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -338,7 +338,7 @@
       "sources": {
         "catalog.py": "a799aef6e2a2cae67f12cfc77bef8a2635e7976218ee8b49d5b844be3ecb70b4",
         "ingest_workflow.py": "b1b7ed3c79a7491a5c3e6a15cef15e08ec3964dd7b2e4ff112b33fc836254079",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -347,7 +347,7 @@
       "content": "2ae84dc8451d88564bff7704fd70ef29b90f1b6561548b6c5e571750da593a2b",
       "sources": {
         "catalog_import.py": "f1f0e6b3c85c69d7d7e38ffe30c6e2bbb0b757838f0bd9c1be54e8e6a5488b25",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -377,7 +377,7 @@
         "film_lab_ai/face_models.py": "5057b36c1d3439589bd93355e9f22fde3a51de7ff06928feef38021b9f724b70",
         "film_lab_ai/face_service.py": "ebb535423089602bfeb73360c6d297b01b5a3dc87ea5b395c12f4b783a313c02",
         "film_lab_ai/face_store.py": "7c47381bf4917abca8f36628d8fed175ade496305f8594f69e815d59b61ce9b5",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/library.js": "8a821cb08fdc1bdf8d25cbeb0ce3d84a596e56dce3b557c84b07ab390ce6d584",
         "web/people.css": "34134f69e1d5e2afbd015776f76c4dea211333fba413ab0181ee157908f5a00f",
         "web/people.js": "82bf9f2310f2950f7b45d4e8c5fa371eb066f10229257ec4b6ac5f904afc8b81"
@@ -391,7 +391,7 @@
         "grade.py": "a85f069c327e2d8c0fa1392cb9f0626627c3958b673e381cc85be35541895e66",
         "media_availability.py": "d95a52401f51850d6291b24cb400c9094a78524983592cdf576933f7fbfa7dc1",
         "merge_acceleration.py": "01eabeadffe67c97a12d3887dfbc3e0107f7e84383d4fab947f2aa7ad8345baf",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/app.js": "d1f6aab486fd514705618f2d232180612daeda14a1feaa901aa4159afc688906",
         "web/gl.js": "71a9356c296b968466e6073fa9172a2b4cf949f6579086c3f55f1ae2ae9b9ecb",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31",
@@ -428,7 +428,7 @@
       "content": "daaceff084a4ad855923488dee5cc8d576d8ea63730c5ff3f89c071a3045cffb",
       "sources": {
         "ingest_workflow.py": "b1b7ed3c79a7491a5c3e6a15cef15e08ec3964dd7b2e4ff112b33fc836254079",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817"
       }
     },
@@ -506,7 +506,7 @@
       "content": "235dbc5ee95d42c2cacb56cc92dc960469fd67f917bba02c123b13ff5a1b6e9f",
       "sources": {
         "app/main.swift": "293ad54260ecb1a58087345aeaec7379739f8b96c915a29870c0c0af12c67735",
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/app.js": "d1f6aab486fd514705618f2d232180612daeda14a1feaa901aa4159afc688906",
         "windows-shell/src/main.rs": "2cc138e76b35146e57043d56217709344b366234cc11ec46f7254c2ae68bd3e8"
       }
@@ -533,7 +533,7 @@
     "xmp-interchange": {
       "content": "f261c55f26a9b517649449b3fd8834ee8ac9c868c80507867bb0d5e1118d2c49",
       "sources": {
-        "server.py": "33fe6fccb09082a20cad905331d1b4f728ec36bcc58ccc4e8c4365eaa09c223b",
+        "server.py": "698070d23e3e2d0413d237d088c0e3bb29e66d80f61a9e6aa7de085f8e9799a7",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817",
         "xmp_sidecar.py": "037302972759023a01eb59439473f24c334b86517b6df9c6a6a9f724665981dc"
       }

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -234,7 +234,7 @@ rustup toolchain install 1.88.0 --profile minimal --target x86_64-unknown-linux-
 python3 -m venv .build/linux/build-tools
 .build/linux/build-tools/bin/pip install uv==0.11.28
 export PATH="$PWD/.build/linux/build-tools/bin:$PATH"
-./scripts/linux/build-release.sh --version 0.1.0
+./scripts/linux/build-release.sh  # version defaults to app_version.py
 ```
 
 Install Rust/rustup first if unavailable. On Arch, the equivalent

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -87,7 +87,7 @@ desktop before release.
 On Windows x64 with Rust 1.88.0, Git, uv 0.11.28, and NSIS installed:
 
 ```powershell
-.\scripts\windows\build-release.ps1 -Version 0.1.0
+.\scripts\windows\build-release.ps1  # version defaults to app_version.py
 ```
 
 The build downloads a hash-verified embedded Python runtime and pinned render

--- a/lighttable_cli/__init__.py
+++ b/lighttable_cli/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-only
 """Dependency-free command and agent client for LightTable."""
 
-__version__ = "1.0"
+from app_version import VERSION as __version__

--- a/lighttable_cli/__main__.py
+++ b/lighttable_cli/__main__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import platform_paths
 
+from . import __version__
 from .client import Client, ClientError, query
 from .instances import Instance, default_instance_directory, discover, select
 from .manifest import (
@@ -1104,7 +1105,7 @@ def run_mcp(client: Client) -> None:
             if method == "initialize":
                 result = {"protocolVersion": "2025-06-18",
                           "capabilities": {"tools": {}, "resources": {}},
-                          "serverInfo": {"name": "lighttable", "version": "1.0"}}
+                          "serverInfo": {"name": "lighttable", "version": __version__}}
             elif method == "tools/list":
                 result = {"tools": [{"name": tool["name"],
                     "description": tool["summary"], "inputSchema": tool["schema"],

--- a/release/README.md
+++ b/release/README.md
@@ -82,18 +82,21 @@ listed as supported. Package-index submissions are separate from direct download
 
 1. Complete unit/installer tests on the exact source to release.
 2. Configure the platform credentials below.
-3. Create and push a new stable tag such as `v0.1.0`. The tag workflow uses the
+3. Set the version with `python3 scripts/release/set-version.py X.Y.Z` and merge
+   that change. About, the local API, the CLI and unversioned builds read
+   `app_version.py`, and the release build refuses a tag that disagrees with it.
+4. Create and push the matching stable tag `vX.Y.Z` from the merged source. The tag workflow uses the
    selected release platforms. Manual dispatch accepts an existing tag version
    and can select one platform. See [Linux distribution](../docs/platforms/linux-distribution.md)
    for platform selection. Published release files are immutable; use another
    version for changes.
-4. The workflow builds and tests the actual bundles, signs/notarizes Mac artifacts,
+5. The workflow builds and tests the actual bundles, signs/notarizes Mac artifacts,
    generates checksums and package definitions from the final bytes, stages a draft
    release, and makes it public only after all selected builds succeed.
-5. Publish the generated Homebrew/Scoop files and submit the WinGet/Chocolatey
+6. Publish the generated Homebrew/Scoop files and submit the WinGet/Chocolatey
    packages after native installation validation. The index repositories can sync
    an existing public release without rebuilding or changing its files.
-6. Publish the prepared npm tarball only after its matching desktop assets are
+7. Publish the prepared npm tarball only after its matching desktop assets are
    public. npm's package name and Homebrew's main-catalog acceptance are separate
    from creating a GitHub repository.
 
@@ -121,11 +124,11 @@ The build uses an ephemeral keychain and deletes it after the job.
 For a local build after preparing `scripts/models/requirements-convert.txt`:
 
 ```sh
-LIGHTTABLE_VERSION=0.1.0 LIGHTTABLE_BUILD_NUMBER=1 \
+LIGHTTABLE_BUILD_NUMBER=1 \
   LIGHTTABLE_SIGN_IDENTITY='Developer ID Application: Your Name (TEAMID)' \
   scripts/build-release.sh
 scripts/notarize-app.sh dist/LightTable.app
-scripts/package-release.sh dist/LightTable.app 0.1.0
+scripts/package-release.sh dist/LightTable.app "$(python3 app_version.py)"
 ```
 
 The notarization script reads credentials from the environment. Public releases

--- a/release/process.md
+++ b/release/process.md
@@ -4,6 +4,15 @@ A release has one immutable source cutoff and independently verified platform
 artifacts. A blocked Windows or store channel does not prevent an accepted Linux
 or macOS channel from progressing. No recurring release scheduler is required.
 
+Set the version before tagging. `app_version.py` is the one release version:
+About, the local API, the command client and every build without an explicit
+version read it. Run `python3 scripts/release/set-version.py X.Y.Z` (it also
+updates the Xcode project), merge that change, and tag `vX.Y.Z` from the merged
+source. The build workflow refuses a tag whose `app_version.py` disagrees, and the
+unit tests fail once the recorded release manifest or npm metadata is ahead of it.
+Per-channel package records such as the Flatpak metainfo and the Arch recipe are
+updated when that channel publishes.
+
 The manual build, preparation and promotion workflows have separate jobs:
 
 1. **Build:** select platforms and the existing immutable release tag. Run the

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-VERSION="${LIGHTTABLE_VERSION:-0.1.0}"
+VERSION="${LIGHTTABLE_VERSION:-$(sed -n 's/^VERSION = "\([^"]*\)"$/\1/p' "$ROOT/app_version.py")}"
 if [[ "$(uname -m)" != arm64 ]]; then
   echo "The macOS release currently supports Apple silicon only." >&2
   exit 1

--- a/scripts/linux/build-release.py
+++ b/scripts/linux/build-release.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PINS = json.loads((ROOT / "packaging/linux/runtime.json").read_text())
+APP_VERSION = re.search(r'^VERSION = "([^"]+)"$', (ROOT / "app_version.py").read_text(),
+                        re.MULTILINE).group(1)
 
 
 def run(*arguments: str | Path, **kwargs) -> str:
@@ -85,7 +87,7 @@ def stage_resources(project: Path, python_source: Path, rust_source: Path, bundl
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--version", default=os.environ.get("LIGHTTABLE_VERSION", "0.1.0"))
+    parser.add_argument("--version", default=os.environ.get("LIGHTTABLE_VERSION", APP_VERSION))
     parser.add_argument("--output-dir", type=Path, default=ROOT / "dist")
     parser.add_argument("--experimental-aarch64", action="store_true",
                         help="Build an explicitly experimental native ARM64 validation package")

--- a/scripts/release/set-version.py
+++ b/scripts/release/set-version.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""Set or check the one LightTable release version.
+
+    python3 scripts/release/set-version.py 0.7.1    # before tagging v0.7.1
+    python3 scripts/release/set-version.py --check  # also run by the unit tests
+
+`app_version.py` is the source. The Xcode project mirrors it for developer
+builds. Published release records (the aggregate manifest and npm metadata) may
+trail an unreleased bump but must never be ahead of it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+STABLE = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+SOURCE_LINE = re.compile(r'^VERSION = "([^"]*)"$', re.MULTILINE)
+MARKETING = re.compile(r"MARKETING_VERSION = ([^;]+);")
+XCODE_PROJECT = "LightTable.xcodeproj/project.pbxproj"
+PUBLISHED_RECORDS = (
+    "release/manifest.json",
+    "packaging/npm/package.json",
+    "packaging/npm/release.json",
+)
+
+
+def version_key(version: str) -> tuple[int, int, int]:
+    base = version.split("-", 1)[0]
+    if not STABLE.fullmatch(base):
+        raise ValueError(f"not a release version: {version!r}")
+    return tuple(int(part) for part in base.split("."))
+
+
+def source_version(root: Path = ROOT) -> str:
+    match = SOURCE_LINE.search((root / "app_version.py").read_text())
+    if not match:
+        raise ValueError("app_version.py does not define VERSION")
+    return match.group(1)
+
+
+def published_versions(root: Path = ROOT) -> dict[str, str]:
+    found = {}
+    for relative in PUBLISHED_RECORDS:
+        path = root / relative
+        if not path.is_file():
+            continue
+        record = json.loads(path.read_text())
+        found[relative] = record["version"]
+        for platform, entry in (record.get("platforms") or {}).items():
+            if isinstance(entry, dict) and entry.get("version"):
+                found[f"{relative} {platform}"] = entry["version"]
+    return found
+
+
+def problems(root: Path = ROOT) -> list[str]:
+    version = source_version(root)
+    if not STABLE.fullmatch(version):
+        return [f"app_version.py VERSION must be MAJOR.MINOR.PATCH, not {version!r}"]
+    found = []
+    marketing = set(MARKETING.findall((root / XCODE_PROJECT).read_text()))
+    if marketing != {version}:
+        found.append(f"{XCODE_PROJECT} MARKETING_VERSION is {sorted(marketing)}, expected {version}")
+    for record, published in published_versions(root).items():
+        if version_key(published) > version_key(version):
+            found.append(
+                f"{record} records {published}, but app_version.py is still {version}; "
+                "bump it with scripts/release/set-version.py"
+            )
+    return found
+
+
+def set_version(version: str, root: Path = ROOT) -> None:
+    if not STABLE.fullmatch(version):
+        raise ValueError("Use a stable MAJOR.MINOR.PATCH version such as 0.7.1")
+    current = source_version(root)
+    if version_key(version) < version_key(current):
+        raise ValueError(f"Refusing to lower the version from {current} to {version}")
+    source = root / "app_version.py"
+    source.write_text(SOURCE_LINE.sub(f'VERSION = "{version}"', source.read_text(), count=1))
+    project = root / XCODE_PROJECT
+    project.write_text(MARKETING.sub(f"MARKETING_VERSION = {version};", project.read_text()))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("version", nargs="?", help="new MAJOR.MINOR.PATCH release version")
+    parser.add_argument("--check", action="store_true", help="verify every copy agrees")
+    args = parser.parse_args()
+    if bool(args.version) == args.check:
+        parser.error("pass either a version or --check")
+    try:
+        if args.version:
+            set_version(args.version)
+    except ValueError as error:
+        parser.error(str(error))
+    found = problems()
+    for problem in found:
+        print(problem, file=sys.stderr)
+    if found:
+        return 1
+    print(f"LightTable version {source_version()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-personal-app.sh
+++ b/scripts/update-personal-app.sh
@@ -43,7 +43,7 @@ INSTALL_APP="${LIGHTTABLE_PERSONAL_APP:-/Applications/LightTable - NPR Installed
 BASE_APP="${LIGHTTABLE_PERSONAL_BASE_APP:-$INSTALL_APP}"
 BUILD_ROOT="$ROOT/.build/personal"
 BUILD_NUMBER="${LIGHTTABLE_BUILD_NUMBER:-$(date +%Y%m%d%H%M)}"
-VERSION="${LIGHTTABLE_VERSION:-0.1.0}"
+VERSION="${LIGHTTABLE_VERSION:-$(sed -n 's/^VERSION = "\([^"]*\)"$/\1/p' "$ROOT/app_version.py")}"
 PRODUCT_NAME="LightTable - NPR Installed"
 BUNDLE_IDENTIFIER="com.reville.filmlab.nprinstalled"
 DATA_NAME="Film Lab - NPR Installed"

--- a/scripts/windows/build-release.ps1
+++ b/scripts/windows/build-release.ps1
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 param(
     [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$')]
-    [string]$Version = "0.1.0",
+    [string]$Version = "",
     [string]$OutputDirectory = "dist",
     [switch]$PortableOnly,
     [switch]$RuntimeSmokeOnly,
@@ -13,6 +13,13 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# Builds without an explicit version use the one release version.
+if (-not $Version) {
+    $Version = [regex]::Match((Get-Content -Raw (Join-Path $PSScriptRoot "..\..\app_version.py")),
+        '(?m)^VERSION = "([^"]+)"\r?$').Groups[1].Value
+    if (-not $Version) { throw "app_version.py does not define VERSION." }
+}
 
 # A Store candidate embeds its prerequisite and signs the entire native payload.
 # Certification still requires a clean offline Windows acceptance run.

--- a/server.py
+++ b/server.py
@@ -52,6 +52,7 @@ if os.environ.get("LIGHTTABLE_DIAGNOSTICS"):
 
 APP = Path(__file__).resolve().parent
 sys.path.insert(0, str(APP))
+import app_version  # noqa: E402
 import film_pipeline as fp  # noqa: E402
 import grade  # noqa: E402
 import edits  # noqa: E402
@@ -6313,7 +6314,7 @@ def health_payload(*, include_token: bool = False) -> dict:
         models = {"available": False, "reason": str(error)}
     payload = {
         "ok": True,
-        "version": "1.0",
+        "version": app_version.VERSION,
         "sourceRevision": _git_revision(APP),
         "catalog": str(cat.path.resolve()) if cat is not None else None,
         "folder": str(FOLDER.resolve()) if FOLDER else "",

--- a/tests/test_app_version.py
+++ b/tests/test_app_version.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import app_version
+import lighttable_cli
+
+
+ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "set_version", ROOT / "scripts/release/set-version.py")
+set_version = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(set_version)
+
+# Hard-coded fallbacks that once made unversioned builds report 0.1.0 or 1.0.
+STALE_DEFAULTS = (
+    ':-0.1.0}',
+    '"LIGHTTABLE_VERSION", "0.1.0"',
+    '$Version = "0.1.0"',
+    "0.1.0-ci",
+    "<key>CFBundleShortVersionString</key><string>1.0</string>",
+)
+
+
+class AppVersionTests(unittest.TestCase):
+    def test_every_copy_agrees_and_is_not_behind_the_published_release(self):
+        self.assertEqual(set_version.problems(), [])
+        self.assertEqual(set_version.source_version(), app_version.VERSION)
+
+    def test_about_api_and_cli_report_the_release_version(self):
+        self.assertEqual(lighttable_cli.__version__, app_version.VERSION)
+        self.assertIn('"version": app_version.VERSION,', (ROOT / "server.py").read_text())
+        self.assertIn('"serverInfo": {"name": "lighttable", "version": __version__}',
+                      (ROOT / "lighttable_cli/__main__.py").read_text())
+        self.assertIn("<string>$(MARKETING_VERSION)</string>", (ROOT / "app/Info.plist").read_text())
+
+    def test_builds_without_an_explicit_version_use_app_version(self):
+        for relative in (
+            "scripts/update-personal-app.sh",
+            "scripts/build-release.sh",
+            "build-app.sh",
+            "scripts/linux/build-release.py",
+            "scripts/windows/build-release.ps1",
+            ".github/workflows/linux-build.yml",
+            ".github/workflows/windows-build.yml",
+        ):
+            source = (ROOT / relative).read_text()
+            self.assertIn("app_version.py", source, relative)
+            for stale in STALE_DEFAULTS:
+                self.assertNotIn(stale, source, relative)
+
+    def test_release_tag_must_carry_the_bump(self):
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        self.assertIn('git show "refs/tags/v$version:app_version.py"', workflow)
+
+    def test_set_version_updates_sources_and_refuses_to_go_backwards(self):
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            for relative in ("app_version.py", set_version.XCODE_PROJECT,
+                             *set_version.PUBLISHED_RECORDS):
+                (root / relative).parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(ROOT / relative, root / relative)
+            major, minor, patch = set_version.version_key(app_version.VERSION)
+            newer = f"{major}.{minor}.{patch + 1}"
+
+            set_version.set_version(newer, root)
+            self.assertEqual(set_version.source_version(root), newer)
+            self.assertEqual(set_version.problems(root), [])
+            with self.assertRaises(ValueError):
+                set_version.set_version(app_version.VERSION, root)
+
+            npm = root / "packaging/npm/package.json"
+            record = json.loads(npm.read_text())
+            record["version"] = f"{major}.{minor + 1}.0"
+            npm.write_text(json.dumps(record))
+            self.assertTrue(any("packaging/npm/package.json" in problem
+                                for problem in set_version.problems(root)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
About, the local API and the CLI reported `0.1.0` or `1.0` in every build that was not given an explicit version, including personal installs of 0.7.0 source.

- `app_version.py` (0.7.0) is now the one release version. About (via the Xcode `MARKETING_VERSION` and build defaults), `/api/health`, the CLI and its MCP `serverInfo` read it.
- Personal, macOS release, dev (`build-app.sh`), Linux and Windows builds default to it; Linux/Windows CI builds become `<version>-ci.N`.
- `scripts/release/set-version.py X.Y.Z` bumps it together with the Xcode project; `--check` verifies the copies agree and that `release/manifest.json` and npm metadata are not ahead of it.
- `release.yml` refuses a tag whose `app_version.py` disagrees with the tag (older tags without the file still build).
- Release docs describe the bump step. Help review lock refreshed because Help articles fingerprint `server.py` (no user-visible text changed).

## Testing
- `tests/test_app_version.py`, `test_personal_build`, `test_ci_workflows`, `test_windows_packaging`: pass
- Full Python suite: 2090 tests; the only failure was the Help fingerprint check, fixed by the review/build and now passing
- `set-version.py --check`, `bash -n` on edited scripts, YAML parse of edited workflows: pass
- Not run locally: PowerShell parse of `build-release.ps1` (no `pwsh` here; Windows CI covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
