### PR TITLE
Run the neutral develop and export finishing in parallel with identical pixels

### DIFF
--- a/color_pipeline.py
+++ b/color_pipeline.py
@@ -132,7 +132,11 @@ def as_float_rgb(image: np.ndarray) -> np.ndarray:
     array = np.asarray(image)
     if array.ndim != 3 or array.shape[2] < 3:
         raise ValueError(T("expected an HxWx3 RGB image"))
-    array = array[..., :3]
+    return _unit_float32(array[..., :3])
+
+
+def _unit_float32(array: np.ndarray) -> np.ndarray:
+    """:func:`as_float_rgb`'s conversion, for any array shape."""
     if np.issubdtype(array.dtype, np.integer):
         maximum = float(np.iinfo(array.dtype).max)
         array = array.astype(np.float32) / maximum
@@ -535,11 +539,30 @@ def linear_prophoto_to_display(
     and keeps per-channel curves from shifting hue. A wider output retains
     the same extended sRGB tone rendering, converting to the requested gamut
     before its first gamut clip.
-    """
-    import colour
 
+    With numba available the rendering runs in parallel kernels that produce
+    the same bits as :func:`_linear_prophoto_to_display_reference`, which
+    stays the implementation without numba and the definition of the output.
+    """
     profile = (_normalise_develop_profile(develop_profile)
                if develop_profile is not None else develop_profile_for(params))
+    try:
+        kernels = _develop_kernels()
+        if kernels is not None:
+            return _develop_with_kernels(
+                kernels, image, params, profile, output_space)
+    except Exception:  # noqa: BLE001 - the reference renders the same pixels
+        pass
+    return _linear_prophoto_to_display_reference(
+        image, params, profile, output_space)
+
+
+def _linear_prophoto_to_display_reference(
+        image: np.ndarray, params: dict | None, profile: str,
+        output_space: str) -> np.ndarray:
+    """The colour-science Develop rendering that the kernels reproduce."""
+    import colour
+
     linear = as_float_rgb(image)
     prophoto = colour.RGB_COLOURSPACES["ProPhoto RGB"]
     srgb = colour.RGB_COLOURSPACES["sRGB"]
@@ -576,12 +599,363 @@ def linear_prophoto_to_display(
     return convert_output_space(encoded, output_space)
 
 
+@functools.lru_cache(maxsize=1)
+def _prophoto_to_srgb_matrix() -> np.ndarray:
+    """The Bradford-adapted matrix ``colour.RGB_to_RGB`` applies above."""
+    import colour
+    return np.ascontiguousarray(colour.matrix_RGB_to_RGB(
+        colour.RGB_COLOURSPACES["ProPhoto RGB"],
+        colour.RGB_COLOURSPACES["sRGB"], "Bradford"), dtype=np.float64)
+
+
+@functools.lru_cache(maxsize=1)
+def _develop_kernels():
+    """Parallel Develop kernels, or None without numba.
+
+    Every channel repeats the float64 operations of the reference in their
+    order: ``np.matmul`` accumulates a matrix row from zero, left to right,
+    and ``eotf_inverse_sRGB`` selects its branch on the matrixed value and
+    calls the same libm ``pow``. Without fast-math LLVM may not contract or
+    reorder that arithmetic, so the rendering is bit-identical, which
+    ``tests/test_color_pipeline.py`` checks against the reference.
+    """
+    import grade
+    if not grade._HAS_NUMBA:
+        return None
+    import numba
+    from types import SimpleNamespace
+
+    @numba.njit(inline="always")
+    def matrix_row(matrix, channel, r, g, b):
+        value = 0.0
+        value += matrix[channel, 0] * r
+        value += matrix[channel, 1] * g
+        value += matrix[channel, 2] * b
+        return value
+
+    @numba.njit(inline="always")
+    def encode_srgb(value):
+        # eotf_inverse_sRGB; the power branch only sees positive values.
+        if value <= 0.0031308:
+            return value * 12.92
+        return 1.055 * value ** (1.0 / 2.4) - 0.055
+
+    @numba.njit(inline="always")
+    def decode_srgb(value, threshold):
+        # eotf_sRGB, whose threshold is eotf_inverse_sRGB(0.0031308).
+        if threshold >= value:
+            return value / 12.92
+        return ((value + 0.055) / 1.055) ** 2.4
+
+    @numba.njit(inline="always")
+    def encode_romm(value, threshold):
+        # cctf_encoding_ROMMRGB at its default 8-bit code-value scale.
+        if threshold > value:
+            encoded = value * 16.0 * 255.0
+        else:
+            encoded = value ** (1.0 / 1.8) * 255.0
+        return encoded / 255.0
+
+    @numba.njit(inline="always")
+    def encode_channel(matrix, channel, r, g, b):
+        return encode_srgb(matrix_row(matrix, channel, r, g, b))
+
+    @numba.njit(inline="always")
+    def clip_unit(value):
+        # np.clip's comparisons: NaN and -0.0 pass through unchanged.
+        if value < 0.0:
+            return 0.0
+        if value > 1.0:
+            return 1.0
+        return value
+
+    @numba.njit(parallel=True)
+    def encode_codes(codes, table, matrix, out, clip):
+        height, width = codes.shape[:2]
+        for y in numba.prange(height):
+            for x in range(width):
+                r = np.float64(table[codes[y, x, 0]])
+                g = np.float64(table[codes[y, x, 1]])
+                b = np.float64(table[codes[y, x, 2]])
+                for channel in range(3):
+                    value = encode_channel(matrix, channel, r, g, b)
+                    out[y, x, channel] = clip_unit(value) if clip else value
+
+    @numba.njit(parallel=True)
+    def encode_values(values, matrix, out, clip):
+        height, width = values.shape[:2]
+        for y in numba.prange(height):
+            for x in range(width):
+                r = np.float64(values[y, x, 0])
+                g = np.float64(values[y, x, 1])
+                b = np.float64(values[y, x, 2])
+                for channel in range(3):
+                    value = encode_channel(matrix, channel, r, g, b)
+                    out[y, x, channel] = clip_unit(value) if clip else value
+
+    @numba.njit(parallel=True)
+    def deliver(encoded, scale, target, matrix, decode_threshold,
+                romm_threshold, out):
+        # convert_output_space(encoded * scale, ...) for the targets of
+        # _delivery_transform: 0 bounds sRGB, 1 re-encodes a gamut with the
+        # sRGB curve, 2 re-encodes ProPhoto with the ROMM curve.
+        height, width = encoded.shape[:2]
+        for y in numba.prange(height):
+            for x in range(width):
+                if target == 0:
+                    for channel in range(3):
+                        out[y, x, channel] = clip_unit(
+                            encoded[y, x, channel] * scale)
+                    continue
+                r = decode_srgb(encoded[y, x, 0] * scale, decode_threshold)
+                g = decode_srgb(encoded[y, x, 1] * scale, decode_threshold)
+                b = decode_srgb(encoded[y, x, 2] * scale, decode_threshold)
+                for channel in range(3):
+                    value = matrix_row(matrix, channel, r, g, b)
+                    if target == 1:
+                        value = encode_srgb(value)
+                    else:
+                        value = encode_romm(value, romm_threshold)
+                    out[y, x, channel] = clip_unit(value)
+
+    @numba.njit(parallel=True)
+    def count_at_least(encoded, threshold, row_counts):
+        # row_counts[y] = (values at or above threshold, NaNs) for row y.
+        # Per-row slots instead of a prange reduction, which numba's parfor
+        # pass cannot analyse alongside the per-row counters.
+        height, width = encoded.shape[:2]
+        for y in numba.prange(height):
+            count = 0
+            nans = 0
+            for x in range(width):
+                for channel in range(3):
+                    value = encoded[y, x, channel]
+                    if np.isnan(value):
+                        nans += 1
+                    elif (value if value > 0.0 else 0.0) >= threshold:
+                        count += 1
+            row_counts[y, 0] = count
+            row_counts[y, 1] = nans
+
+    @numba.njit(parallel=True)
+    def gather_at_least(encoded, threshold, offsets, out):
+        height, width = encoded.shape[:2]
+        for y in numba.prange(height):
+            index = offsets[y]
+            for x in range(width):
+                for channel in range(3):
+                    value = encoded[y, x, channel]
+                    # np.maximum(value, 0.0), which also turns -0.0 into 0.0.
+                    value = value if value > 0.0 else 0.0
+                    if value >= threshold:
+                        out[index] = value
+                        index += 1
+
+    return SimpleNamespace(
+        lock=grade._PARALLEL_KERNEL_LOCK, encode_codes=encode_codes,
+        encode_values=encode_values, deliver=deliver,
+        count_at_least=count_at_least, gather_at_least=gather_at_least)
+
+
+def warm_develop_jit() -> None:
+    """Compile the kernels a 16-bit RAW develop uses before the first open.
+
+    Compiling runs no parallel region, so it happens outside the kernel lock
+    and never holds up a grade render while the application starts.
+    """
+    try:
+        kernels = _develop_kernels()
+        if kernels is None:
+            return
+        import numba
+        from numba import types
+
+        def array(dtype, ndim):
+            return numba.typeof(np.zeros((1,) * ndim, dtype=dtype))
+
+        codes, table = array(np.uint16, 3), array(np.float32, 1)
+        matrix, encoded = array(np.float64, 2), array(np.float64, 3)
+        display, counts = array(np.float32, 3), array(np.int64, 2)
+        offsets, candidates = array(np.int64, 1), array(np.float64, 1)
+        kernels.encode_codes.compile((codes, table, matrix, encoded, types.boolean))
+        kernels.encode_codes.compile((codes, table, matrix, display, types.boolean))
+        kernels.deliver.compile((encoded, types.float64, types.int64, matrix,
+                                 types.float64, types.float64, display))
+        kernels.count_at_least.compile((encoded, types.float64, counts))
+        kernels.gather_at_least.compile((encoded, types.float64, offsets, candidates))
+    except Exception:  # noqa: BLE001 - warming is an optimisation only
+        pass
+
+
+def _develop_source(image: np.ndarray) -> tuple[np.ndarray, np.ndarray | None]:
+    """Develop input as ``(codes, table)`` or ``(as_float_rgb(image), None)``.
+
+    For 8- and 16-bit input the table holds :func:`as_float_rgb` of every
+    code value, so ``table[codes]`` is exactly the converted image without
+    materialising it.
+    """
+    array = np.asarray(image)
+    if (array.ndim == 3 and array.shape[2] >= 3
+            and array.dtype in (np.dtype(np.uint8), np.dtype(np.uint16))):
+        levels = np.arange(np.iinfo(array.dtype).max + 1, dtype=array.dtype)
+        table = as_float_rgb(np.repeat(levels[None, :, None], 3, axis=2))[0, :, 0]
+        return np.ascontiguousarray(array[..., :3]), np.ascontiguousarray(table)
+    return np.ascontiguousarray(as_float_rgb(array)), None
+
+
+def _develop_white_point(encoded: np.ndarray, kernels, *,
+                         min_values: int = 1 << 20,
+                         sample_stride: int = 97) -> float:
+    """``float(np.percentile(np.maximum(encoded, 0.0), 99.5))``, exactly.
+
+    numpy copies and partitions every value of a full-resolution frame, but
+    its "linear" percentile only depends on the two order statistics either
+    side of the virtual index ``(n - 1) * 0.995``. A strided sample picks a
+    threshold that keeps roughly the brightest 1%; the kernels count and
+    gather just those, and everything left out ranks below every candidate,
+    so the ranks shift by the number left out. A NaN, or a sample that kept
+    too few, falls back to numpy itself.
+    """
+    count = encoded.size
+    if count < min_values or not encoded.flags.c_contiguous:
+        return float(np.percentile(np.maximum(encoded, 0.0), 99.5))
+    sample = np.maximum(encoded.reshape(-1)[::sample_stride], 0.0)
+    position = sample.size - 1 - sample.size // 100
+    threshold = float(np.partition(sample, position)[position])
+    row_counts = np.zeros((encoded.shape[0], 2), dtype=np.int64)
+    with kernels.lock:
+        kernels.count_at_least(encoded, threshold, row_counts)
+    virtual = (count - 1) * (99.5 / 100)
+    lower_rank = int(virtual)
+    skipped = count - int(row_counts[:, 0].sum())
+    if row_counts[:, 1].any() or lower_rank < skipped:
+        return float(np.percentile(np.maximum(encoded, 0.0), 99.5))
+    offsets = np.zeros(encoded.shape[0], dtype=np.int64)
+    np.cumsum(row_counts[:-1, 0], out=offsets[1:])
+    candidates = np.empty(count - skipped, dtype=np.float64)
+    with kernels.lock:
+        kernels.gather_at_least(encoded, threshold, offsets, candidates)
+    rank = lower_rank - skipped
+    candidates.partition((rank, rank + 1))
+    lower = float(candidates[rank])
+    upper = float(candidates[rank + 1])
+    # numpy's _lerp, which interpolates from the upper neighbour past the
+    # midpoint; matching it keeps the rounding identical.
+    gamma = virtual - lower_rank
+    difference = upper - lower
+    if gamma >= 0.5:
+        return upper - difference * (1 - gamma)
+    return lower + difference * gamma
+
+
+def _develop_with_kernels(kernels, image: np.ndarray, params: dict | None,
+                          profile: str, output_space: str) -> np.ndarray:
+    """:func:`_linear_prophoto_to_display_reference` on the parallel kernels.
+
+    Everything the reference does before its gamut matrix, from the integer
+    conversion through the exposure gain and the base curve, depends on one
+    channel's value alone. With integer input it is evaluated by the same
+    numpy calls on the table of code values instead of on the frame, and a
+    kernel looks each channel up. Only a camera profile, which mixes
+    channels, needs the frame converted first.
+    """
+    output_space = normalise_output_space(output_space)
+    matrix = _prophoto_to_srgb_matrix()
+    codes, table = _develop_source(image)
+    shape = codes.shape[:2] + (3,)
+
+    def encode(values, table, out):
+        # A float32 destination is the delivered sRGB rendering, bounded as
+        # convert_output_space bounds it; float64 keeps extended code values.
+        clip = out.dtype == np.float32
+        with kernels.lock:
+            if table is None:
+                kernels.encode_values(values, matrix, out, clip)
+            else:
+                kernels.encode_codes(values, table, matrix, out, clip)
+        return out
+
+    def deliver(encoded, scale):
+        transform = _delivery_transform(output_space)
+        if transform is None:
+            np.multiply(encoded, scale, out=encoded)
+            return convert_output_space(encoded, output_space)
+        display = np.empty(shape, dtype=np.float32)
+        with kernels.lock:
+            kernels.deliver(encoded, scale, *transform, display)
+        return display
+
+    encoded = encode(codes, table, np.empty(shape, dtype=np.float64))
+    white = _develop_white_point(encoded, kernels)
+    normalise = np.isfinite(white) and white > 0
+    if profile == "linear":
+        # Multiplying by exactly 1.0 leaves every value's bits unchanged.
+        return deliver(encoded, min(4.0, 0.96 / white) if normalise else 1.0)
+
+    gain = (float(_srgb_decode(min(0.96, 4.0 * white)) / _srgb_decode(white))
+            if normalise else None)
+    curve = standard_base_curve() if profile == "standard" else soft_base_curve()
+
+    def expose(linear):
+        if gain is None:
+            return linear
+        return np.clip(linear * np.float32(gain), 0.0, 1.0)
+
+    if table is not None and not _camera_profile_identity(params):
+        table = np.interp(expose(table), standard_base_curve_domain(),
+                          curve).astype(np.float32)
+        values = codes
+    else:
+        linear = expose(table[codes] if table is not None else codes)
+        linear, profile_has_curve = apply_camera_profile(linear, params)
+        if not profile_has_curve:
+            linear = np.interp(linear, standard_base_curve_domain(),
+                               curve).astype(np.float32)
+        values = np.ascontiguousarray(linear, dtype=np.float32)
+        table = None
+    if output_space == "srgb":
+        del encoded
+        return encode(values, table, np.empty(shape, dtype=np.float32))
+    return deliver(encode(values, table, encoded), 1.0)
+
+
+@functools.lru_cache(maxsize=4)
+def _delivery_transform(output_space: str):
+    """Kernel arguments reproducing ``convert_output_space`` from sRGB.
+
+    ``(target, matrix, sRGB decode threshold, ROMM threshold)``, or None
+    when the destination's transfer functions are not the ones the kernel
+    implements, in which case colour-science converts.
+    """
+    import colour
+    from colour.models.rgb.transfer_functions import (
+        cctf_encoding_ROMMRGB, eotf_inverse_sRGB, eotf_sRGB)
+
+    if output_space == "srgb":
+        return 0, np.eye(3), 0.0, 0.0
+    source = colour.RGB_COLOURSPACES[COLOUR_SPACE_NAMES["srgb"]]
+    destination = colour.RGB_COLOURSPACES[COLOUR_SPACE_NAMES[output_space]]
+    if destination.cctf_encoding is eotf_inverse_sRGB:
+        target = 1
+    elif destination.cctf_encoding is cctf_encoding_ROMMRGB:
+        target = 2
+    else:
+        return None
+    if source.cctf_decoding is not eotf_sRGB:
+        return None
+    # The same default CAT and the same expressions the colour functions use.
+    matrix = np.ascontiguousarray(
+        colour.matrix_RGB_to_RGB(source, destination, "CAT02"), dtype=np.float64)
+    return (target, matrix, float(eotf_inverse_sRGB(0.0031308)),
+            float(16 ** (1.8 / (1 - 1.8))))
+
+
 def decode_raw_display(path: Path | str, params: dict | None = None,
                        **decode_options) -> np.ndarray:
     """Decode RAW with the selected capture settings to encoded 16-bit sRGB."""
     linear = decode_raw(path, params, **decode_options)
     display = linear_prophoto_to_display_srgb(linear, params)
-    return (display * 65535.0 + 0.5).astype(np.uint16)
+    return to_uint16(display)
 
 
 _EMBEDDED_PREVIEWS: OrderedDict[tuple, np.ndarray] = OrderedDict()
@@ -697,22 +1071,72 @@ def resize_float_to_size(image: np.ndarray,
     remains in mode ``F`` and the results are stacked without an 8-bit
     round-trip. ``reducing_gap`` uses a cheap reduction before the final
     Lanczos pass for large camera originals.
+
+    Each channel is converted, resampled and bounded on its own thread;
+    Pillow and numpy release the GIL for that work, and every step is
+    per channel, so the result is the one a single thread produces.
     """
-    source = as_float_rgb(image)
+    array = np.asarray(image)
+    if array.ndim != 3 or array.shape[2] < 3:
+        raise ValueError(T("expected an HxWx3 RGB image"))
     width = max(1, int(size[0]))
     height = max(1, int(size[1]))
-    if source.shape[1] == width and source.shape[0] == height:
-        return source
-    channels = [
-        np.asarray(
-            Image.fromarray(source[..., channel], mode="F").resize(
-                (width, height), Image.Resampling.LANCZOS, reducing_gap=3.0),
-            dtype=np.float32,
-        )
-        for channel in range(3)
-    ]
-    return np.clip(np.stack(channels, axis=2), 0.0, 1.0).astype(
-        np.float32, copy=False)
+    if array.shape[1] == width and array.shape[0] == height:
+        return as_float_rgb(array)
+    resized = np.empty((height, width, 3), dtype=np.float32)
+
+    def resize_channel(channel: int) -> None:
+        plane = Image.fromarray(_unit_float32(array[..., channel]), mode="F")
+        resized[..., channel] = np.clip(np.asarray(
+            plane.resize((width, height), Image.Resampling.LANCZOS,
+                         reducing_gap=3.0),
+            dtype=np.float32), 0.0, 1.0)
+
+    list(_pixel_pool().map(resize_channel, range(3)))
+    return resized
+
+
+_PIXEL_WORKERS = max(3, min(8, os.cpu_count() or 1))
+
+
+@functools.lru_cache(maxsize=1)
+def _pixel_pool():
+    """Threads for per-channel and per-band numpy and Pillow work.
+
+    Work submitted here must not itself wait on this pool.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    return ThreadPoolExecutor(max_workers=_PIXEL_WORKERS,
+                              thread_name_prefix="lighttable-pixels")
+
+
+def run_row_bands(rows: int, render_band) -> None:
+    """Call ``render_band(start, stop)`` over bands of ``range(rows)`` in parallel.
+
+    For per-pixel numpy, Pillow or SciPy work that writes only its own rows:
+    those libraries release the GIL, and the bands together give exactly the
+    result of one call over every row.
+    """
+    step = max(1, -(-rows // _PIXEL_WORKERS))
+    bands = [(start, min(rows, start + step)) for start in range(0, rows, step)]
+    if len(bands) == 1:
+        render_band(*bands[0])
+        return
+    list(_pixel_pool().map(lambda band: render_band(*band), bands))
+
+
+def to_uint16(image: np.ndarray) -> np.ndarray:
+    """``(image * 65535.0 + 0.5).astype(np.uint16)`` on parallel row bands."""
+    image = np.asarray(image)
+    if image.ndim < 2 or image.size < (1 << 22):
+        return (image * 65535.0 + 0.5).astype(np.uint16)
+    out = np.empty(image.shape, dtype=np.uint16)
+
+    def quantise_band(start: int, stop: int) -> None:
+        out[start:stop] = (image[start:stop] * 65535.0 + 0.5).astype(np.uint16)
+
+    run_row_bands(image.shape[0], quantise_band)
+    return out
 
 
 def resize_float_width(image: np.ndarray, max_width: int | None) -> np.ndarray:
@@ -740,6 +1164,10 @@ def convert_output_space(image_srgb: np.ndarray, output_space: str, *,
     input_space = normalise_output_space(input_space)
     if output_space == input_space:
         return np.clip(image_srgb, 0.0, 1.0).astype(np.float32)
+    if input_space == "srgb":
+        converted = _convert_from_srgb_with_kernels(image_srgb, output_space)
+        if converted is not None:
+            return converted
     import colour
 
     converted = colour.RGB_to_RGB(
@@ -750,6 +1178,31 @@ def convert_output_space(image_srgb: np.ndarray, output_space: str, *,
         apply_cctf_encoding=True,
     )
     return np.clip(converted, 0.0, 1.0).astype(np.float32)
+
+
+def _convert_from_srgb_with_kernels(image: np.ndarray,
+                                    output_space: str) -> np.ndarray | None:
+    """:func:`convert_output_space` from sRGB on the parallel kernel.
+
+    The same bits as the colour-science conversion below, which remains the
+    path for small images, other shapes and input spaces, or when the kernel
+    is unavailable. Returns None to request that path.
+    """
+    array = np.asarray(image)
+    if (array.ndim != 3 or array.shape[2] != 3 or array.size < (1 << 20)
+            or array.dtype not in (np.dtype(np.float32), np.dtype(np.float64))):
+        return None
+    kernels = _develop_kernels()
+    transform = _delivery_transform(output_space) if kernels is not None else None
+    if transform is None:
+        return None
+    converted = np.empty(array.shape, dtype=np.float32)
+    try:
+        with kernels.lock:
+            kernels.deliver(np.ascontiguousarray(array), 1.0, *transform, converted)
+    except Exception:  # noqa: BLE001 - colour-science converts the same pixels
+        return None
+    return converted
 
 
 def wide_develop_edits_supported(job: dict) -> bool:

--- a/docs/help/review-lock.json
+++ b/docs/help/review-lock.json
@@ -93,7 +93,7 @@
       "content": "a94cf3edb0403756d16cc7e0b65d24374451e2322e6de012d1ed2232c5db591e",
       "sources": {
         "app/main.swift": "293ad54260ecb1a58087345aeaec7379739f8b96c915a29870c0c0af12c67735",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "web/edit-transfer.js": "768afe5a493987fc44e20cc50a71a0c45da3464827f32792983e0ca1796034a0",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31",
@@ -103,7 +103,7 @@
     "editing-crop-geometry": {
       "content": "8540d6a3489f09244e5bb0f7b885bcf5bfd981b965c71dd1f3e2f317223462bc",
       "sources": {
-        "edits.py": "0c505b372ad95dfcdd7878648a59fbf26e3db6669864d50961b3c321510a19b1",
+        "edits.py": "b2634312fdfeb5185059b9f346e6f5529408766ce5d648c9d003a952ef5ebafb",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
     },
@@ -158,7 +158,7 @@
     "editing-masks-brush-gradients": {
       "content": "f81bc90ff1a10bee0f5bd4908e7e974538f853bc34c7f0df0d7c895e8498152f",
       "sources": {
-        "edits.py": "0c505b372ad95dfcdd7878648a59fbf26e3db6669864d50961b3c321510a19b1",
+        "edits.py": "b2634312fdfeb5185059b9f346e6f5529408766ce5d648c9d003a952ef5ebafb",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "web/edit-cursor.js": "8a6f3fdcac831c86607bc98e794588a669cc6dce8db68c067e858448b0b34cd8",
         "web/editor-panels.js": "e0f20f90fdc1b3eaae4631a2f22d8b1c0e8cca7b7f18551514046849aba79442",
@@ -182,7 +182,7 @@
       "sources": {
         "app/main.swift": "293ad54260ecb1a58087345aeaec7379739f8b96c915a29870c0c0af12c67735",
         "merge_workflow.py": "1645759c959111d306622837f1a048973f7b1c1bcb877fa5e3c9c9e4d70dabd9",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -195,7 +195,7 @@
         "preset_library.py": "751779c9f3eb00a3ed02be4f69f9bb546a043c06d385832e228744ee3571fb8c",
         "preset_submission.py": "6f56eeb58611560e99ad9d8644388a1a8fe804e636c6181b2b8e9f2cd8d72995",
         "presets/builtin.json": "d82181ddb5d522736dcb626d29bd41da3b5478e9a7182a69798224bed844f713",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31",
         "web/numeric-controls.js": "2a636746cdc7ed8a6307edba404d0ad9102fd4d66662e09b72a56e1502a43f76",
@@ -263,7 +263,7 @@
     "export-photos": {
       "content": "eee4673a39ad76c0d276d7ab4790509d55aaa0c7fbadd8f403f44d22372cc4da",
       "sources": {
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -338,7 +338,7 @@
       "sources": {
         "catalog.py": "a799aef6e2a2cae67f12cfc77bef8a2635e7976218ee8b49d5b844be3ecb70b4",
         "ingest_workflow.py": "b1b7ed3c79a7491a5c3e6a15cef15e08ec3964dd7b2e4ff112b33fc836254079",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -347,7 +347,7 @@
       "content": "2ae84dc8451d88564bff7704fd70ef29b90f1b6561548b6c5e571750da593a2b",
       "sources": {
         "catalog_import.py": "f1f0e6b3c85c69d7d7e38ffe30c6e2bbb0b757838f0bd9c1be54e8e6a5488b25",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31"
       }
@@ -377,7 +377,7 @@
         "film_lab_ai/face_models.py": "5057b36c1d3439589bd93355e9f22fde3a51de7ff06928feef38021b9f724b70",
         "film_lab_ai/face_service.py": "ebb535423089602bfeb73360c6d297b01b5a3dc87ea5b395c12f4b783a313c02",
         "film_lab_ai/face_store.py": "7c47381bf4917abca8f36628d8fed175ade496305f8594f69e815d59b61ce9b5",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/library.js": "8a821cb08fdc1bdf8d25cbeb0ce3d84a596e56dce3b557c84b07ab390ce6d584",
         "web/people.css": "34134f69e1d5e2afbd015776f76c4dea211333fba413ab0181ee157908f5a00f",
         "web/people.js": "82bf9f2310f2950f7b45d4e8c5fa371eb066f10229257ec4b6ac5f904afc8b81"
@@ -391,7 +391,7 @@
         "grade.py": "a85f069c327e2d8c0fa1392cb9f0626627c3958b673e381cc85be35541895e66",
         "media_availability.py": "d95a52401f51850d6291b24cb400c9094a78524983592cdf576933f7fbfa7dc1",
         "merge_acceleration.py": "01eabeadffe67c97a12d3887dfbc3e0107f7e84383d4fab947f2aa7ad8345baf",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "web/gl.js": "71a9356c296b968466e6073fa9172a2b4cf949f6579086c3f55f1ae2ae9b9ecb",
         "web/index.html": "23a88b63ff518119e5874b1efdda9004ba9b09ec319562f58aa71c62ea1d0a31",
@@ -428,7 +428,7 @@
       "content": "daaceff084a4ad855923488dee5cc8d576d8ea63730c5ff3f89c071a3045cffb",
       "sources": {
         "ingest_workflow.py": "b1b7ed3c79a7491a5c3e6a15cef15e08ec3964dd7b2e4ff112b33fc836254079",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817"
       }
     },
@@ -447,7 +447,7 @@
     "settings-and-defaults": {
       "content": "36af0e391db2ac30d1ca009a2ec1b8138ace10b6b2a45966418762d455d713b4",
       "sources": {
-        "color_pipeline.py": "4e050d682cdb5497c34d5f9c6e228a3c83a43bef7ca155964588946163dc68ae",
+        "color_pipeline.py": "93d12d01301374a3c5d447e9ca9452445dfc7e62141b9e7d2f55bede520fca5c",
         "desktop_updater.py": "ee4b3046a0b202cb579f60d02ff6e1ff7f7754ca4a394a12ef7be3ba96a026cd",
         "linux_theme.py": "0712b6783baf454abe704ce3bfda01ffa5170096ba4b9104470109da7007ff6f",
         "server_updates.py": "cc3b07c1396b2d26a710d8cb3d9b67574f68c5293ca89433257e9a9f118b43d5",
@@ -506,7 +506,7 @@
       "content": "235dbc5ee95d42c2cacb56cc92dc960469fd67f917bba02c123b13ff5a1b6e9f",
       "sources": {
         "app/main.swift": "293ad54260ecb1a58087345aeaec7379739f8b96c915a29870c0c0af12c67735",
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/app.js": "ffffa2409686a96a21521b8134b44df98af0b3c72c2cd778e92b941c183f87c6",
         "windows-shell/src/main.rs": "2cc138e76b35146e57043d56217709344b366234cc11ec46f7254c2ae68bd3e8"
       }
@@ -533,7 +533,7 @@
     "xmp-interchange": {
       "content": "f261c55f26a9b517649449b3fd8834ee8ac9c868c80507867bb0d5e1118d2c49",
       "sources": {
-        "server.py": "68ed9bed844a69fe2ea808b3b1a01cced296ea1c6c1439827ad79fd8024057a4",
+        "server.py": "a00ec9326eec997c4b1dd5caf6e61ec8a7803c1fb66fcec41ee1ee1c2a18c486",
         "web/catalog-ui.js": "623a52dfb3912386040d52873c9d3fd19c3da8abd77c4d8394d67ed830b30817",
         "xmp_sidecar.py": "037302972759023a01eb59439473f24c334b86517b6df9c6a6a9f724665981dc"
       }

--- a/edits.py
+++ b/edits.py
@@ -752,40 +752,56 @@ def apply_manual_optics(image: np.ndarray, optics: dict) -> np.ndarray:
                 optics["vignette"], optics["flipHorizontal"],
                 optics["flipVertical"])):
         return image
+    import color_pipeline
+
     height, width = image.shape[:2]
-    yy, xx = np.mgrid[0:height, 0:width].astype(np.float32)
     half = max(min(width, height) / 2.0, 1.0)
-    nx = (xx - (width - 1) / 2.0) / half / scale
-    ny = (yy - (height - 1) / 2.0) / half / scale
-    if optics["flipHorizontal"]:
-        nx = -nx
-    if optics["flipVertical"]:
-        ny = -ny
     cosine, sine = math.cos(rotation), math.sin(rotation)
-    rx = cosine * nx - sine * ny
-    ry = sine * nx + cosine * ny
-    px = rx * (1.0 + vertical * 0.45 * ry)
-    py = ry * (1.0 + horizontal * 0.45 * rx)
-    radius2 = px * px + py * py
-    factor = 1.0 + distortion * 0.18 * radius2
-    if any((distortion, vertical, horizontal, rotation, scale - 1.0)):
-        source_x = px * factor * half + (width - 1) / 2.0
-        source_y = py * factor * half + (height - 1) / 2.0
-        warped = np.stack([
-            _map_coordinates()(image[..., channel], [source_y, source_x],
-                               order=1, mode="constant", cval=0.0)
-            for channel in range(3)
-        ], axis=2)
+    warp = any((distortion, vertical, horizontal, rotation, scale - 1.0))
+    if warp:
+        channels = [np.ascontiguousarray(image[..., channel]) for channel in range(3)]
+        result = np.empty((height, width, 3), dtype=np.float32)
     else:
         # Discrete flips need no interpolation. Reconstructing their integer
         # coordinates through normalized float32 can put a border just below
         # zero and sample black; it also softens unchanged source pixels.
-        warped = image[::(-1 if optics["flipVertical"] else 1),
-                       ::(-1 if optics["flipHorizontal"] else 1)].copy()
-    if optics["vignette"]:
-        radial = np.clip(radius2 / 2.0, 0.0, 1.5)
-        warped *= (1.0 + optics["vignette"] * 0.8 * radial)[..., None]
-    return np.clip(warped, 0.0, 1.0).astype(np.float32)
+        flipped = image[::(-1 if optics["flipVertical"] else 1),
+                        ::(-1 if optics["flipHorizontal"] else 1)]
+        result = np.empty(flipped.shape, dtype=np.float32)
+
+    # Every value below depends only on its own output pixel, so bands of
+    # rows render in parallel and assemble the single-pass result exactly.
+    def render_band(start: int, stop: int) -> None:
+        yy, xx = np.mgrid[start:stop, 0:width].astype(np.float32)
+        nx = (xx - (width - 1) / 2.0) / half / scale
+        ny = (yy - (height - 1) / 2.0) / half / scale
+        if optics["flipHorizontal"]:
+            nx = -nx
+        if optics["flipVertical"]:
+            ny = -ny
+        rx = cosine * nx - sine * ny
+        ry = sine * nx + cosine * ny
+        px = rx * (1.0 + vertical * 0.45 * ry)
+        py = ry * (1.0 + horizontal * 0.45 * rx)
+        radius2 = px * px + py * py
+        factor = 1.0 + distortion * 0.18 * radius2
+        if warp:
+            source_x = px * factor * half + (width - 1) / 2.0
+            source_y = py * factor * half + (height - 1) / 2.0
+            warped = np.stack([
+                _map_coordinates()(channel, [source_y, source_x],
+                                   order=1, mode="constant", cval=0.0)
+                for channel in channels
+            ], axis=2)
+        else:
+            warped = flipped[start:stop].copy()
+        if optics["vignette"]:
+            radial = np.clip(radius2 / 2.0, 0.0, 1.5)
+            warped *= (1.0 + optics["vignette"] * 0.8 * radial)[..., None]
+        result[start:stop] = np.clip(warped, 0.0, 1.0).astype(np.float32)
+
+    color_pipeline.run_row_bands(height, render_band)
+    return result
 
 
 def apply_base(image: np.ndarray, optics=None, heals=None,

--- a/server.py
+++ b/server.py
@@ -2441,8 +2441,7 @@ def neutral_tiff_for(name: str, params: dict | None = None, *,
                         denoise_cancel=denoise_cancel))
                     display = color_pipeline.linear_prophoto_to_display(
                         linear, params, output_space=output_space)
-                    tf.imwrite(temporary,
-                               (display * 65535.0 + 0.5).astype(np.uint16))
+                    tf.imwrite(temporary, color_pipeline.to_uint16(display))
                 else:
                     platform_image.convert_processed_to_tiff(
                         src, temporary, app_root=APP, output_space=output_space)
@@ -2500,7 +2499,7 @@ def build_neutral_preview(name: str, width: int, rotate: float = 0,
                    linear.shape) if identity is not None else None
             def develop():
                 display = color_pipeline.linear_prophoto_to_display_srgb(linear, params)
-                return (display * 65535.0 + 0.5).astype(np.uint16)
+                return color_pipeline.to_uint16(display)
             image = NEUTRAL_DISPLAY_CACHE.get_or_build(
                 key, develop, raw_decode_runtime.check_cancel)
     else:
@@ -4450,7 +4449,10 @@ def _render_preview(name: str, params: dict, width: int,
         else:
             arr = linear_for(name, width, params)
             preview_progress.advance(2)
-            out = fp.render(arr, params)
+            # The Python film engine runs numba parallel kernels too; two
+            # parallel regions entered at once abort the process.
+            with grade._PARALLEL_KERNEL_LOCK:
+                out = fp.render(arr, params)
             preview_progress.advance(3)
         ms = int((time.time() - t0) * 1000)
         if engine != "rs":
@@ -8257,6 +8259,7 @@ def main() -> None:
         except Exception:
             pass
         grade.warm_grade_jit()
+        color_pipeline.warm_develop_jit()
     timer = threading.Timer(0.75, warm_colour)
     timer.daemon = True
     timer.start()

--- a/tests/test_camera_profile_develop.py
+++ b/tests/test_camera_profile_develop.py
@@ -57,6 +57,28 @@ class CameraProfileDevelopTests(unittest.TestCase):
                          color_pipeline.raw_decode_fingerprint(
                              {"camera_profile": "Missing Camera Adobe Standard.dcp"}))
 
+    def test_parallel_develop_matches_the_reference_with_a_profile(self):
+        kernels = color_pipeline._develop_kernels()
+        if kernels is None:
+            self.skipTest("needs numba")
+        codes = (_scene() * 65535.0).astype(np.uint16)
+        with tempfile.TemporaryDirectory() as folder:
+            curved = write_profile(Path(folder) / "Test Camera Standard.dcp",
+                                   tone_curve=[[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]])
+            plain = write_profile(Path(folder) / "Test Camera Adobe Standard.dcp")
+            index = {curved.name: curved, plain.name: plain}
+            color_pipeline.CAMERA_PROFILE_RESOLVER = index.get
+            for path in (curved, plain):
+                params = fp.clean_params({"camera_profile": path.name})
+                for image in (codes, _scene()):
+                    for space in ("srgb", "display_p3"):
+                        self.assertEqual(
+                            color_pipeline._develop_with_kernels(
+                                kernels, image, params, "standard", space).tobytes(),
+                            color_pipeline._linear_prophoto_to_display_reference(
+                                image, params, "standard", space).tobytes(),
+                            f"{path.name} {image.dtype} {space}")
+
     def test_profile_tone_curve_replaces_the_built_in_curve(self):
         scene = _scene()
         with tempfile.TemporaryDirectory() as folder:

--- a/tests/test_color_pipeline.py
+++ b/tests/test_color_pipeline.py
@@ -407,5 +407,187 @@ class StandardDevelopProfileTests(unittest.TestCase):
             self.assertLess(top, 0.995, msg=profile)
 
 
+def _previous_resize_float_to_size(image, size):
+    """The single-threaded resize the threaded one must reproduce."""
+    from PIL import Image
+    source = color_pipeline.as_float_rgb(image)
+    channels = [
+        np.asarray(Image.fromarray(source[..., channel], mode="F").resize(
+            size, Image.Resampling.LANCZOS, reducing_gap=3.0), dtype=np.float32)
+        for channel in range(3)]
+    return np.clip(np.stack(channels, axis=2), 0.0, 1.0).astype(np.float32, copy=False)
+
+
+@unittest.skipIf(color_pipeline._develop_kernels() is None, "needs numba")
+class DevelopKernelTests(unittest.TestCase):
+    """The parallel Develop must be bit-identical to the colour-science render."""
+
+    PROFILES = ("linear", "standard", "soft")
+    SPACES = ("srgb", "display_p3", "prophoto")
+
+    def setUp(self):
+        self.kernels = color_pipeline._develop_kernels()
+
+    def assertSameBits(self, actual, expected, msg=None):
+        self.assertEqual(actual.dtype, expected.dtype, msg)
+        self.assertEqual(actual.shape, expected.shape, msg)
+        self.assertEqual(actual.tobytes(), expected.tobytes(), msg)
+
+    def _inputs(self):
+        rng = np.random.default_rng(29)
+        codes = rng.integers(0, 65536, (40, 56, 3), dtype=np.uint16)
+        codes[:4] = 0
+        codes[4:6] = 65535
+        rgba = np.concatenate(
+            [codes, np.full((40, 56, 1), 65535, dtype=np.uint16)], axis=2)
+        return {
+            "uint16": codes,
+            "uint16 with alpha": rgba,
+            "uint8": rng.integers(0, 256, (40, 56, 3), dtype=np.uint8),
+            # Out-of-range floats exercise the input clip; squared values put
+            # most of the frame in the shadows, like a linear decode.
+            "float32": (rng.random((40, 56, 3), dtype=np.float32) * 1.5 - 0.2) ** 2,
+            "float64": codes / 65535.0,
+            "dim uint16": (codes // 64).astype(np.uint16),
+        }
+
+    def test_every_profile_and_output_space_matches_the_reference(self):
+        for label, image in self._inputs().items():
+            for profile in self.PROFILES:
+                for space in self.SPACES:
+                    msg = f"{label} {profile} {space}"
+                    params = {"developProfile": profile}
+                    expected = color_pipeline._linear_prophoto_to_display_reference(
+                        image, params, profile, space)
+                    # Called directly so a kernel error fails instead of
+                    # silently taking the reference path.
+                    self.assertSameBits(color_pipeline._develop_with_kernels(
+                        self.kernels, image, params, profile, space), expected, msg)
+                    self.assertSameBits(color_pipeline.linear_prophoto_to_display(
+                        image, params, output_space=space), expected, msg)
+
+    def test_wide_gamut_export_conversion_matches_colour_science(self):
+        import colour
+        rng = np.random.default_rng(17)
+        # Large enough for the kernel path; extended values reach both
+        # transfer-function branches and the output clip.
+        frames = (rng.random((800, 700, 3), dtype=np.float32) * 1.3 - 0.15,
+                  rng.random((800, 700, 3)) * 1.3 - 0.15)
+        for frame in frames:
+            for space in ("display_p3", "prophoto"):
+                expected = np.clip(colour.RGB_to_RGB(
+                    np.asarray(frame, dtype=np.float64), "sRGB",
+                    color_pipeline.COLOUR_SPACE_NAMES[space],
+                    apply_cctf_decoding=True, apply_cctf_encoding=True),
+                    0.0, 1.0).astype(np.float32)
+                converted = color_pipeline._convert_from_srgb_with_kernels(
+                    frame, space)
+                self.assertIsNotNone(converted, space)
+                self.assertSameBits(converted, expected, f"{frame.dtype} {space}")
+                self.assertSameBits(color_pipeline.convert_output_space(
+                    frame, space), expected, f"{frame.dtype} {space}")
+
+    def test_black_frame_skips_normalisation_identically(self):
+        black = np.zeros((8, 8, 3), dtype=np.uint16)
+        for profile in self.PROFILES:
+            for space in self.SPACES:
+                self.assertSameBits(
+                    color_pipeline._develop_with_kernels(
+                        self.kernels, black, {}, profile, space),
+                    color_pipeline._linear_prophoto_to_display_reference(
+                        black, {}, profile, space), f"{profile} {space}")
+
+    def test_kernel_failure_renders_through_the_reference(self):
+        image = self._inputs()["uint16"]
+        expected = color_pipeline._linear_prophoto_to_display_reference(
+            image, {}, "standard", "srgb")
+        with mock.patch.object(color_pipeline, "_develop_with_kernels",
+                               side_effect=RuntimeError("kernel")):
+            self.assertSameBits(
+                color_pipeline.linear_prophoto_to_display_srgb(image, {}), expected)
+
+    def test_warm_up_compiles_every_kernel_a_raw_develop_uses(self):
+        names = ("encode_codes", "deliver", "count_at_least", "gather_at_least")
+        color_pipeline.warm_develop_jit()
+        warmed = {name: len(getattr(self.kernels, name).signatures) for name in names}
+        for name in names:
+            self.assertTrue(warmed[name], name)
+        # A 16-bit frame large enough for the candidate percentile must find
+        # every specialization already compiled, so warming covered it.
+        codes = np.random.default_rng(2).integers(
+            0, 65536, (620, 600, 3), dtype=np.uint16)
+        for profile in self.PROFILES:
+            for space in ("srgb", "display_p3"):
+                color_pipeline._develop_with_kernels(
+                    self.kernels, codes, {}, profile, space)
+        for name in names:
+            self.assertEqual(len(getattr(self.kernels, name).signatures),
+                             warmed[name], name)
+
+    def test_white_point_gathers_candidates_and_matches_numpy(self):
+        rng = np.random.default_rng(5)
+        shape = (180, 240, 3)
+        spread = rng.random(shape) * 1.4 - 0.2
+        ties = np.round(rng.random(shape), 2)
+        clipped = np.where(rng.random(shape) < 0.8, 1.0, rng.random(shape))
+        signed_zero = np.where(rng.random(shape) < 0.5, -0.0, spread)
+        cases = {"spread": spread, "ties": ties, "clipped": clipped,
+                 "signed zero": signed_zero, "black": np.zeros(shape),
+                 "negative": -np.abs(spread)}
+        for label, encoded in cases.items():
+            encoded = np.ascontiguousarray(encoded)
+            expected = float(np.percentile(np.maximum(encoded, 0.0), 99.5))
+            with mock.patch.object(color_pipeline.np, "percentile",
+                                   side_effect=AssertionError("numpy fallback")):
+                white = color_pipeline._develop_white_point(
+                    encoded, self.kernels, min_values=0, sample_stride=7)
+            self.assertEqual(np.float64(white).tobytes(),
+                             np.float64(expected).tobytes(), label)
+
+    def test_white_point_falls_back_to_numpy_when_the_sample_misleads(self):
+        size = 180 * 240 * 3
+        flat = np.full(size, 0.5)
+        sampled = np.arange(size) % 7 == 0
+        # Just over 1% of the sampled values are the brightest in the frame,
+        # so the sample's threshold keeps far fewer than 0.5% of all values.
+        bright = np.flatnonzero(sampled)[::90]
+        flat[sampled] = 0.0
+        flat[bright] = 1.0
+        encoded = flat.reshape(180, 240, 3)
+        expected = float(np.percentile(np.maximum(encoded, 0.0), 99.5))
+        with mock.patch.object(color_pipeline.np, "percentile",
+                               wraps=np.percentile) as percentile:
+            white = color_pipeline._develop_white_point(
+                encoded, self.kernels, min_values=0, sample_stride=7)
+        percentile.assert_called_once()
+        self.assertEqual(white, expected)
+
+        with_nan = np.ascontiguousarray(encoded.copy())
+        with_nan[3, 4, 1] = np.nan
+        self.assertTrue(np.isnan(color_pipeline._develop_white_point(
+            with_nan, self.kernels, min_values=0, sample_stride=7)))
+
+
+class ThreadedPixelOperationTests(unittest.TestCase):
+    def test_threaded_resize_matches_the_single_threaded_resize(self):
+        rng = np.random.default_rng(3)
+        for image in (rng.integers(0, 65536, (300, 420, 3), dtype=np.uint16),
+                      rng.random((300, 420, 4), dtype=np.float32) * 1.2 - 0.1):
+            for size in ((150, 107), (420, 300), (840, 600)):
+                expected = _previous_resize_float_to_size(image, size)
+                resized = color_pipeline.resize_float_to_size(image, size)
+                self.assertEqual(resized.dtype, expected.dtype)
+                self.assertEqual(resized.tobytes(), expected.tobytes(), size)
+
+    def test_band_quantisation_matches_the_whole_frame_expression(self):
+        rng = np.random.default_rng(8)
+        for image in (rng.random((1210, 1203, 3), dtype=np.float32),
+                      rng.random((1210, 1203, 3)) * 1.1 - 0.05,
+                      rng.random((9, 7, 3), dtype=np.float32)):
+            expected = (image * 65535.0 + 0.5).astype(np.uint16)
+            self.assertEqual(color_pipeline.to_uint16(image).tobytes(),
+                             expected.tobytes())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_edits.py
+++ b/tests/test_edits.py
@@ -198,6 +198,59 @@ class LocalEditTests(unittest.TestCase):
         self.assertTrue(np.isfinite(transformed).all())
         self.assertGreater(float(np.abs(transformed - self.image).mean()), 0.01)
 
+    def test_banded_manual_optics_match_the_single_pass_render(self):
+        import math
+        from scipy.ndimage import map_coordinates
+
+        def single_pass(image, optics):
+            optics = edits.clean_optics(optics)
+            height, width = image.shape[:2]
+            yy, xx = np.mgrid[0:height, 0:width].astype(np.float32)
+            half = max(min(width, height) / 2.0, 1.0)
+            nx = (xx - (width - 1) / 2.0) / half / optics["scale"]
+            ny = (yy - (height - 1) / 2.0) / half / optics["scale"]
+            if optics["flipHorizontal"]:
+                nx = -nx
+            if optics["flipVertical"]:
+                ny = -ny
+            rotation = math.radians(optics["rotate"])
+            cosine, sine = math.cos(rotation), math.sin(rotation)
+            rx = cosine * nx - sine * ny
+            ry = sine * nx + cosine * ny
+            px = rx * (1.0 + optics["vertical"] * 0.45 * ry)
+            py = ry * (1.0 + optics["horizontal"] * 0.45 * rx)
+            radius2 = px * px + py * py
+            factor = 1.0 + optics["distortion"] * 0.18 * radius2
+            if any((optics["distortion"], optics["vertical"], optics["horizontal"],
+                    rotation, optics["scale"] - 1.0)):
+                warped = np.stack([map_coordinates(
+                    image[..., channel],
+                    [py * factor * half + (height - 1) / 2.0,
+                     px * factor * half + (width - 1) / 2.0],
+                    order=1, mode="constant", cval=0.0) for channel in range(3)], axis=2)
+            else:
+                warped = image[::(-1 if optics["flipVertical"] else 1),
+                               ::(-1 if optics["flipHorizontal"] else 1)].copy()
+            if optics["vignette"]:
+                warped *= (1.0 + optics["vignette"] * 0.8
+                           * np.clip(radius2 / 2.0, 0.0, 1.5))[..., None]
+            return np.clip(warped, 0.0, 1.0).astype(np.float32)
+
+        rng = np.random.default_rng(12)
+        rgb = rng.random((331, 257, 3), dtype=np.float32)
+        rgba = rng.random((97, 64, 4), dtype=np.float32)
+        for image, optics in (
+                (rgb, {"distortion": 0.4, "vertical": 0.3, "horizontal": -0.2,
+                       "rotate": 7.5, "scale": 1.1, "vignette": -0.4}),
+                (rgb, {"vignette": 0.6}),
+                (rgb, {"flipHorizontal": True, "vignette": 0.3}),
+                (rgba, {"flipVertical": True, "flipHorizontal": True}),
+                (rgba, {"rotate": -3.0})):
+            expected = single_pass(image, optics)
+            rendered = edits.apply_manual_optics(image, optics)
+            self.assertEqual(rendered.shape, expected.shape, optics)
+            self.assertEqual(rendered.tobytes(), expected.tobytes(), optics)
+
     def test_manual_optics_flips_match_pixel_geometry(self):
         horizontal = edits.apply_manual_optics(
             self.image, {"flipHorizontal": True})


### PR DESCRIPTION
## Summary
The neutral (Film-off) develop behind Develop previews, compare's Original and profile-off exports took about ten seconds for a 40 MP RAW, all in single-threaded colour-science/numpy passes. It now runs in parallel **with byte-identical output**, and the same approach speeds up wide-gamut export conversion, resizing and manual optics.

- **Develop kernels** (`color_pipeline._develop_with_kernels`): numba float64 kernels that repeat the reference arithmetic in order (`np.matmul` row accumulation, `eotf_inverse_sRGB`, `eotf_sRGB`, ROMM encode, `np.clip` NaN/-0.0 behaviour). The original implementation is kept as `_linear_prophoto_to_display_reference`, used without numba or if a kernel fails.
- **Per-code-value tables** for 8/16-bit input: normalisation, exposure gain and the base curve depend on one channel only, so numpy evaluates them once per code value.
- **Exact white point**: the 99.5th percentile is taken from gathered candidates using numpy's own index and `_lerp` rules, falling back to `np.percentile` on NaN or an unrepresentative sample.
- **Wide gamut**: `convert_output_space` from sRGB to Display P3 / ProPhoto uses the same kernel for large frames.
- **Threads**: `resize_float_to_size` resizes channels concurrently; `to_uint16` and `edits.apply_manual_optics` render row bands. Every band computes what the single pass did.
- **Safety**: the in-process Python film engine now holds `grade._PARALLEL_KERNEL_LOCK` (numba's workqueue layer aborts on concurrent parallel regions); the startup warm-up compiles the develop kernels without holding that lock.

No cache version bump: output bytes are unchanged.

## Measurements
Apple M5 Pro, real X-Trans RAF (7752×5178), `NUMBA_NUM_THREADS=4` as the app sets it. SHA-256 of every output equal before and after.

| Step | Before | After |
| --- | --- | --- |
| Develop, Standard sRGB | 9.5–10.9 s | 0.4–0.9 s |
| Develop, Linear / Soft | 2.4 s / 9.2 s | 0.4–0.7 s / 0.4 s |
| Develop, Display P3 / ProPhoto | 15.7 s / 15.9 s | 0.9–1.6 s / 1.0–1.1 s |
| uint16 quantisation | 0.68 s | 0.1 s |
| Manual optics (median of 3) | 3.65 s | 2.09 s |
| Display P3 export conversion + JPEG (median of 3) | 11.96 s | 1.12 s |
| `/api/orig?quality=full&w=7000`, cold, installed OpenMP runtime | 19.2 s | 5.8 s (JPEG bytes identical) |

The remaining cold compare time is mostly the ~4.3 s OpenMP RAW decode.

## Testing
- Byte-for-byte kernel vs reference on the real RAF for all profiles and output spaces, uint16 and float input.
- New tests: all profiles × output spaces × uint8/uint16/RGBA/float32/float64 inputs; black frames; kernel-failure fallback; warm-up covers a real 16-bit develop without new compiles; percentile against numpy (spread, ties, clipped, signed zero, black, negatives, NaN, misleading sample); wide-gamut conversion; threaded resize, quantisation and optics against the previous single-pass code; camera-profile develop.
- Full suite: 2096 tests OK (44 skipped). `node --test tests/*.test.mjs`: 467 pass (no web changes). Help `check` and `localization-check` current after review acknowledgement (the source changes do not alter documented behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
